### PR TITLE
Add basic webhook set up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,12 @@ help: ## Display this help.
 
 ##@ Development
 
+.PHONY: manifests
+manifests: ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
+	$(CONTROLLER_GEN) webhook paths="./..." output:webhook:artifacts:config=pkg/webhooks/controlplanemachineset/testdata
+
 .PHONY: generate
-generate: ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
+generate: manifests ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
 .PHONY: fmt

--- a/cmd/control-plane-machine-set-operator/main.go
+++ b/cmd/control-plane-machine-set-operator/main.go
@@ -31,7 +31,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	"github.com/openshift/cluster-control-plane-machine-set-operator/pkg/controllers/controlplanemachineset"
+	cpmscontroller "github.com/openshift/cluster-control-plane-machine-set-operator/pkg/controllers/controlplanemachineset"
+	cpmswebhook "github.com/openshift/cluster-control-plane-machine-set-operator/pkg/webhooks/controlplanemachineset"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -76,13 +77,19 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = (&controlplanemachineset.ControlPlaneMachineSetReconciler{
+	if err := (&cpmscontroller.ControlPlaneMachineSetReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ControlPlaneMachineSet")
 		os.Exit(1)
 	}
+
+	if err := (&cpmswebhook.ControlPlaneMachineSetWebhook{}).SetupWebhookWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "ControlPlaneMachineSet")
+		os.Exit(1)
+	}
+
 	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/pkg/webhooks/controlplanemachineset/suite_test.go
+++ b/pkg/webhooks/controlplanemachineset/suite_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controlplanemachineset
+
+import (
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	cpmsv1beta1 "github.com/openshift/cluster-control-plane-machine-set-operator/pkg/api/machine/v1beta1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	//+kubebuilder:scaffold:imports
+)
+
+var cfg *rest.Config
+var k8sClient client.Client
+var testEnv *envtest.Environment
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Controller Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		// TODO: Import CRDs from the vendor directory once the API moves to openshift/api
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "manifests")},
+		ErrorIfCRDPathMissing: true,
+		WebhookInstallOptions: envtest.WebhookInstallOptions{
+			Paths: []string{filepath.Join("testdata")},
+		},
+	}
+
+	cfg, err := testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	Expect(cpmsv1beta1.Install(scheme.Scheme)).To(Succeed())
+
+	//+kubebuilder:scaffold:scheme
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/pkg/webhooks/controlplanemachineset/suite_test.go
+++ b/pkg/webhooks/controlplanemachineset/suite_test.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	cpmsv1beta1 "github.com/openshift/cluster-control-plane-machine-set-operator/pkg/api/machine/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -35,6 +36,7 @@ import (
 var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
+var testScheme *runtime.Scheme
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -55,15 +57,17 @@ var _ = BeforeSuite(func() {
 		},
 	}
 
-	cfg, err := testEnv.Start()
+	var err error
+	cfg, err = testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
-	Expect(cpmsv1beta1.Install(scheme.Scheme)).To(Succeed())
+	testScheme = scheme.Scheme
+	Expect(cpmsv1beta1.Install(testScheme)).To(Succeed())
 
 	//+kubebuilder:scaffold:scheme
 
-	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	k8sClient, err = client.New(cfg, client.Options{Scheme: testScheme})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 })

--- a/pkg/webhooks/controlplanemachineset/testdata/manifests.yaml
+++ b/pkg/webhooks/controlplanemachineset/testdata/manifests.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-machine-openshift-io-v1beta1-controlplanemachineset
+  failurePolicy: Fail
+  name: controlplanemachineset.machine.openshift.io
+  rules:
+  - apiGroups:
+    - machine.openshift.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - controlplanemachinesets
+  sideEffects: None

--- a/pkg/webhooks/controlplanemachineset/webhooks.go
+++ b/pkg/webhooks/controlplanemachineset/webhooks.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controlplanemachineset
+
+import (
+	"context"
+
+	cpmsv1beta1 "github.com/openshift/cluster-control-plane-machine-set-operator/pkg/api/machine/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+// ControlPlaneMachineSetWebhook acts as a webhook validator for the
+// machinev1beta1.ControlPlaneMachineSet resource.
+type ControlPlaneMachineSetWebhook struct{}
+
+func (r *ControlPlaneMachineSetWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		WithValidator(r).
+		For(&cpmsv1beta1.ControlPlaneMachineSet{}).
+		Complete()
+}
+
+//+kubebuilder:webhook:verbs=create;update,path=/validate-machine-openshift-io-v1beta1-controlplanemachineset,mutating=false,failurePolicy=fail,groups=machine.openshift.io,resources=controlplanemachinesets,versions=v1beta1,name=controlplanemachineset.machine.openshift.io,sideEffects=None,admissionReviewVersions=v1beta1
+
+var _ webhook.CustomValidator = &ControlPlaneMachineSetWebhook{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (r *ControlPlaneMachineSetWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) error {
+	return nil
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (r *ControlPlaneMachineSetWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) error {
+	return nil
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (r *ControlPlaneMachineSetWebhook) ValidateDelete(ctx context.Context, obj runtime.Object) error {
+	return nil
+}

--- a/pkg/webhooks/controlplanemachineset/webhooks_test.go
+++ b/pkg/webhooks/controlplanemachineset/webhooks_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controlplanemachineset
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var _ = Describe("Webhooks", func() {
+	var mgrCancel context.CancelFunc
+	var mgrDone chan struct{}
+
+	BeforeEach(func() {
+		By("Setting up a manager and webhook")
+		mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+			Scheme:             testScheme,
+			MetricsBindAddress: "0",
+			Port:               testEnv.WebhookInstallOptions.LocalServingPort,
+			Host:               testEnv.WebhookInstallOptions.LocalServingHost,
+			CertDir:            testEnv.WebhookInstallOptions.LocalServingCertDir,
+		})
+		Expect(err).ToNot(HaveOccurred(), "Manager should be able to be created")
+
+		wh := &ControlPlaneMachineSetWebhook{}
+		Expect(wh.SetupWebhookWithManager(mgr)).To(Succeed(), "Webhook should be able to register with manager")
+
+		By("Starting the manager")
+		var mgrCtx context.Context
+		mgrCtx, mgrCancel = context.WithCancel(context.Background())
+		mgrDone = make(chan struct{})
+
+		go func() {
+			defer GinkgoRecover()
+			defer close(mgrDone)
+
+			Expect(mgr.Start(mgrCtx)).To(Succeed())
+		}()
+	})
+
+	AfterEach(func() {
+		By("Stopping the manager")
+		mgrCancel()
+		// Wait for the mgrDone to be closed, which will happen once the mgr has stopped
+		<-mgrDone
+	})
+})


### PR DESCRIPTION
This adds a validating webhook which will later make a number of validations against create and update events for ControlPlaneMachineSet resources.

At the moment, this is just very basic scaffolding for the webhooks, getting them registered and then boilerplate for the test suites.

Note, as the test requires a webhook manifest, I'm using the kubebuilder generator to build this and place it in the testdata folder close to the tests