### PR TITLE
Add golangci-lint configuration for stricter linting

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,108 @@
+linters:
+  disable-all: true
+  # Enable specific linter
+  # https://golangci-lint.run/usage/linters/#enabled-by-default-linters
+  enable:
+    # Default linters
+    - deadcode
+    - errcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - structcheck
+    - typecheck
+    - unused
+    - varcheck
+    # Additional linters
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - contextcheck
+    - cyclop
+    - dogsled
+    - dupl
+    - durationcheck
+    - errname
+    - errorlint
+    - exhaustive
+    - exportloopref
+    - forcetypeassert
+    - funlen
+    - gochecknoglobals
+    - gocognit
+    - goconst
+    - gocritic
+    - gocyclo
+    - godot
+    - goerr113
+    - gofmt
+    - goheader
+    - goimports
+    - goprintffuncname
+    - gosec
+    - ifshort
+    - importas
+    - makezero
+    - misspell
+    - nakedret
+    - nestif
+    - nilerr
+    - nilnil
+    - nlreturn
+    - noctx
+    - nolintlint
+    - prealloc
+    - predeclared
+    - revive
+    - stylecheck
+    - tagliatelle
+    - tenv
+    - unconvert
+    - unparam
+    - wastedassign
+    - whitespace
+    - wrapcheck
+    - wsl
+linters-settings:
+  goheader:
+    template: |-
+      Copyright {{YEAR}} Red Hat, Inc.
+
+      Licensed under the Apache License, Version 2.0 (the "License");
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
+  nlreturn:
+    block-size: 2
+  revive:
+    confidence: 0
+    rules:
+    - name: exported
+      severity: warning
+      disabled: false
+      arguments:
+        - "checkPrivateReceivers"
+        - "disableStutteringCheck"
+  stylecheck:
+    # https://staticcheck.io/docs/options#checks
+    checks: ["all", "-ST1000"]
+    dot-import-whitelist:
+      - "github.com/onsi/gomega"
+issues:
+  exclude-use-default: false
+  exclude-rules:
+    # Exclude some linters from running on tests files.
+    - path: _test\.go
+      linters:
+        - gocyclo
+        - dupl
+        - gosec
+        - gochecknoglobals

--- a/cmd/control-plane-machine-set-operator/main.go
+++ b/cmd/control-plane-machine-set-operator/main.go
@@ -25,7 +25,6 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
@@ -36,26 +35,27 @@ import (
 	//+kubebuilder:scaffold:imports
 )
 
-var (
-	scheme   = runtime.NewScheme()
-	setupLog = ctrl.Log.WithName("setup")
-)
+func main() { //nolint:funlen
+	scheme := runtime.NewScheme()
+	setupLog := ctrl.Log.WithName("setup")
 
-func init() {
-	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		setupLog.Error(err, "unable to set up client-go scheme")
+		os.Exit(1)
+	}
 
-	//+kubebuilder:scaffold:scheme
-}
+	var (
+		metricsAddr          string
+		enableLeaderElection bool
+		probeAddr            string
+	)
 
-func main() {
-	var metricsAddr string
-	var enableLeaderElection bool
-	var probeAddr string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+
 	opts := zap.Options{
 		Development: true,
 	}
@@ -96,12 +96,14 @@ func main() {
 		setupLog.Error(err, "unable to set up health check")
 		os.Exit(1)
 	}
+
 	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up ready check")
 		os.Exit(1)
 	}
 
 	setupLog.Info("starting manager")
+
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)

--- a/pkg/controllers/controlplanemachineset/controller.go
+++ b/pkg/controllers/controlplanemachineset/controller.go
@@ -18,6 +18,7 @@ package controlplanemachineset
 
 import (
 	"context"
+	"fmt"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -25,13 +26,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-// ControlPlaneMachineSetReconciler reconciles a ControlPlaneMachineSet object
+// ControlPlaneMachineSetReconciler reconciles a ControlPlaneMachineSet object.
 type ControlPlaneMachineSetReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
 }
 
-// Reconcile reconciles the ControlPlaneMachineSet object
+// Reconcile reconciles the ControlPlaneMachineSet object.
 func (r *ControlPlaneMachineSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	_ = log.FromContext(ctx)
 
@@ -42,8 +43,12 @@ func (r *ControlPlaneMachineSetReconciler) Reconcile(ctx context.Context, req ct
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ControlPlaneMachineSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
+	if err := ctrl.NewControllerManagedBy(mgr).
 		// Uncomment the following line adding a pointer to an instance of the controlled resource as an argument
 		// For().
-		Complete(r)
+		Complete(r); err != nil {
+		return fmt.Errorf("could not set up controller for ControlPlaneMachineSet: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/webhooks/controlplanemachineset/suite_test.go
+++ b/pkg/webhooks/controlplanemachineset/suite_test.go
@@ -56,7 +56,7 @@ var _ = BeforeSuite(func() {
 		},
 		ErrorIfCRDPathMissing: true,
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
-			Paths: []string{filepath.Join("testdata")},
+			Paths: []string{"testdata"},
 		},
 	}
 

--- a/pkg/webhooks/controlplanemachineset/webhooks.go
+++ b/pkg/webhooks/controlplanemachineset/webhooks.go
@@ -18,6 +18,7 @@ package controlplanemachineset
 
 import (
 	"context"
+	"fmt"
 
 	machinev1 "github.com/openshift/api/machine/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -29,28 +30,33 @@ import (
 // machinev1beta1.ControlPlaneMachineSet resource.
 type ControlPlaneMachineSetWebhook struct{}
 
+// SetupWebhookWithManager sets up a new ControlPlaneMachineSet webhook with the manager.
 func (r *ControlPlaneMachineSetWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewWebhookManagedBy(mgr).
+	if err := ctrl.NewWebhookManagedBy(mgr).
 		WithValidator(r).
 		For(&machinev1.ControlPlaneMachineSet{}).
-		Complete()
+		Complete(); err != nil {
+		return fmt.Errorf("error constructing ControlPlaneMachineSet webhook: %w", err)
+	}
+
+	return nil
 }
 
 //+kubebuilder:webhook:verbs=create;update,path=/validate-machine-openshift-io-v1beta1-controlplanemachineset,mutating=false,failurePolicy=fail,groups=machine.openshift.io,resources=controlplanemachinesets,versions=v1beta1,name=controlplanemachineset.machine.openshift.io,sideEffects=None,admissionReviewVersions=v1beta1
 
 var _ webhook.CustomValidator = &ControlPlaneMachineSetWebhook{}
 
-// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (r *ControlPlaneMachineSetWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) error {
 	return nil
 }
 
-// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
 func (r *ControlPlaneMachineSetWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) error {
 	return nil
 }
 
-// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
 func (r *ControlPlaneMachineSetWebhook) ValidateDelete(ctx context.Context, obj runtime.Object) error {
 	return nil
 }


### PR DESCRIPTION
This adds quite strict linting to the repo which may need tuning over time, but for now this seems to work and takes about 10s on my machine.

The important things I'm trying to achieve:
- Functions aren't super long
- Functions are well documented
- Whitespace is well thought out
- License header is present on all files
- Code duplication is minimised
- 
This config is possibly overly strict but I thought better to do that now and relax it rather than vice-versa.