### PR TITLE
Scaffold watches for resources in ControlPlaneMachineSet controller

### DIFF
--- a/pkg/controllers/controlplanemachineset/controller.go
+++ b/pkg/controllers/controlplanemachineset/controller.go
@@ -20,16 +20,50 @@ import (
 	"context"
 	"fmt"
 
+	configv1 "github.com/openshift/api/config/v1"
+	machinev1 "github.com/openshift/api/machine/v1"
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const (
+	// clusterControlPlaneMachineSetName is the name of the ControlPlaneMachineSet.
+	// As ControlPlaneMachineSets are singletons within the namespace, only ControlPlaneMachineSets
+	// with this name should be reconciled.
+	clusterControlPlaneMachineSetName = "cluster"
 )
 
 // ControlPlaneMachineSetReconciler reconciles a ControlPlaneMachineSet object.
 type ControlPlaneMachineSetReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
+
+	// Namespace is the namespace in which the ControlPlaneMachineSet controller should operate.
+	// Any ControlPlaneMachineSet not in this namespace should be ignored.
+	Namespace string
+
+	// OperatorName is the name of the ClusterOperator with which the controller should report
+	// its status.
+	OperatorName string
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *ControlPlaneMachineSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewControllerManagedBy(mgr).
+		For(&machinev1.ControlPlaneMachineSet{}, builder.WithPredicates(filterControlPlaneMachineSet(r.Namespace))).
+		Owns(&machinev1beta1.Machine{}, builder.WithPredicates(filterControlPlaneMachines(r.Namespace))).
+		Watches(&source.Kind{Type: &configv1.ClusterOperator{}}, handler.EnqueueRequestsFromMapFunc(clusterOperatorToControlPlaneMachineSet(r.Namespace, r.OperatorName))).
+		Complete(r); err != nil {
+		return fmt.Errorf("could not set up controller for ControlPlaneMachineSet: %w", err)
+	}
+
+	return nil
 }
 
 // Reconcile reconciles the ControlPlaneMachineSet object.
@@ -39,16 +73,4 @@ func (r *ControlPlaneMachineSetReconciler) Reconcile(ctx context.Context, req ct
 	// TODO(user): your logic here
 
 	return ctrl.Result{}, nil
-}
-
-// SetupWithManager sets up the controller with the Manager.
-func (r *ControlPlaneMachineSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	if err := ctrl.NewControllerManagedBy(mgr).
-		// Uncomment the following line adding a pointer to an instance of the controlled resource as an argument
-		// For().
-		Complete(r); err != nil {
-		return fmt.Errorf("could not set up controller for ControlPlaneMachineSet: %w", err)
-	}
-
-	return nil
 }

--- a/pkg/controllers/controlplanemachineset/suite_test.go
+++ b/pkg/controllers/controlplanemachineset/suite_test.go
@@ -22,9 +22,13 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	configv1 "github.com/openshift/api/config/v1"
 	machinev1 "github.com/openshift/api/machine/v1"
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -47,7 +51,11 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "vendor", "github.com", "openshift", "api", "machine", "v1")},
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "..", "vendor", "github.com", "openshift", "api", "machine", "v1"),
+			filepath.Join("..", "..", "..", "vendor", "github.com", "openshift", "api", "machine", "v1beta1"),
+			filepath.Join("..", "..", "..", "vendor", "github.com", "openshift", "api", "config", "v1"),
+		},
 		ErrorIfCRDPathMissing: true,
 	}
 
@@ -56,6 +64,8 @@ var _ = BeforeSuite(func() {
 	Expect(cfg).NotTo(BeNil())
 
 	Expect(machinev1.Install(scheme.Scheme)).To(Succeed())
+	Expect(machinev1beta1.Install(scheme.Scheme)).To(Succeed())
+	Expect(configv1.Install(scheme.Scheme)).To(Succeed())
 
 	//+kubebuilder:scaffold:scheme
 

--- a/pkg/controllers/controlplanemachineset/watch_filters.go
+++ b/pkg/controllers/controlplanemachineset/watch_filters.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controlplanemachineset
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// clusterOperatorToControlPlaneMachineSet maps the cluster operator to the control
+// plane machine set singleton in the namespace provided.
+func clusterOperatorToControlPlaneMachineSet(namespace string, operatorName string) func(client.Object) []reconcile.Request {
+	return func(obj client.Object) []reconcile.Request {
+		// TODO: Implement this function to filter the object just to the ClusterOperator
+		// for this operator and to map to a reconcile of the CPMS singleton.
+		return []reconcile.Request{}
+	}
+}
+
+// filterControlPlaneMachineSet filters control plane machine set requests
+// to just the singleton within the namespace provided.
+// TODO: remove noline once implemented.
+func filterControlPlaneMachineSet(namespace string) predicate.Predicate { //nolint:unparam
+	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
+		// TODO: Implement this function to filter the object to just the CPMS singleton
+		// within the namespace provided.
+		return false
+	})
+}
+
+// filterControlPlaneMachines filters machine requests to just the machines that present as control plane machines,
+//  i.e. they are labelled with the correct labels to identify them as control plane machines.
+// TODO: remove noline once implemented.
+func filterControlPlaneMachines(namespace string) predicate.Predicate { //nolint:unparam
+	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
+		// TODO: Implement this function to filter the object to just the
+		// control plane machines in the namespace provided.
+		return false
+	})
+}

--- a/pkg/controllers/controlplanemachineset/watch_filters_test.go
+++ b/pkg/controllers/controlplanemachineset/watch_filters_test.go
@@ -1,0 +1,251 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controlplanemachineset
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/cluster-control-plane-machine-set-operator/pkg/test/resourcebuilder"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var _ = Describe("Watch Filters", func() {
+	Context("clusterOperatorToControlPlaneMachineSet", func() {
+		const testNamespace = "test"
+		const operatorName = "control-plane-machine-set"
+
+		var clusterOperatorFilter func(client.Object) []reconcile.Request
+
+		BeforeEach(func() {
+			clusterOperatorFilter = clusterOperatorToControlPlaneMachineSet(testNamespace, operatorName)
+		})
+
+		PIt("Panics with the wrong object kind", func() {
+			cpms := resourcebuilder.ControlPlaneMachineSet().Build()
+			Expect(func() {
+				clusterOperatorFilter(cpms)
+			}).To(PanicWith("TODO"), "A programming error occurs when passing the wrong object, the function should panic")
+		})
+
+		It("returns nothing when the wrong cluster operator is provided", func() {
+			co := resourcebuilder.ClusterOperator().WithName("machine-api-operator").Build()
+			Expect(clusterOperatorFilter(co)).To(BeEmpty())
+		})
+
+		PIt("returns a request for the cluster ControlPlaneMachineSet when the correct cluster operator is provided", func() {
+			co := resourcebuilder.ClusterOperator().WithName(operatorName).Build()
+			Expect(clusterOperatorFilter(co)).To(ConsistOf(reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: testNamespace,
+					Name:      clusterControlPlaneMachineSetName,
+				},
+			}))
+		})
+	})
+
+	// createEvent is used to pass objects to the predicate Create function.
+	createEvent := func(obj client.Object) event.CreateEvent {
+		return event.CreateEvent{
+			Object: obj,
+		}
+	}
+
+	// updateEvent is used to pass objects to the predicate Update function.
+	updateEvent := func(obj client.Object) event.UpdateEvent {
+		return event.UpdateEvent{
+			ObjectNew: obj,
+		}
+	}
+
+	// deleteEvent is used to pass objects to the predicate Delete function.
+	deleteEvent := func(obj client.Object) event.DeleteEvent {
+		return event.DeleteEvent{
+			Object: obj,
+		}
+	}
+
+	// genericEvent is used to pass objects to the predicate Generic function.
+	genericEvent := func(obj client.Object) event.GenericEvent {
+		return event.GenericEvent{
+			Object: obj,
+		}
+	}
+
+	Context("filterControlPlaneMachineSet", func() {
+		const testNamespace = "test"
+
+		var cpmsPredicate predicate.Predicate
+
+		BeforeEach(func() {
+			cpmsPredicate = filterControlPlaneMachineSet(testNamespace)
+		})
+
+		PIt("Panics with the wrong object kind", func() {
+			machine := resourcebuilder.Machine().Build()
+			Expect(func() {
+				cpmsPredicate.Create(createEvent(machine))
+			}).To(PanicWith("TODO"), "A programming error occurs when passing the wrong object, the function should panic")
+
+			Expect(func() {
+				cpmsPredicate.Update(updateEvent(machine))
+			}).To(PanicWith("TODO"), "A programming error occurs when passing the wrong object, the function should panic")
+
+			Expect(func() {
+				cpmsPredicate.Delete(deleteEvent(machine))
+			}).To(PanicWith("TODO"), "A programming error occurs when passing the wrong object, the function should panic")
+
+			Expect(func() {
+				cpmsPredicate.Generic(genericEvent(machine))
+			}).To(PanicWith("TODO"), "A programming error occurs when passing the wrong object, the function should panic")
+		})
+
+		It("Returns false with the wrong namespace", func() {
+			cpms := resourcebuilder.ControlPlaneMachineSet().
+				WithName(clusterControlPlaneMachineSetName).
+				WithNamespace("wrong-namespace").
+				Build()
+
+			Expect(cpmsPredicate.Create(createEvent(cpms))).To(BeFalse())
+			Expect(cpmsPredicate.Update(updateEvent(cpms))).To(BeFalse())
+			Expect(cpmsPredicate.Delete(deleteEvent(cpms))).To(BeFalse())
+			Expect(cpmsPredicate.Generic(genericEvent(cpms))).To(BeFalse())
+		})
+
+		It("Returns false with the wrong name", func() {
+			cpms := resourcebuilder.ControlPlaneMachineSet().
+				WithName("wrong-name").
+				WithNamespace(testNamespace).
+				Build()
+
+			Expect(cpmsPredicate.Create(createEvent(cpms))).To(BeFalse())
+			Expect(cpmsPredicate.Update(updateEvent(cpms))).To(BeFalse())
+			Expect(cpmsPredicate.Delete(deleteEvent(cpms))).To(BeFalse())
+			Expect(cpmsPredicate.Generic(genericEvent(cpms))).To(BeFalse())
+		})
+
+		PIt("Returns true with the correct namespace and name", func() {
+			cpms := resourcebuilder.ControlPlaneMachineSet().
+				WithName(clusterControlPlaneMachineSetName).
+				WithNamespace(testNamespace).
+				Build()
+
+			Expect(cpmsPredicate.Create(createEvent(cpms))).To(BeTrue())
+			Expect(cpmsPredicate.Update(updateEvent(cpms))).To(BeTrue())
+			Expect(cpmsPredicate.Delete(deleteEvent(cpms))).To(BeTrue())
+			Expect(cpmsPredicate.Generic(genericEvent(cpms))).To(BeTrue())
+		})
+	})
+
+	Context("filterControlPlaneMachines", func() {
+		const testNamespace = "test"
+
+		var machinePredicate predicate.Predicate
+
+		BeforeEach(func() {
+			machinePredicate = filterControlPlaneMachines(testNamespace)
+		})
+
+		PIt("Panics with the wrong object kind", func() {
+			cpms := resourcebuilder.ControlPlaneMachineSet().Build()
+			Expect(func() {
+				machinePredicate.Create(createEvent(cpms))
+			}).To(PanicWith("TODO"), "A programming error occurs when passing the wrong object, the function should panic")
+
+			Expect(func() {
+				machinePredicate.Update(updateEvent(cpms))
+			}).To(PanicWith("TODO"), "A programming error occurs when passing the wrong object, the function should panic")
+
+			Expect(func() {
+				machinePredicate.Delete(deleteEvent(cpms))
+			}).To(PanicWith("TODO"), "A programming error occurs when passing the wrong object, the function should panic")
+
+			Expect(func() {
+				machinePredicate.Generic(genericEvent(cpms))
+			}).To(PanicWith("TODO"), "A programming error occurs when passing the wrong object, the function should panic")
+		})
+
+		It("Returns false with the wrong namespace", func() {
+			machine := resourcebuilder.Machine().
+				WithNamespace("wrong-namespace").
+				AsMaster().
+				Build()
+
+			Expect(machinePredicate.Create(createEvent(machine))).To(BeFalse())
+			Expect(machinePredicate.Update(updateEvent(machine))).To(BeFalse())
+			Expect(machinePredicate.Delete(deleteEvent(machine))).To(BeFalse())
+			Expect(machinePredicate.Generic(genericEvent(machine))).To(BeFalse())
+		})
+
+		It("Returns false with worker machines", func() {
+			machine := resourcebuilder.Machine().
+				WithNamespace(testNamespace).
+				AsWorker().
+				Build()
+
+			Expect(machinePredicate.Create(createEvent(machine))).To(BeFalse())
+			Expect(machinePredicate.Update(updateEvent(machine))).To(BeFalse())
+			Expect(machinePredicate.Delete(deleteEvent(machine))).To(BeFalse())
+			Expect(machinePredicate.Generic(genericEvent(machine))).To(BeFalse())
+		})
+
+		It("Returns false when missing the machine type label", func() {
+			machine := resourcebuilder.Machine().
+				WithNamespace(testNamespace).
+				WithLabels(map[string]string{
+					"machine.openshift.io/cluster-api-machine-role": "master",
+				}).
+				Build()
+
+			Expect(machinePredicate.Create(createEvent(machine))).To(BeFalse())
+			Expect(machinePredicate.Update(updateEvent(machine))).To(BeFalse())
+			Expect(machinePredicate.Delete(deleteEvent(machine))).To(BeFalse())
+			Expect(machinePredicate.Generic(genericEvent(machine))).To(BeFalse())
+		})
+
+		It("Returns false when missing the machine role label", func() {
+			machine := resourcebuilder.Machine().
+				WithNamespace(testNamespace).
+				WithLabels(map[string]string{
+					"machine.openshift.io/cluster-api-machine-type": "master",
+				}).
+				Build()
+
+			Expect(machinePredicate.Create(createEvent(machine))).To(BeFalse())
+			Expect(machinePredicate.Update(updateEvent(machine))).To(BeFalse())
+			Expect(machinePredicate.Delete(deleteEvent(machine))).To(BeFalse())
+			Expect(machinePredicate.Generic(genericEvent(machine))).To(BeFalse())
+		})
+
+		PIt("Returns true with the correct namespace and labels", func() {
+			machine := resourcebuilder.Machine().
+				WithNamespace(testNamespace).
+				AsMaster().
+				Build()
+
+			Expect(machinePredicate.Create(createEvent(machine))).To(BeTrue())
+			Expect(machinePredicate.Update(updateEvent(machine))).To(BeTrue())
+			Expect(machinePredicate.Delete(deleteEvent(machine))).To(BeTrue())
+			Expect(machinePredicate.Generic(genericEvent(machine))).To(BeTrue())
+		})
+	})
+})

--- a/pkg/test/resourcebuilder/cluster_operator.go
+++ b/pkg/test/resourcebuilder/cluster_operator.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcebuilder
+
+import (
+	configv1 "github.com/openshift/api/config/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ClusterOperator creates a new cluster operator builder.
+func ClusterOperator() ClusterOperatorBuilder {
+	return ClusterOperatorBuilder{}
+}
+
+// ClusterOperatorBuilder is used to build out a cluster operator object.
+type ClusterOperatorBuilder struct {
+	name string
+}
+
+// Build builds a new cluster operator based on the configuration provided.
+func (n ClusterOperatorBuilder) Build() *configv1.ClusterOperator {
+	return &configv1.ClusterOperator{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: n.name,
+		},
+	}
+}
+
+// WithName sets the name for the cluster operator builder.
+func (n ClusterOperatorBuilder) WithName(name string) ClusterOperatorBuilder {
+	n.name = name
+	return n
+}


### PR DESCRIPTION
This PR ensures that the operator is watching the ControlPlaneMachineSet, Machine and ClusterOperator resources which will trigger reconciles.

This is scaffold at the moment as the filters themselves have yet to be implemented, this will be left as a future task. Tests have also been scaffolded, but more tests may be added when the implementation of the watches is done.