### PR TITLE
Scaffold basic high level reconcile

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/openshift/cluster-control-plane-machine-set-operator
 go 1.17
 
 require (
+	github.com/go-logr/logr v1.2.2
 	github.com/golangci/golangci-lint v1.44.2
 	github.com/onsi/ginkgo/v2 v2.1.3
 	github.com/onsi/gomega v1.18.1
@@ -55,7 +56,6 @@ require (
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/fzipp/gocyclo v0.4.0 // indirect
 	github.com/go-critic/go-critic v0.6.2 // indirect
-	github.com/go-logr/logr v1.2.2 // indirect
 	github.com/go-logr/zapr v1.2.0 // indirect
 	github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 // indirect
 	github.com/go-toolsmith/astcast v1.0.0 // indirect

--- a/pkg/controllers/controlplanemachineset/cluster_operator.go
+++ b/pkg/controllers/controlplanemachineset/cluster_operator.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controlplanemachineset
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	machinev1 "github.com/openshift/api/machine/v1"
+)
+
+// setClusterOperatorAvailable sets the control-plane-machine-set cluster operator status to available.
+// This is used primarily when a ControlPlaneMachineSet doesn't exist.
+func (r *ControlPlaneMachineSetReconciler) setClusterOperatorAvailable(ctx context.Context, logger logr.Logger) error {
+	return nil
+}
+
+// setClusterOperatorStatus sets the control-plane-machine-set clsuter operator status based on the status of the
+// ControlPlaneMachine passed into it.
+// Notably, when the conditions of the ControlPlaneMachineSet indicate that the operations of the ControlPlaneMachineSet
+// are not functioning as expected, the cluster operator should be marked degraded.
+func (r *ControlPlaneMachineSetReconciler) updateClusterOperatorStatus(ctx context.Context, logger logr.Logger, cpms *machinev1.ControlPlaneMachineSet) error {
+	return nil
+}

--- a/pkg/controllers/controlplanemachineset/cluster_operator_test.go
+++ b/pkg/controllers/controlplanemachineset/cluster_operator_test.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controlplanemachineset
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	configv1 "github.com/openshift/api/config/v1"
+	machinev1 "github.com/openshift/api/machine/v1"
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+	"github.com/openshift/cluster-control-plane-machine-set-operator/pkg/test"
+	"github.com/openshift/cluster-control-plane-machine-set-operator/pkg/test/resourcebuilder"
+	corev1 "k8s.io/api/core/v1"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
+)
+
+var _ = Describe("Cluster Operator Status with a running controller", func() {
+	var mgrCancel context.CancelFunc
+	var mgrDone chan struct{}
+
+	var namespaceName string
+
+	const operatorName = "control-plane-machine-set"
+
+	var co *configv1.ClusterOperator
+
+	BeforeEach(func() {
+		By("Setting up a namespace for the test")
+		ns := resourcebuilder.Namespace().WithGenerateName("control-plane-machine-set-cluster-operator-").Build()
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+		namespaceName = ns.GetName()
+
+		By("Setting up a manager and controller")
+		mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+			Scheme:             testScheme,
+			MetricsBindAddress: "0",
+			Port:               testEnv.WebhookInstallOptions.LocalServingPort,
+			Host:               testEnv.WebhookInstallOptions.LocalServingHost,
+			CertDir:            testEnv.WebhookInstallOptions.LocalServingCertDir,
+		})
+		Expect(err).ToNot(HaveOccurred(), "Manager should be able to be created")
+
+		reconciler := &ControlPlaneMachineSetReconciler{
+			Namespace:    namespaceName,
+			OperatorName: operatorName,
+		}
+		Expect(reconciler.SetupWithManager(mgr)).To(Succeed(), "Reconciler should be able to setup with manager")
+
+		By("Starting the manager")
+		var mgrCtx context.Context
+		mgrCtx, mgrCancel = context.WithCancel(context.Background())
+		mgrDone = make(chan struct{})
+
+		go func() {
+			defer GinkgoRecover()
+			defer close(mgrDone)
+
+			Expect(mgr.Start(mgrCtx)).To(Succeed())
+		}()
+
+		// CVO will create a blank cluster operator for us before the operator starts.
+		co = resourcebuilder.ClusterOperator().WithName(operatorName).Build()
+		Expect(k8sClient.Create(ctx, co)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		By("Stopping the manager")
+		mgrCancel()
+		// Wait for the mgrDone to be closed, which will happen once the mgr has stopped
+		<-mgrDone
+
+		test.CleanupResources(ctx, cfg, k8sClient, namespaceName,
+			&corev1.Node{},
+			&configv1.ClusterOperator{},
+			&machinev1beta1.Machine{},
+			&machinev1.ControlPlaneMachineSet{},
+		)
+	})
+
+	Context("with no ControlPlaneMachineSet", func() {
+		PIt("Set the cluster operator available", func() {
+			co := resourcebuilder.ClusterOperator().WithName(operatorName).Build()
+
+			Eventually(komega.Object(co)).Should(HaveField(".Status.Conditions", test.MatchClusterOperatorStatusConditions([]configv1.ClusterOperatorStatusCondition{
+				{
+					Type:   configv1.OperatorAvailable,
+					Status: configv1.ConditionTrue,
+				},
+				{
+					Type:   configv1.OperatorProgressing,
+					Status: configv1.ConditionFalse,
+				},
+				{
+					Type:   configv1.OperatorDegraded,
+					Status: configv1.ConditionFalse,
+				},
+				{
+					Type:   configv1.OperatorUpgradeable,
+					Status: configv1.ConditionTrue,
+				},
+			})))
+		})
+
+		Context("And an invalid cluster operator", func() {
+			BeforeEach(func() {
+				coStatus := resourcebuilder.ClusterOperatorStatus().Build()
+				Eventually(komega.UpdateStatus(co, func() {
+					co.Status = coStatus
+				})).Should(Succeed())
+			})
+
+			PIt("Set the cluster operator available", func() {
+				co := resourcebuilder.ClusterOperator().WithName(operatorName).Build()
+
+				Eventually(komega.Object(co)).Should(HaveField(".Status.Conditions", test.MatchClusterOperatorStatusConditions([]configv1.ClusterOperatorStatusCondition{
+					{
+						Type:   configv1.OperatorAvailable,
+						Status: configv1.ConditionTrue,
+					},
+					{
+						Type:   configv1.OperatorProgressing,
+						Status: configv1.ConditionFalse,
+					},
+					{
+						Type:   configv1.OperatorDegraded,
+						Status: configv1.ConditionFalse,
+					},
+					{
+						Type:   configv1.OperatorUpgradeable,
+						Status: configv1.ConditionTrue,
+					},
+				})))
+			})
+		})
+
+	})
+})

--- a/pkg/controllers/controlplanemachineset/controller.go
+++ b/pkg/controllers/controlplanemachineset/controller.go
@@ -20,10 +20,14 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-logr/logr"
 	configv1 "github.com/openshift/api/config/v1"
 	machinev1 "github.com/openshift/api/machine/v1"
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	errorutils "k8s.io/apimachinery/pkg/util/errors"
+
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -68,9 +72,57 @@ func (r *ControlPlaneMachineSetReconciler) SetupWithManager(mgr ctrl.Manager) er
 
 // Reconcile reconciles the ControlPlaneMachineSet object.
 func (r *ControlPlaneMachineSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	_ = log.FromContext(ctx)
+	logger := log.FromContext(ctx, "namepace", req.Namespace, "name", req.Name)
 
-	// TODO(user): your logic here
+	logger.V(1).Info("Reconciling control plane machine set")
+	defer logger.V(1).Info("Finished reconciling control plane machine set")
 
+	cpms := &machinev1.ControlPlaneMachineSet{}
+	cpmsKey := client.ObjectKey{Namespace: req.Namespace, Name: req.Name}
+
+	// Fetch the ControlPlaneMachineSet and set the cluster operator to available if it doesn't exist.
+	if err := r.Get(ctx, cpmsKey, cpms); apierrors.IsNotFound(err) {
+		logger.V(1).Info("No control plane machine set found, setting operator status available")
+
+		if err := r.setClusterOperatorAvailable(ctx, logger); err != nil {
+			return ctrl.Result{}, fmt.Errorf("unable to reconcile cluster operator status: %w", err)
+		}
+	} else if err != nil {
+		return ctrl.Result{}, fmt.Errorf("unable to fetch control plane machine set: %w", err)
+	}
+
+	// Take a copy of the original object to be able to create a patch for the status at the end.
+	patchBase := client.MergeFrom(cpms)
+
+	// Collect errors as an aggregate to return together after all patches have been performed.
+	var errs []error
+
+	result, err := r.reconcile(ctx, logger, cpms)
+	if err != nil {
+		// Don't return an error here so that we have an opportunity to update the status and cluster operator status.
+		errs = append(errs, fmt.Errorf("error reconciling control plane machine set: %w", err))
+	}
+
+	if err := r.updateControlPlaneMachineSetStatus(ctx, logger, cpms, patchBase); err != nil {
+		// Don't return an error here so that we have an opportunity to update the cluster operator status.
+		errs = append(errs, fmt.Errorf("error updating control plane machine set status: %w", err))
+	}
+
+	if err := r.updateClusterOperatorStatus(ctx, logger, cpms); err != nil {
+		// Don't return an error here so we can aggregate the errors with previous updates.
+		errs = append(errs, fmt.Errorf("error updating control plane machine set status: %w", err))
+	}
+
+	if len(errs) > 0 {
+		return ctrl.Result{}, errorutils.NewAggregate(errs)
+	}
+
+	return result, nil
+}
+
+// reconcile performs the main business logic of the ControlPlaneMachineSet operator.
+// Notably it actions the various parts of the business logic without performing any status updates on the
+// ControlPlaneMachineSet object itself, these updates are handled at the parent scope.
+func (r *ControlPlaneMachineSetReconciler) reconcile(ctx context.Context, logger logr.Logger, cpms *machinev1.ControlPlaneMachineSet) (ctrl.Result, error) {
 	return ctrl.Result{}, nil
 }

--- a/pkg/controllers/controlplanemachineset/controller_test.go
+++ b/pkg/controllers/controlplanemachineset/controller_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controlplanemachineset
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	configv1 "github.com/openshift/api/config/v1"
+	machinev1 "github.com/openshift/api/machine/v1"
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+	"github.com/openshift/cluster-control-plane-machine-set-operator/pkg/test"
+	"github.com/openshift/cluster-control-plane-machine-set-operator/pkg/test/resourcebuilder"
+	corev1 "k8s.io/api/core/v1"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var _ = Describe("With a running controller", func() {
+	var mgrCancel context.CancelFunc
+	var mgrDone chan struct{}
+
+	var namespaceName string
+
+	const operatorName = "control-plane-machine-set"
+
+	var co *configv1.ClusterOperator
+
+	BeforeEach(func() {
+		By("Setting up a namespace for the test")
+		ns := resourcebuilder.Namespace().WithGenerateName("control-plane-machine-set-controller-").Build()
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+		namespaceName = ns.GetName()
+
+		By("Setting up a manager and controller")
+		mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+			Scheme:             testScheme,
+			MetricsBindAddress: "0",
+			Port:               testEnv.WebhookInstallOptions.LocalServingPort,
+			Host:               testEnv.WebhookInstallOptions.LocalServingHost,
+			CertDir:            testEnv.WebhookInstallOptions.LocalServingCertDir,
+		})
+		Expect(err).ToNot(HaveOccurred(), "Manager should be able to be created")
+
+		reconciler := &ControlPlaneMachineSetReconciler{
+			Namespace:    namespaceName,
+			OperatorName: operatorName,
+		}
+		Expect(reconciler.SetupWithManager(mgr)).To(Succeed(), "Reconciler should be able to setup with manager")
+
+		By("Starting the manager")
+		var mgrCtx context.Context
+		mgrCtx, mgrCancel = context.WithCancel(context.Background())
+		mgrDone = make(chan struct{})
+
+		go func() {
+			defer GinkgoRecover()
+			defer close(mgrDone)
+
+			Expect(mgr.Start(mgrCtx)).To(Succeed())
+		}()
+
+		// CVO will create a blank cluster operator for us before the operator starts.
+		co = resourcebuilder.ClusterOperator().WithName(operatorName).Build()
+		Expect(k8sClient.Create(ctx, co)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		By("Stopping the manager")
+		mgrCancel()
+		// Wait for the mgrDone to be closed, which will happen once the mgr has stopped
+		<-mgrDone
+
+		test.CleanupResources(ctx, cfg, k8sClient, namespaceName,
+			&corev1.Node{},
+			&configv1.ClusterOperator{},
+			&machinev1beta1.Machine{},
+			&machinev1.ControlPlaneMachineSet{},
+		)
+	})
+})

--- a/pkg/controllers/controlplanemachineset/status.go
+++ b/pkg/controllers/controlplanemachineset/status.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controlplanemachineset
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	machinev1 "github.com/openshift/api/machine/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// updateControlPlaneMachineSetStatus ensures that the status of the ControlPlaneMachineSet is up to date after
+// the resource has been reconciled.
+func (r *ControlPlaneMachineSetReconciler) updateControlPlaneMachineSetStatus(ctx context.Context, logger logr.Logger, cpms *machinev1.ControlPlaneMachineSet, patchBase client.Patch) error {
+	return nil
+}

--- a/pkg/test/cleanup.go
+++ b/pkg/test/cleanup.go
@@ -53,7 +53,7 @@ func cleanupResource(ctx context.Context, k8sClient client.Client, namespace str
 
 		listObj := newListFromObject(k8sClient, obj)
 
-		return komega.ObjectList(listObj)()
+		return komega.ObjectList(listObj, client.InNamespace(namespace))()
 	}).Should(HaveField("Items", HaveLen(0)))
 }
 

--- a/pkg/test/conditions.go
+++ b/pkg/test/conditions.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+// errActualTypeMismatchClusterOperatorStatusCondition is used when the type of the actual object does not match
+// the expected type or ClusterOperatorStatusCondition.
+var errActualTypeMismatchClusterOperatorStatusCondition = errors.New("actual should be of type ClusterOperatorStatusCondition")
+
+// MatchClusterOperatorStatusConditions returns a custom matcher to check equality of configv1.ClusterOperatorStatusConditions.
+func MatchClusterOperatorStatusConditions(expected []configv1.ClusterOperatorStatusCondition) types.GomegaMatcher {
+	return &matchConditions{
+		expected: expected,
+	}
+}
+
+type matchConditions struct {
+	expected []configv1.ClusterOperatorStatusCondition
+}
+
+// Match checks for equality between the actual and expected objects.
+func (m matchConditions) Match(actual interface{}) (success bool, err error) {
+	elems := []interface{}{}
+	for _, condition := range m.expected {
+		elems = append(elems, MatchClusterOperatorStatusCondition(condition))
+	}
+
+	ok, err := gomega.ConsistOf(elems).Match(actual)
+	if !ok {
+		return false, wrap(err, "conditions did not match")
+	}
+
+	return true, nil
+}
+
+// FailureMessage is the message returned to the test when the actual and expected
+// objects do not match.
+func (m matchConditions) FailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("expected\n\t%#v\nto match\n\t%#v\n", actual, m.expected)
+}
+
+// NegatedFailureMessage is the negated version of the FailureMessage.
+func (m matchConditions) NegatedFailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("expected\n\t%#v\nto not match\n\t%#v\n", actual, m.expected)
+}
+
+// MatchClusterOperatorStatusCondition returns a custom matcher to check equality of configv1.ClusterOperatorStatusCondition.
+func MatchClusterOperatorStatusCondition(expected configv1.ClusterOperatorStatusCondition) types.GomegaMatcher {
+	return &matchCondition{
+		expected: expected,
+	}
+}
+
+type matchCondition struct {
+	expected configv1.ClusterOperatorStatusCondition
+}
+
+// Match checks for equality between the actual and expected objects.
+func (m matchCondition) Match(actual interface{}) (success bool, err error) {
+	actualCondition, ok := actual.(configv1.ClusterOperatorStatusCondition)
+	if !ok {
+		return false, errActualTypeMismatchClusterOperatorStatusCondition
+	}
+
+	ok, err = gomega.Equal(m.expected.Type).Match(actualCondition.Type)
+	if !ok {
+		return false, wrap(err, "condition type does not match")
+	}
+
+	ok, err = gomega.Equal(m.expected.Status).Match(actualCondition.Status)
+	if !ok {
+		return false, wrap(err, "condition status does not match")
+	}
+
+	ok, err = gomega.Equal(m.expected.Reason).Match(actualCondition.Reason)
+	if !ok {
+		return false, wrap(err, "condition reason does not match")
+	}
+
+	ok, err = gomega.Equal(m.expected.Message).Match(actualCondition.Message)
+	if !ok {
+		return false, wrap(err, "condition message does not match")
+	}
+
+	return true, nil
+}
+
+// FailureMessage is the message returned to the test when the actual and expected
+// objects do not match.
+func (m matchCondition) FailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("expected\n\t%#v\nto match\n\t%#v\n", actual, m.expected)
+}
+
+// NegatedFailureMessage is the negated version of the FailureMessage.
+func (m matchCondition) NegatedFailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("expected\n\t%#v\nto not match\n\t%#v\n", actual, m.expected)
+}
+
+// wrap wraps an error with the given message if the error isn't nil.
+func wrap(err error, msg string) error {
+	if err == nil {
+		return nil
+	}
+
+	if !strings.HasSuffix(msg, "%w") {
+		msg = fmt.Sprintf("%s: %%w", msg)
+	}
+
+	// We are expecting the passed messages to wrap the error, so skip linting.
+	return fmt.Errorf(msg, err) //nolint:goerr113
+}

--- a/pkg/test/conditions_test.go
+++ b/pkg/test/conditions_test.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	configv1 "github.com/openshift/api/config/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("Conditions", func() {
+	Context("MatchConditions", func() {
+		var condAvailable, condUpgradable configv1.ClusterOperatorStatusCondition
+
+		BeforeEach(func() {
+			condAvailable = configv1.ClusterOperatorStatusCondition{
+				Type:               configv1.OperatorAvailable,
+				Status:             configv1.ConditionTrue,
+				Message:            "Operating as expected",
+				Reason:             "OperatorAvailable",
+				LastTransitionTime: metav1.Now(),
+			}
+
+			condUpgradable = configv1.ClusterOperatorStatusCondition{
+				Type:               configv1.OperatorUpgradeable,
+				Status:             configv1.ConditionTrue,
+				Message:            "Operating as expected",
+				Reason:             "OperatorUpgradable",
+				LastTransitionTime: metav1.Now(),
+			}
+		})
+
+		It("matches when the conditions match", func() {
+			// Order should not matter so switch them around a few times
+			availableUpgradable := []configv1.ClusterOperatorStatusCondition{condAvailable, condUpgradable}
+			upgradableAvailable := []configv1.ClusterOperatorStatusCondition{condUpgradable, condAvailable}
+
+			Expect(availableUpgradable).To(MatchClusterOperatorStatusConditions(availableUpgradable))
+			Expect(availableUpgradable).To(MatchClusterOperatorStatusConditions(upgradableAvailable))
+			Expect(upgradableAvailable).To(MatchClusterOperatorStatusConditions(availableUpgradable))
+			Expect(upgradableAvailable).To(MatchClusterOperatorStatusConditions(upgradableAvailable))
+		})
+
+		It("does not match when the conditions do not match", func() {
+			// Order should not matter so switch them around a few times
+			condUpgradableFalse := condUpgradable.DeepCopy()
+			condUpgradableFalse.Status = configv1.ConditionFalse
+
+			actual := []configv1.ClusterOperatorStatusCondition{condAvailable, *condUpgradableFalse}
+			expected := []configv1.ClusterOperatorStatusCondition{condUpgradable, condAvailable}
+
+			Expect(actual).ToNot(MatchClusterOperatorStatusConditions(expected))
+		})
+
+		It("does not match with too few conditions", func() {
+			// Order should not matter so switch them around a few times
+			actual := []configv1.ClusterOperatorStatusCondition{condAvailable}
+			expected := []configv1.ClusterOperatorStatusCondition{condUpgradable, condAvailable}
+
+			Expect(actual).ToNot(MatchClusterOperatorStatusConditions(expected))
+		})
+
+		It("does not match with too many conditions", func() {
+			// Order should not matter so switch them around a few times
+			condUpgradableFalse := condUpgradable.DeepCopy()
+			condUpgradableFalse.Status = configv1.ConditionFalse
+
+			actual := []configv1.ClusterOperatorStatusCondition{condAvailable, condUpgradable, *condUpgradableFalse}
+			expected := []configv1.ClusterOperatorStatusCondition{condUpgradable, condAvailable}
+
+			Expect(actual).ToNot(MatchClusterOperatorStatusConditions(expected))
+		})
+
+		It("does not match with an invalid actual", func() {
+			expected := []configv1.ClusterOperatorStatusCondition{condUpgradable, condAvailable}
+
+			ok, err := MatchClusterOperatorStatusConditions(expected).Match(metav1.Condition{})
+			Expect(err).To(MatchError(HavePrefix("conditions did not match: ConsistOf matcher expects an array/slice/map.")))
+			Expect(ok).To(BeFalse())
+		})
+	})
+
+	Context("MatchCondition", func() {
+		var cond configv1.ClusterOperatorStatusCondition
+
+		BeforeEach(func() {
+			cond = configv1.ClusterOperatorStatusCondition{
+				Type:               configv1.OperatorAvailable,
+				Status:             configv1.ConditionTrue,
+				Message:            "Operating as expected",
+				Reason:             "OperatorAvailable",
+				LastTransitionTime: metav1.Now(),
+			}
+		})
+
+		It("matches when all fields match", func() {
+			Expect(cond).To(MatchClusterOperatorStatusCondition(cond))
+		})
+
+		It("matches when the timestamps differ", func() {
+			condLater := cond.DeepCopy()
+			condLater.LastTransitionTime = metav1.NewTime(time.Now().Add(1 * time.Hour))
+			Expect(cond).To(MatchClusterOperatorStatusCondition(*condLater))
+		})
+
+		It("does not match when the type is mismatched", func() {
+			condUpgradable := cond.DeepCopy()
+			condUpgradable.Type = configv1.OperatorUpgradeable
+			Expect(cond).ToNot(MatchClusterOperatorStatusCondition(*condUpgradable))
+		})
+
+		It("does not match when the status is mismatched", func() {
+			condFalse := cond.DeepCopy()
+			condFalse.Status = configv1.ConditionFalse
+			Expect(cond).ToNot(MatchClusterOperatorStatusCondition(*condFalse))
+		})
+
+		It("does not match when the message is mismatched", func() {
+			condEmptyMessage := cond.DeepCopy()
+			condEmptyMessage.Message = ""
+			Expect(cond).ToNot(MatchClusterOperatorStatusCondition(*condEmptyMessage))
+		})
+
+		It("does not match when the reason is mismatched", func() {
+			condEmptyReason := cond.DeepCopy()
+			condEmptyReason.Reason = ""
+			Expect(cond).ToNot(MatchClusterOperatorStatusCondition(*condEmptyReason))
+		})
+
+		It("does not match with an invalid actual", func() {
+			ok, err := MatchClusterOperatorStatusCondition(cond).Match(metav1.Condition{})
+			Expect(err).To(Equal(errActualTypeMismatchClusterOperatorStatusCondition))
+			Expect(ok).To(BeFalse())
+		})
+	})
+})

--- a/pkg/test/resourcebuilder/cluster_operator.go
+++ b/pkg/test/resourcebuilder/cluster_operator.go
@@ -45,3 +45,20 @@ func (n ClusterOperatorBuilder) WithName(name string) ClusterOperatorBuilder {
 	n.name = name
 	return n
 }
+
+// ClusterOperatorStatus creates a new cluster operator status builder.
+func ClusterOperatorStatus() ClusterOperatorStatusBuilder {
+	return ClusterOperatorStatusBuilder{}
+}
+
+// ClusterOperatorStatusBuilder is used to build out a cluster operator status object.
+type ClusterOperatorStatusBuilder struct {
+	conditions []configv1.ClusterOperatorStatusCondition
+}
+
+// Build builds a new cluster operator status based on the configuration provided.
+func (n ClusterOperatorStatusBuilder) Build() configv1.ClusterOperatorStatus {
+	return configv1.ClusterOperatorStatus{
+		Conditions: n.conditions,
+	}
+}

--- a/pkg/test/suite_test.go
+++ b/pkg/test/suite_test.go
@@ -44,7 +44,7 @@ var ctx = context.Background()
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
 
-	RunSpecs(t, "Test Suite")
+	RunSpecs(t, "Test Utils Suite")
 }
 
 var _ = BeforeSuite(func() {


### PR DESCRIPTION
This PR adds a very high level reconcile skeleton of fetching the CPMS, setting the cluster operator status and updating the CPMS status. There is no real logic here but I've added some more test helpers and some tests to cover the ClusterOperator setting the status when there is no CPMS present, this logic should be implemented soon to ensure we can run the operator on a real cluster.