### PR TITLE
Ensure the finalizer addition is the first action within the reconcile

### DIFF
--- a/pkg/controllers/controlplanemachineset/controller_test.go
+++ b/pkg/controllers/controlplanemachineset/controller_test.go
@@ -30,6 +30,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 )
 
 var _ = Describe("With a running controller", func() {
@@ -93,5 +94,193 @@ var _ = Describe("With a running controller", func() {
 			&machinev1beta1.Machine{},
 			&machinev1.ControlPlaneMachineSet{},
 		)
+	})
+
+	Context("when a new Control Plane Machine Set is created", func() {
+		var cpms *machinev1.ControlPlaneMachineSet
+
+		// Create the CPMS just before each test so that we can set up
+		// various test cases in BeforeEach blocks.
+		JustBeforeEach(func() {
+			// The default CPMS should be sufficient for this test.
+			cpms = resourcebuilder.ControlPlaneMachineSet().WithNamespace(namespaceName).Build()
+			Expect(k8sClient.Create(ctx, cpms)).Should(Succeed())
+		})
+
+		PIt("should add the controlplanemachineset.machine.openshift.io finalizer", func() {
+			Eventually(komega.Object(cpms)).Should(HaveField("ObjectMeta.Finalizers", ContainElement(controlPlaneMachineSetFinalizer)))
+		})
+	})
+
+	Context("with an existing ControlPlaneMachineSet", func() {
+		var cpms *machinev1.ControlPlaneMachineSet
+
+		BeforeEach(func() {
+			// The default CPMS should be sufficient for this test.
+			cpms = resourcebuilder.ControlPlaneMachineSet().WithNamespace(namespaceName).Build()
+			Expect(k8sClient.Create(ctx, cpms)).Should(Succeed())
+
+			// To ensure that at least one reconcile happens, wait for the status to not be empty.
+			Eventually(komega.Object(cpms)).Should(HaveField("Status.ObservedGeneration", Not(Equal(int64(0)))))
+		})
+
+		Context("if the finalizer is removed", func() {
+			BeforeEach(func() {
+				// Ensure the finalizer was already added
+				Expect(komega.Object(cpms)()).Should(HaveField("ObjectMeta.Finalizers", ContainElement(controlPlaneMachineSetFinalizer)))
+
+				// Remove the finalizer
+				Eventually(komega.Update(cpms, func() {
+					cpms.ObjectMeta.Finalizers = []string{}
+				})).Should(Succeed())
+
+				// CPMS should now have no finalizers, reflecting the state of the API.
+				Expect(cpms.ObjectMeta.Finalizers).To(BeEmpty())
+			})
+
+			PIt("should re-add the controlplanemachineset.machine.openshift.io finalizer", func() {
+				Eventually(komega.Object(cpms)).Should(HaveField("ObjectMeta.Finalizers", ContainElement(controlPlaneMachineSetFinalizer)))
+			})
+		})
+	})
+})
+
+var _ = Describe("ensureFinalizer", func() {
+	var namespaceName string
+	var reconciler *ControlPlaneMachineSetReconciler
+	var cpms *machinev1.ControlPlaneMachineSet
+	var logger test.TestLogger
+
+	const existingFinalizer = "existingFinalizer"
+
+	BeforeEach(func() {
+		By("Setting up a namespace for the test")
+		ns := resourcebuilder.Namespace().WithGenerateName("control-plane-machine-set-controller-").Build()
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+		namespaceName = ns.GetName()
+
+		reconciler = &ControlPlaneMachineSetReconciler{
+			Client:    k8sClient,
+			Scheme:    testScheme,
+			Namespace: namespaceName,
+		}
+
+		// The ControlPlaneMachineSet should already exist by the time we get here.
+		By("Creating a ControlPlaneMachineSet")
+		cpms = resourcebuilder.ControlPlaneMachineSet().WithNamespace(namespaceName).Build()
+		cpms.ObjectMeta.Finalizers = []string{existingFinalizer}
+		Expect(k8sClient.Create(ctx, cpms)).Should(Succeed())
+
+		logger = test.NewTestLogger()
+	})
+
+	AfterEach(func() {
+		test.CleanupResources(ctx, cfg, k8sClient, namespaceName,
+			&machinev1.ControlPlaneMachineSet{},
+		)
+	})
+
+	Context("when the finalizer does not exist", func() {
+		var updatedFinalizer bool
+		var err error
+
+		BeforeEach(func() {
+			updatedFinalizer, err = reconciler.ensureFinalizer(ctx, logger.Logger(), cpms)
+		})
+
+		It("does not error", func() {
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		PIt("returns that it updated the finalizer", func() {
+			Expect(updatedFinalizer).To(BeTrue())
+		})
+
+		PIt("sets an appropriate log line", func() {
+			Expect(logger.Entries()).To(ConsistOf(
+				test.LogEntry{
+					Level:   2,
+					Message: "Added finalizer to control plane machine set",
+				},
+			))
+		})
+
+		PIt("ensures the finalizer is set on the API", func() {
+			Eventually(komega.Object(cpms)).Should(HaveField("ObjectMeta.Finalizers", ContainElement(controlPlaneMachineSetFinalizer)))
+		})
+
+		It("does not remove any existing finalizers", func() {
+			Eventually(komega.Object(cpms)).Should(HaveField("ObjectMeta.Finalizers", ContainElement(existingFinalizer)))
+		})
+	})
+
+	Context("when the finalizer already exists", func() {
+		var updatedFinalizer bool
+		var err error
+
+		BeforeEach(func() {
+			By("Adding the finalizer to the existing object")
+			Eventually(komega.Update(cpms, func() {
+				cpms.SetFinalizers(append(cpms.GetFinalizers(), controlPlaneMachineSetFinalizer))
+			})).Should(Succeed())
+
+			Eventually(komega.Object(cpms)).Should(HaveField("ObjectMeta.Finalizers", ConsistOf(controlPlaneMachineSetFinalizer, existingFinalizer)))
+
+			updatedFinalizer, err = reconciler.ensureFinalizer(ctx, logger.Logger(), cpms)
+		})
+
+		It("does not error", func() {
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns that it did not update the finalizer", func() {
+			Expect(updatedFinalizer).To(BeFalse())
+		})
+
+		PIt("sets an appropriate log line", func() {
+			Expect(logger.Entries()).To(ConsistOf(
+				test.LogEntry{
+					Level:   4,
+					Message: "Finalizer already present on control plane machine set",
+				},
+			))
+		})
+
+		It("does not remove any existing finalizers", func() {
+			Eventually(komega.Object(cpms)).Should(HaveField("ObjectMeta.Finalizers", ConsistOf(controlPlaneMachineSetFinalizer, existingFinalizer)))
+		})
+	})
+
+	Context("when the finalizer already exists, but the input is stale", func() {
+		var updatedFinalizer bool
+		var err error
+
+		BeforeEach(func() {
+			By("Adding the finalizer to the existing object")
+			originalCPMS := cpms.DeepCopy()
+			Eventually(komega.Update(cpms, func() {
+				cpms.SetFinalizers(append(cpms.GetFinalizers(), controlPlaneMachineSetFinalizer))
+			})).Should(Succeed())
+
+			Eventually(komega.Object(cpms)).Should(HaveField("ObjectMeta.Finalizers", ConsistOf(controlPlaneMachineSetFinalizer, existingFinalizer)))
+
+			updatedFinalizer, err = reconciler.ensureFinalizer(ctx, logger.Logger(), originalCPMS)
+		})
+
+		PIt("should return a conflict error", func() {
+			Expect(err).To(MatchError(ContainSubstring("TODO")))
+		})
+
+		It("returns that it did not update the finalizer", func() {
+			Expect(updatedFinalizer).To(BeFalse())
+		})
+
+		PIt("does not log", func() {
+			Expect(logger.Entries()).To(BeEmpty())
+		})
+
+		It("does not remove any existing finalizers", func() {
+			Eventually(komega.Object(cpms)).Should(HaveField("ObjectMeta.Finalizers", ConsistOf(controlPlaneMachineSetFinalizer, existingFinalizer)))
+		})
 	})
 })

--- a/pkg/test/logger.go
+++ b/pkg/test/logger.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"github.com/go-logr/logr"
+)
+
+// LogEntry captures the information about a particular log line.
+type LogEntry struct {
+	// Error is the error passed to an error log line.
+	Error error
+
+	// KeysAndValues are the keys and values that were logged with
+	// the log line.
+	KeysAndValues []interface{}
+
+	// Level is the level of the info log line.
+	Level int
+
+	// Messages is the message from the log line.
+	Message string
+}
+
+// TestLogger provides a logr.Logger and access to a list of log
+// entries logged via the logger.
+type TestLogger interface {
+	Entries() []LogEntry
+	Logger() logr.Logger
+}
+
+// NewTestLogger constructs a new TestLogger.
+func NewTestLogger() TestLogger {
+	l := &testLogger{
+		entries: &[]LogEntry{},
+	}
+	l.logger = logr.New(l)
+
+	return l
+}
+
+// testLogger is an implementation of the TestLogger interface.
+type testLogger struct {
+	entries       *[]LogEntry
+	keysAndValues []interface{}
+	logger        logr.Logger
+	runtimeInfo   logr.RuntimeInfo
+}
+
+// Logger provides the TestLoggers logr.Logger.
+func (t *testLogger) Logger() logr.Logger {
+	return t.logger
+}
+
+// Entries returns the previously logged log entries.
+func (t *testLogger) Entries() []LogEntry {
+	return *t.entries
+}
+
+// Init configures the logr.LogSink implementation.
+func (t *testLogger) Init(info logr.RuntimeInfo) {
+	t.runtimeInfo = info
+}
+
+// Enabled is used to determine whether an info log should be logged.
+func (t *testLogger) Enabled(_ int) bool {
+	// Always return true so that we capture every log line in the test.
+	return true
+}
+
+// Info accepts an info log line.
+func (t *testLogger) Info(level int, msg string, keysAndValues ...interface{}) {
+	*t.entries = append(*t.entries, LogEntry{
+		KeysAndValues: append(t.keysAndValues, keysAndValues...),
+		Level:         level,
+		Message:       msg,
+	})
+}
+
+// Error accepts an error log line.
+func (t *testLogger) Error(err error, msg string, keysAndValues ...interface{}) {
+	*t.entries = append(*t.entries, LogEntry{
+		Error:         err,
+		KeysAndValues: append(t.keysAndValues, keysAndValues...),
+		Message:       msg,
+	})
+}
+
+// WithValues creates a child logger with additional keys and values attached.
+func (t *testLogger) WithValues(keysAndValues ...interface{}) logr.LogSink {
+	return &testLogger{
+		runtimeInfo:   t.runtimeInfo,
+		logger:        t.logger,
+		entries:       t.entries,
+		keysAndValues: append(t.keysAndValues, keysAndValues...),
+	}
+}
+
+// WithName sets the name of the logger. This is not currently supported.
+func (t *testLogger) WithName(name string) logr.LogSink {
+	return t
+}

--- a/pkg/test/logger_test.go
+++ b/pkg/test/logger_test.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"errors"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("TestLogger", func() {
+	var logger TestLogger
+
+	BeforeEach(func() {
+		logger = NewTestLogger()
+	})
+
+	It("adds info logs to the entries", func() {
+		logger.Logger().V(1).Info("some log message", "extra", "detail")
+		logger.Logger().V(3).Info("another log message", "key", "value")
+
+		Expect(logger.Entries()).To(ConsistOf(
+			LogEntry{
+				Level:         1,
+				Message:       "some log message",
+				KeysAndValues: []interface{}{"extra", "detail"},
+			},
+			LogEntry{
+				Level:         3,
+				Message:       "another log message",
+				KeysAndValues: []interface{}{"key", "value"},
+			},
+		))
+	})
+
+	It("adds error logs to the entries", func() {
+		err := errors.New("error") //nolint:goerr113
+		logger.Logger().Error(err, "some log message", "extra", "detail")
+
+		Expect(logger.Entries()).To(ConsistOf(
+			LogEntry{
+				Error:         err,
+				Message:       "some log message",
+				KeysAndValues: []interface{}{"extra", "detail"},
+			},
+		))
+	})
+
+	Context("when adding extra keys and values to the logger", func() {
+		var myKeyValueLogger logr.Logger
+
+		BeforeEach(func() {
+			myKeyValueLogger = logger.Logger().WithValues("myKey", "myValue")
+		})
+
+		It("adds the key and value to the logs", func() {
+			myKeyValueLogger.V(2).Info("some log message", "extra", "detail")
+
+			Expect(logger.Entries()).To(ConsistOf(
+				LogEntry{
+					Level:         2,
+					Message:       "some log message",
+					KeysAndValues: []interface{}{"myKey", "myValue", "extra", "detail"},
+				},
+			))
+		})
+
+		It("does not add the key and value to the logs from the parent logger", func() {
+			logger.Logger().V(2).Info("some log message", "extra", "detail")
+
+			Expect(logger.Entries()).To(ConsistOf(
+				LogEntry{
+					Level:         2,
+					Message:       "some log message",
+					KeysAndValues: []interface{}{"extra", "detail"},
+				},
+			))
+		})
+	})
+})


### PR DESCRIPTION
The finalizer is the only spec update we should be doing to the CPMS. So that we avoid conflicts, once we add the finalizer, we should make sure to requeue the object before attempting to reconcile the status in the next reconcile.

This sets up an `ensureFinalizer` function which will need implementing and the pending tests enabling.
