### PR TITLE
Cleanup utils should not use default Gomega

### DIFF
--- a/pkg/controllers/controlplanemachineset/cluster_operator_test.go
+++ b/pkg/controllers/controlplanemachineset/cluster_operator_test.go
@@ -88,7 +88,7 @@ var _ = Describe("Cluster Operator Status with a running controller", func() {
 		// Wait for the mgrDone to be closed, which will happen once the mgr has stopped
 		<-mgrDone
 
-		test.CleanupResources(ctx, cfg, k8sClient, namespaceName,
+		test.CleanupResources(Default, ctx, cfg, k8sClient, namespaceName,
 			&corev1.Node{},
 			&configv1.ClusterOperator{},
 			&machinev1beta1.Machine{},

--- a/pkg/controllers/controlplanemachineset/controller_test.go
+++ b/pkg/controllers/controlplanemachineset/controller_test.go
@@ -89,7 +89,7 @@ var _ = Describe("With a running controller", func() {
 		// Wait for the mgrDone to be closed, which will happen once the mgr has stopped
 		<-mgrDone
 
-		test.CleanupResources(ctx, cfg, k8sClient, namespaceName,
+		test.CleanupResources(Default, ctx, cfg, k8sClient, namespaceName,
 			&corev1.Node{},
 			&configv1.ClusterOperator{},
 			&machinev1beta1.Machine{},
@@ -214,7 +214,7 @@ var _ = Describe("ensureFinalizer", func() {
 	})
 
 	AfterEach(func() {
-		test.CleanupResources(ctx, cfg, k8sClient, namespaceName,
+		test.CleanupResources(Default, ctx, cfg, k8sClient, namespaceName,
 			&machinev1.ControlPlaneMachineSet{},
 		)
 	})

--- a/pkg/test/cleanup_test.go
+++ b/pkg/test/cleanup_test.go
@@ -49,14 +49,14 @@ var _ = Describe("Cleanup", func() {
 	})
 
 	It("should delete all Machines", func() {
-		CleanupResources(ctx, cfg, k8sClient, namespaceName,
+		CleanupResources(Default, ctx, cfg, k8sClient, namespaceName,
 			&machinev1beta1.Machine{},
 		)
 		Expect(komega.ObjectList(&machinev1beta1.MachineList{})()).To(HaveField("Items", HaveLen(0)))
 	})
 
 	It("should delete the namespace when given", func() {
-		CleanupResources(ctx, cfg, k8sClient, namespaceName,
+		CleanupResources(Default, ctx, cfg, k8sClient, namespaceName,
 			&machinev1beta1.Machine{},
 		)
 
@@ -69,7 +69,7 @@ var _ = Describe("Cleanup", func() {
 	It("should not error when no namespace is given", func() {
 		// In this case it won't actually delete anything, but that shouldn't cause any errors.
 		// Any remaining resources won't affect other tests as they are in a separate namespace.
-		CleanupResources(ctx, cfg, k8sClient, "")
+		CleanupResources(Default, ctx, cfg, k8sClient, "")
 	})
 
 	It("should ignore resources in another namespace", func() {
@@ -86,7 +86,7 @@ var _ = Describe("Cleanup", func() {
 		}
 
 		// Check that it can delete all resources in the namespace
-		CleanupResources(ctx, cfg, k8sClient, namespaceName,
+		CleanupResources(Default, ctx, cfg, k8sClient, namespaceName,
 			&machinev1beta1.Machine{},
 		)
 		Expect(komega.ObjectList(&machinev1beta1.MachineList{}, client.InNamespace(namespaceName))()).To(HaveField("Items", HaveLen(0)))
@@ -95,7 +95,7 @@ var _ = Describe("Cleanup", func() {
 		Expect(komega.ObjectList(&machinev1beta1.MachineList{}, client.InNamespace(ns.GetName()))()).To(HaveField("Items", HaveLen(3)))
 
 		// Cleanup the second namespace
-		CleanupResources(ctx, cfg, k8sClient, ns.GetName(),
+		CleanupResources(Default, ctx, cfg, k8sClient, ns.GetName(),
 			&machinev1beta1.Machine{},
 		)
 		Expect(komega.ObjectList(&machinev1beta1.MachineList{}, client.InNamespace(ns.GetName()))()).To(HaveField("Items", HaveLen(0)))
@@ -115,7 +115,7 @@ var _ = Describe("Cleanup", func() {
 			Eventually(komega.Object(machine)).Should(HaveField("ObjectMeta.Finalizers", ConsistOf("finalizer1", "finalizer2")))
 		}
 
-		CleanupResources(ctx, cfg, k8sClient, namespaceName,
+		CleanupResources(Default, ctx, cfg, k8sClient, namespaceName,
 			&machinev1beta1.Machine{},
 		)
 		Eventually(komega.ObjectList(&machinev1beta1.MachineList{}, client.InNamespace(namespaceName))).Should(HaveField("Items", HaveLen(0)))

--- a/pkg/test/cleanup_test.go
+++ b/pkg/test/cleanup_test.go
@@ -48,11 +48,11 @@ var _ = Describe("Cleanup", func() {
 		}
 	})
 
-	It("should delete all Machines", func() {
+	It("should delete all Machines in the namespace", func() {
 		CleanupResources(Default, ctx, cfg, k8sClient, namespaceName,
 			&machinev1beta1.Machine{},
 		)
-		Expect(komega.ObjectList(&machinev1beta1.MachineList{})()).To(HaveField("Items", HaveLen(0)))
+		Expect(komega.ObjectList(&machinev1beta1.MachineList{}, client.InNamespace(namespaceName))()).To(HaveField("Items", HaveLen(0)))
 	})
 
 	It("should delete the namespace when given", func() {

--- a/pkg/webhooks/controlplanemachineset/webhooks_test.go
+++ b/pkg/webhooks/controlplanemachineset/webhooks_test.go
@@ -74,7 +74,7 @@ var _ = Describe("Webhooks", func() {
 		// Wait for the mgrDone to be closed, which will happen once the mgr has stopped
 		<-mgrDone
 
-		test.CleanupResources(ctx, cfg, k8sClient, namespaceName,
+		test.CleanupResources(Default, ctx, cfg, k8sClient, namespaceName,
 			&machinev1beta1.Machine{},
 			&machinev1.ControlPlaneMachineSet{},
 		)


### PR DESCRIPTION
In order to make the cleanup util generic (and any future utils), we should make sure that the test that calls the util should be able to pass in their own Gomega. This will ensure that the util can be reused when a test declares its own Gomega (eg when using `NewWithT`). This is basically an effort to make sure this is generic enough to be copied into other projects/a shared library at some later date.