### PR TITLE
Ensure deletion logic is handled when deletion timestamp is set

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/go-logr/logr v1.2.2
 	github.com/golangci/golangci-lint v1.44.2
 	github.com/onsi/ginkgo/v2 v2.1.3
-	github.com/onsi/gomega v1.18.1
+	github.com/onsi/gomega v1.18.2-0.20220228162959-c8ba5823d8c2
 	github.com/openshift/api v0.0.0-20220308093233-c21df43305c4
 	k8s.io/api v0.23.4
 	k8s.io/apimachinery v0.23.4

--- a/go.sum
+++ b/go.sum
@@ -744,8 +744,9 @@ github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGV
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
-github.com/onsi/gomega v1.18.1 h1:M1GfJqGRrBrrGGsbxzV5dqM2U2ApXefZCQpkukxYRLE=
 github.com/onsi/gomega v1.18.1/go.mod h1:0q+aL8jAiMXy9hbwj2mr5GziHiwhAIQpFmmtT5hitRs=
+github.com/onsi/gomega v1.18.2-0.20220228162959-c8ba5823d8c2 h1:vondSjoVjo5NyDsFOg1wb8FKbcQpHQkVmGvolpFHFzE=
+github.com/onsi/gomega v1.18.2-0.20220228162959-c8ba5823d8c2/go.mod h1:0q+aL8jAiMXy9hbwj2mr5GziHiwhAIQpFmmtT5hitRs=
 github.com/openshift/api v0.0.0-20220308093233-c21df43305c4 h1:oHDjn+1/zSCwTnxyQhDEEGnbsjVQKNLTLoFjThkbEPY=
 github.com/openshift/api v0.0.0-20220308093233-c21df43305c4/go.mod h1:F/eU6jgr6Q2VhMu1mSpMmygxAELd7+BUxs3NHZ25jV4=
 github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=

--- a/vendor/github.com/onsi/gomega/matchers.go
+++ b/vendor/github.com/onsi/gomega/matchers.go
@@ -320,6 +320,20 @@ func ContainElements(elements ...interface{}) types.GomegaMatcher {
 	}
 }
 
+//HaveEach succeeds if actual solely contains elements that match the passed in element.
+//Please note that if actual is empty, HaveEach always will succeed.
+//By default HaveEach() uses Equal() to perform the match, however a
+//matcher can be passed in instead:
+//    Expect([]string{"Foo", "FooBar"}).Should(HaveEach(ContainSubstring("Foo")))
+//
+//Actual must be an array, slice or map.
+//For maps, HaveEach searches through the map's values.
+func HaveEach(element interface{}) types.GomegaMatcher {
+	return &matchers.HaveEachMatcher{
+		Element: element,
+	}
+}
+
 //HaveKey succeeds if actual is a map with the passed in key.
 //By default HaveKey uses Equal() to perform the match, however a
 //matcher can be passed in instead:

--- a/vendor/github.com/onsi/gomega/matchers/have_each_matcher.go
+++ b/vendor/github.com/onsi/gomega/matchers/have_each_matcher.go
@@ -1,0 +1,65 @@
+package matchers
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/onsi/gomega/format"
+)
+
+type HaveEachMatcher struct {
+	Element interface{}
+}
+
+func (matcher *HaveEachMatcher) Match(actual interface{}) (success bool, err error) {
+	if !isArrayOrSlice(actual) && !isMap(actual) {
+		return false, fmt.Errorf("HaveEach matcher expects an array/slice/map.  Got:\n%s",
+			format.Object(actual, 1))
+	}
+
+	elemMatcher, elementIsMatcher := matcher.Element.(omegaMatcher)
+	if !elementIsMatcher {
+		elemMatcher = &EqualMatcher{Expected: matcher.Element}
+	}
+
+	value := reflect.ValueOf(actual)
+	if value.Len() == 0 {
+		return false, fmt.Errorf("HaveEach matcher expects a non-empty array/slice/map.  Got:\n%s",
+			format.Object(actual, 1))
+	}
+
+	var valueAt func(int) interface{}
+	if isMap(actual) {
+		keys := value.MapKeys()
+		valueAt = func(i int) interface{} {
+			return value.MapIndex(keys[i]).Interface()
+		}
+	} else {
+		valueAt = func(i int) interface{} {
+			return value.Index(i).Interface()
+		}
+	}
+
+	// if there are no elements, then HaveEach will match.
+	for i := 0; i < value.Len(); i++ {
+		success, err := elemMatcher.Match(valueAt(i))
+		if err != nil {
+			return false, err
+		}
+		if !success {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+// FailureMessage returns a suitable failure message.
+func (matcher *HaveEachMatcher) FailureMessage(actual interface{}) (message string) {
+	return format.Message(actual, "to contain element matching", matcher.Element)
+}
+
+// NegatedFailureMessage returns a suitable negated failure message.
+func (matcher *HaveEachMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	return format.Message(actual, "not to contain element matching", matcher.Element)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -463,7 +463,7 @@ github.com/onsi/ginkgo/v2/internal/parallel_support
 github.com/onsi/ginkgo/v2/internal/testingtproxy
 github.com/onsi/ginkgo/v2/reporters
 github.com/onsi/ginkgo/v2/types
-# github.com/onsi/gomega v1.18.1
+# github.com/onsi/gomega v1.18.2-0.20220228162959-c8ba5823d8c2
 ## explicit; go 1.16
 github.com/onsi/gomega
 github.com/onsi/gomega/format


### PR DESCRIPTION
When a deletion timestamp is set, we expect that the normal reconcile logic will be skipped. This forks the logic into a reconcileDelete function at the beginning. I've also added a couple of tests which outline what we are expecting from the deletion logic.