### PR TITLE
Add conditions matchers for metav1.Condition

### DIFF
--- a/pkg/test/conditions.go
+++ b/pkg/test/conditions.go
@@ -33,17 +33,17 @@ var errActualTypeMismatchClusterOperatorStatusCondition = errors.New("actual sho
 
 // MatchClusterOperatorStatusConditions returns a custom matcher to check equality of configv1.ClusterOperatorStatusConditions.
 func MatchClusterOperatorStatusConditions(expected []configv1.ClusterOperatorStatusCondition) types.GomegaMatcher {
-	return &matchConditions{
+	return &matchClusterOperatorConditions{
 		expected: expected,
 	}
 }
 
-type matchConditions struct {
+type matchClusterOperatorConditions struct {
 	expected []configv1.ClusterOperatorStatusCondition
 }
 
 // Match checks for equality between the actual and expected objects.
-func (m matchConditions) Match(actual interface{}) (success bool, err error) {
+func (m matchClusterOperatorConditions) Match(actual interface{}) (success bool, err error) {
 	elems := []interface{}{}
 	for _, condition := range m.expected {
 		elems = append(elems, MatchClusterOperatorStatusCondition(condition))
@@ -59,28 +59,28 @@ func (m matchConditions) Match(actual interface{}) (success bool, err error) {
 
 // FailureMessage is the message returned to the test when the actual and expected
 // objects do not match.
-func (m matchConditions) FailureMessage(actual interface{}) (message string) {
+func (m matchClusterOperatorConditions) FailureMessage(actual interface{}) (message string) {
 	return fmt.Sprintf("expected\n\t%#v\nto match\n\t%#v\n", actual, m.expected)
 }
 
 // NegatedFailureMessage is the negated version of the FailureMessage.
-func (m matchConditions) NegatedFailureMessage(actual interface{}) (message string) {
+func (m matchClusterOperatorConditions) NegatedFailureMessage(actual interface{}) (message string) {
 	return fmt.Sprintf("expected\n\t%#v\nto not match\n\t%#v\n", actual, m.expected)
 }
 
 // MatchClusterOperatorStatusCondition returns a custom matcher to check equality of configv1.ClusterOperatorStatusCondition.
 func MatchClusterOperatorStatusCondition(expected configv1.ClusterOperatorStatusCondition) types.GomegaMatcher {
-	return &matchCondition{
+	return &matchClusterOperatorCondition{
 		expected: expected,
 	}
 }
 
-type matchCondition struct {
+type matchClusterOperatorCondition struct {
 	expected configv1.ClusterOperatorStatusCondition
 }
 
 // Match checks for equality between the actual and expected objects.
-func (m matchCondition) Match(actual interface{}) (success bool, err error) {
+func (m matchClusterOperatorCondition) Match(actual interface{}) (success bool, err error) {
 	actualCondition, ok := actual.(configv1.ClusterOperatorStatusCondition)
 	if !ok {
 		return false, errActualTypeMismatchClusterOperatorStatusCondition
@@ -111,12 +111,12 @@ func (m matchCondition) Match(actual interface{}) (success bool, err error) {
 
 // FailureMessage is the message returned to the test when the actual and expected
 // objects do not match.
-func (m matchCondition) FailureMessage(actual interface{}) (message string) {
+func (m matchClusterOperatorCondition) FailureMessage(actual interface{}) (message string) {
 	return fmt.Sprintf("expected\n\t%#v\nto match\n\t%#v\n", actual, m.expected)
 }
 
 // NegatedFailureMessage is the negated version of the FailureMessage.
-func (m matchCondition) NegatedFailureMessage(actual interface{}) (message string) {
+func (m matchClusterOperatorCondition) NegatedFailureMessage(actual interface{}) (message string) {
 	return fmt.Sprintf("expected\n\t%#v\nto not match\n\t%#v\n", actual, m.expected)
 }
 

--- a/pkg/test/conditions_test.go
+++ b/pkg/test/conditions_test.go
@@ -28,6 +28,131 @@ import (
 
 var _ = Describe("Conditions", func() {
 	Context("MatchConditions", func() {
+		var condAvailable, condUpgradable metav1.Condition
+
+		BeforeEach(func() {
+			condAvailable = metav1.Condition{
+				Type:               "Available",
+				Status:             metav1.ConditionTrue,
+				Message:            "Operating as expected",
+				Reason:             "OperatorAvailable",
+				LastTransitionTime: metav1.Now(),
+			}
+
+			condUpgradable = metav1.Condition{
+				Type:               "Upgradeable",
+				Status:             metav1.ConditionTrue,
+				Message:            "Operating as expected",
+				Reason:             "OperatorUpgradable",
+				LastTransitionTime: metav1.Now(),
+			}
+		})
+
+		It("matches when the conditions match", func() {
+			// Order should not matter so switch them around a few times
+			availableUpgradable := []metav1.Condition{condAvailable, condUpgradable}
+			upgradableAvailable := []metav1.Condition{condUpgradable, condAvailable}
+
+			Expect(availableUpgradable).To(MatchConditions(availableUpgradable))
+			Expect(availableUpgradable).To(MatchConditions(upgradableAvailable))
+			Expect(upgradableAvailable).To(MatchConditions(availableUpgradable))
+			Expect(upgradableAvailable).To(MatchConditions(upgradableAvailable))
+		})
+
+		It("does not match when the conditions do not match", func() {
+			// Order should not matter so switch them around a few times
+			condUpgradableFalse := condUpgradable.DeepCopy()
+			condUpgradableFalse.Status = metav1.ConditionFalse
+
+			actual := []metav1.Condition{condAvailable, *condUpgradableFalse}
+			expected := []metav1.Condition{condUpgradable, condAvailable}
+
+			Expect(actual).ToNot(MatchConditions(expected))
+		})
+
+		It("does not match with too few conditions", func() {
+			// Order should not matter so switch them around a few times
+			actual := []metav1.Condition{condAvailable}
+			expected := []metav1.Condition{condUpgradable, condAvailable}
+
+			Expect(actual).ToNot(MatchConditions(expected))
+		})
+
+		It("does not match with too many conditions", func() {
+			// Order should not matter so switch them around a few times
+			condUpgradableFalse := condUpgradable.DeepCopy()
+			condUpgradableFalse.Status = metav1.ConditionFalse
+
+			actual := []metav1.Condition{condAvailable, condUpgradable, *condUpgradableFalse}
+			expected := []metav1.Condition{condUpgradable, condAvailable}
+
+			Expect(actual).ToNot(MatchConditions(expected))
+		})
+
+		It("does not match with an invalid actual", func() {
+			expected := []metav1.Condition{condUpgradable, condAvailable}
+
+			ok, err := MatchConditions(expected).Match(metav1.Condition{})
+			Expect(err).To(MatchError(HavePrefix("conditions did not match: ConsistOf matcher expects an array/slice/map.")))
+			Expect(ok).To(BeFalse())
+		})
+	})
+
+	Context("MatchCondition", func() {
+		var cond metav1.Condition
+
+		BeforeEach(func() {
+			cond = metav1.Condition{
+				Type:               "Available",
+				Status:             metav1.ConditionTrue,
+				Message:            "Operating as expected",
+				Reason:             "OperatorAvailable",
+				LastTransitionTime: metav1.Now(),
+			}
+		})
+
+		It("matches when all fields match", func() {
+			Expect(cond).To(MatchCondition(cond))
+		})
+
+		It("matches when the timestamps differ", func() {
+			condLater := cond.DeepCopy()
+			condLater.LastTransitionTime = metav1.NewTime(time.Now().Add(1 * time.Hour))
+			Expect(cond).To(MatchCondition(*condLater))
+		})
+
+		It("does not match when the type is mismatched", func() {
+			condUpgradable := cond.DeepCopy()
+			condUpgradable.Type = "Upgradable"
+			Expect(cond).ToNot(MatchCondition(*condUpgradable))
+		})
+
+		It("does not match when the status is mismatched", func() {
+			condFalse := cond.DeepCopy()
+			condFalse.Status = metav1.ConditionFalse
+			Expect(cond).ToNot(MatchCondition(*condFalse))
+		})
+
+		It("does not match when the message is mismatched", func() {
+			condEmptyMessage := cond.DeepCopy()
+			condEmptyMessage.Message = ""
+			Expect(cond).ToNot(MatchCondition(*condEmptyMessage))
+		})
+
+		It("does not match when the reason is mismatched", func() {
+			condEmptyReason := cond.DeepCopy()
+			condEmptyReason.Reason = ""
+			Expect(cond).ToNot(MatchCondition(*condEmptyReason))
+		})
+
+		It("does not match with an invalid actual", func() {
+			ok, err := MatchCondition(cond).Match(configv1.ClusterOperatorStatusCondition{})
+			Expect(err).To(Equal(errActualTypeMismatchCondition))
+			Expect(ok).To(BeFalse())
+		})
+	})
+
+	Context("MatchClusterOperatorStatusConditions", func() {
 		var condAvailable, condUpgradable configv1.ClusterOperatorStatusCondition
 
 		BeforeEach(func() {
@@ -98,7 +223,7 @@ var _ = Describe("Conditions", func() {
 		})
 	})
 
-	Context("MatchCondition", func() {
+	Context("MatchClusterOperatorCondition", func() {
 		var cond configv1.ClusterOperatorStatusCondition
 
 		BeforeEach(func() {


### PR DESCRIPTION
As we are using metav1.Conditions in the ControlPlaneMachineSet itself, we also need conditions matchers for the metav1.Conditions. Posting this early to make the reviews easier on later PRs.