### PR TITLE
Add tests for ensuring owner references on Machines targeted by the ControlPlaneMachineSet

### DIFF
--- a/pkg/controllers/controlplanemachineset/consts.go
+++ b/pkg/controllers/controlplanemachineset/consts.go
@@ -65,6 +65,12 @@ const (
 	// and is not currently encountering any issues in operation.
 	reasonAsExpected = "AsExpected"
 
+	// reasonMachinesAlreadyOwned denotes that the ControlPlaneMachineSet has identified
+	// some Control Plane Machines that are already owned by a different controller.
+	// In this scenario, the operator must cease operations to prevent possible conflicts
+	// with the other controller.
+	reasonMachinesAlreadyOwned = "MachinesAlreadyOwned"
+
 	// reasonUnmanagedNodes denotes that the ControlPlaneMachineSet has identified some
 	// Control Plane Node that is not currently managed by a Control Plane Machine.
 	// In this scenario, to prevent potential for degrading the cluster into an unsupported

--- a/pkg/controllers/controlplanemachineset/suite_test.go
+++ b/pkg/controllers/controlplanemachineset/suite_test.go
@@ -27,11 +27,14 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	machinev1 "github.com/openshift/api/machine/v1"
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -43,6 +46,7 @@ var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
 var testScheme *runtime.Scheme
+var testRESTMapper meta.RESTMapper
 var ctx = context.Background()
 
 func TestAPIs(t *testing.T) {
@@ -79,6 +83,9 @@ var _ = BeforeSuite(func() {
 	k8sClient, err = client.New(cfg, client.Options{Scheme: testScheme})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
+
+	testRESTMapper, err = apiutil.NewDynamicRESTMapper(cfg)
+	Expect(err).NotTo(HaveOccurred())
 
 	komega.SetClient(k8sClient)
 	komega.SetContext(ctx)

--- a/pkg/test/resourcebuilder/machine_info.go
+++ b/pkg/test/resourcebuilder/machine_info.go
@@ -32,8 +32,9 @@ func MachineInfo() MachineInfoBuilder {
 
 // MachineInfoBuilder is used to build out a machineinfo object.
 type MachineInfoBuilder struct {
-	machineGVR  schema.GroupVersionResource
-	machineName string
+	machineGVR       schema.GroupVersionResource
+	machineName      string
+	machineOwnerRefs []metav1.OwnerReference
 
 	nodeGVR  schema.GroupVersionResource
 	nodeName string
@@ -57,7 +58,8 @@ func (m MachineInfoBuilder) Build() machineproviders.MachineInfo {
 		info.MachineRef = &machineproviders.ObjectRef{
 			GroupVersionResource: m.machineGVR,
 			ObjectMeta: metav1.ObjectMeta{
-				Name: m.machineName,
+				Name:            m.machineName,
+				OwnerReferences: m.machineOwnerRefs,
 			},
 		}
 	}
@@ -83,6 +85,18 @@ func (m MachineInfoBuilder) WithMachineGVR(gvr schema.GroupVersionResource) Mach
 // WithMachineName sets the machine name for the machineinfo builder.
 func (m MachineInfoBuilder) WithMachineName(name string) MachineInfoBuilder {
 	m.machineName = name
+	return m
+}
+
+// WithMachineOwnerReference adds an owner reference for the machine for the machineinfo builder.
+func (m MachineInfoBuilder) WithMachineOwnerReference(or metav1.OwnerReference) MachineInfoBuilder {
+	m.machineOwnerRefs = append(m.machineOwnerRefs, or)
+	return m
+}
+
+// WithMachineOwnerReferences replaces the owner references for the machine for the machineinfo builder.
+func (m MachineInfoBuilder) WithMachineOwnerReferences(ors []metav1.OwnerReference) MachineInfoBuilder {
+	m.machineOwnerRefs = ors
 	return m
 }
 


### PR DESCRIPTION
This is currently based on #19 and as such, only the last 2 commits need to be reviewed for this PR.

When we have gathered information about the Machines, one part of the operation of the operator is to ensure the owner references on the Machines.

Since this can be done generically (only interacting with ObjectMeta) this part of the logic is in the core of the ControlPlaneMachineSet reconciler and not a part of the Machine provider itself.

I have added tests to define the logic of the `ensureOwnerReferences` function but the remaining logic needs to be implemented still (until the tests pass)