### PR TITLE
Fix "build" target in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ verify-%: ## Ensure no diff after running some other target
 
 .PHONY: build
 build: generate fmt vet ## Build manager binary.
-	go build -o bin/manager cmd/control-plane-machine-set-operator
+	go build -o bin/manager ./cmd/control-plane-machine-set-operator
 
 define ensure-home
 	@ export HOME=$${HOME:=/tmp/kubebuilder-testing}; \


### PR DESCRIPTION
Now "make build" fails with error:

```txt
go build -o bin/manager cmd/control-plane-machine-set-operator
cannot find package "." in:
        /home/mfedosin/projects/cluster-control-plane-machine-set-operator/vendor/cmd/control-plane-machine-set-operator
make: *** [Makefile:85: build] Error 1
```

This PR fixes it, allowing to successfully build the binary.