### PR TITLE
[OCPCLOUD-1523] Ensure missing indexes are included when sorting MachineInfos within updates

### DIFF
--- a/pkg/machineproviders/types.go
+++ b/pkg/machineproviders/types.go
@@ -66,9 +66,6 @@ type ObjectRef struct {
 type MachineProvider interface {
 	// GetMachineInfos is used to collect information about the Control Plane Machines and Nodes that currently exist
 	// within the Cluster, as referred to by the ControlPlaneMachineSet.
-	// If there are any Machines missing (eg a failure domain is missing a Machine, or there are only 2 Machines when we
-	// expect 3), then a placeholder MachineInfo should be returned with enough information to create the Machine should
-	// that be required. It is up to the caller to decide how to handle the missing Machine.
 	GetMachineInfos() ([]MachineInfo, error)
 
 	// CreateMachine is used to instruct the Machine Provider to create a new Machine. The only input is the index for

--- a/pkg/test/resourcebuilder/control_plane_machine_set.go
+++ b/pkg/test/resourcebuilder/control_plane_machine_set.go
@@ -40,6 +40,7 @@ func ControlPlaneMachineSet() ControlPlaneMachineSetBuilder {
 				machineTypeLabelName: "master",
 			},
 		},
+		strategyType: machinev1.RollingUpdate,
 	}
 }
 
@@ -51,6 +52,7 @@ type ControlPlaneMachineSetBuilder struct {
 	namespace              string
 	replicas               int32
 	selector               metav1.LabelSelector
+	strategyType           machinev1.ControlPlaneMachineSetStrategyType
 }
 
 // Build builds a new controlplanemachineset based on the configuration provided.
@@ -64,6 +66,9 @@ func (m ControlPlaneMachineSetBuilder) Build() *machinev1.ControlPlaneMachineSet
 		Spec: machinev1.ControlPlaneMachineSetSpec{
 			Replicas: int32Ptr(m.replicas),
 			Selector: m.selector,
+			Strategy: machinev1.ControlPlaneMachineSetStrategy{
+				Type: m.strategyType,
+			},
 		},
 	}
 
@@ -107,5 +112,11 @@ func (m ControlPlaneMachineSetBuilder) WithReplicas(replicas int32) ControlPlane
 // WithSelector sets the selector for the controlplanemachineset builder.
 func (m ControlPlaneMachineSetBuilder) WithSelector(selector metav1.LabelSelector) ControlPlaneMachineSetBuilder {
 	m.selector = selector
+	return m
+}
+
+// WithStrategyType sets the update strategy type for the controlplanemachineset builder.
+func (m ControlPlaneMachineSetBuilder) WithStrategyType(strategy machinev1.ControlPlaneMachineSetStrategyType) ControlPlaneMachineSetBuilder {
+	m.strategyType = strategy
 	return m
 }


### PR DESCRIPTION
Originally, I had asserted that MachineProviders would ensure that the core of the ControlPlaneMachineSet knows about a missing index. This spreads the logic out rather awkwardly. It would be preferable to handle the missing machines directly within the update logic instead.