### PR TITLE
[OCPCLOUD-1525] Add AWS Failure Domain and Provider Config skeletons

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -97,6 +97,10 @@ linters-settings:
     dot-import-whitelist:
       - "github.com/onsi/gomega"
 issues:
+  exclude:
+    # Not all platforms are supported by this operator, those which aren't
+    # supported will be caught by the default case in the switches.
+    - "missing cases in switch of type v1.PlatformType: (\\.*)"
   exclude-use-default: false
   exclude-rules:
     # Exclude some linters from running on tests files.

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/failuredomain/failuredomain.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/failuredomain/failuredomain.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package failuredomain
+
+import (
+	"errors"
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+	machinev1 "github.com/openshift/api/machine/v1"
+)
+
+const (
+	// unknownFailureDomain is used as the string representation of a failure
+	// domain when the platform type is unrecognised.
+	unknownFailureDomain = "<unknown>"
+)
+
+var (
+	// errUnsupportedPlatformType is an error used when an unknown platform
+	// type is configured within the failure domain config.
+	errUnsupportedPlatformType = errors.New("unsupported platform type")
+)
+
+// FailureDomain is an interface that allows external code to interact with
+// failure domains across different platform types.
+type FailureDomain interface {
+	// String returns a string representation of the failure domain.
+	String() string
+
+	// Type returns the platform type of the failure domain.
+	Type() configv1.PlatformType
+
+	// AWS returns the AWSFailureDomain if the platform type is AWS.
+	AWS() machinev1.AWSFailureDomain
+}
+
+// failureDomain holds an implementation of the FailureDomain interface.
+type failureDomain struct {
+	platformType configv1.PlatformType
+
+	aws machinev1.AWSFailureDomain
+}
+
+// String returns a string representation of the failure domain.
+func (f failureDomain) String() string {
+	switch f.platformType {
+	case configv1.AWSPlatformType:
+		return awsFailureDomainToString(f.aws)
+	default:
+		return unknownFailureDomain
+	}
+}
+
+// Type returns the platform type of the failure domain.
+func (f failureDomain) Type() configv1.PlatformType {
+	return f.platformType
+}
+
+// AWS returns the AWSFailureDomain if the platform type is AWS.
+func (f failureDomain) AWS() machinev1.AWSFailureDomain {
+	return f.aws
+}
+
+// NewFailureDomains creates a set of FailureDomains representing the input failure
+// domains held within the ControlPlaneMachineSet.
+func NewFailureDomains(failureDomains machinev1.FailureDomains) ([]FailureDomain, error) {
+	switch failureDomains.Platform {
+	case configv1.AWSPlatformType:
+		return newAWSFailureDomains(failureDomains)
+	default:
+		return nil, fmt.Errorf("%w: %s", errUnsupportedPlatformType, failureDomains.Platform)
+	}
+}
+
+// newAWSFailureDomains constructs a list of AWSFailureDomains from the provided
+// failure domains configuration.
+func newAWSFailureDomains(failureDomains machinev1.FailureDomains) ([]FailureDomain, error) {
+	// TODO: replace this with actual logic to create failure domains from the failure domains.
+	// This is here as a dummy to keep the linter happy.
+	dummyFailureDomains := failureDomain{
+		platformType: failureDomains.Platform,
+	}
+
+	return []FailureDomain{dummyFailureDomains}, nil
+}
+
+// awsFailureDomainToString converts the AWSFailureDomain into a string.
+// Typically most failure domains are represented by their availability zone,
+// so we return the AWS AvailabilityZone if it is set.
+// Else return the Subnet which should be set if the AvailabilityZone is not.
+func awsFailureDomainToString(fd machinev1.AWSFailureDomain) string {
+	if fd.Placement.AvailabilityZone != "" {
+		return fd.Placement.AvailabilityZone
+	}
+
+	if fd.Subnet != nil {
+		switch fd.Subnet.Type {
+		case machinev1.AWSARNReferenceType:
+			if fd.Subnet.ARN != nil {
+				return *fd.Subnet.ARN
+			}
+		case machinev1.AWSFiltersReferenceType:
+			if fd.Subnet.Filters != nil {
+				return fmt.Sprintf("%+v", *fd.Subnet.Filters)
+			}
+		case machinev1.AWSIDReferenceType:
+			if fd.Subnet.ID != nil {
+				return *fd.Subnet.ID
+			}
+		}
+	}
+
+	// If the previous attempts to find a suitable string do not work,
+	// this should catch the fallthrough.
+	return unknownFailureDomain
+}

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/failuredomain/failuredomain_test.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/failuredomain/failuredomain_test.go
@@ -1,0 +1,164 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package failuredomain
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	configv1 "github.com/openshift/api/config/v1"
+	machinev1 "github.com/openshift/api/machine/v1"
+	"github.com/openshift/cluster-control-plane-machine-set-operator/pkg/test/resourcebuilder"
+)
+
+var _ = Describe("FailureDomains", func() {
+	Context("NewFailureDomains", func() {
+		Context("With AWS failure domain configuration", func() {
+			var failureDomains []FailureDomain
+			var err error
+
+			BeforeEach(func() {
+				config := resourcebuilder.AWSFailureDomains().BuildFailureDomains()
+
+				failureDomains, err = NewFailureDomains(config)
+			})
+
+			It("should not error", func() {
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			PIt("should construct a list of failure domains", func() {
+				Expect(failureDomains).To(ConsistOf(
+					HaveField(".String()", "us-east-1a"),
+					HaveField(".String()", "us-east-1b"),
+					HaveField(".String()", "us-east-1c"),
+				))
+			})
+		})
+
+		Context("With invalid AWS failure domain configuration", func() {
+			var failureDomains []FailureDomain
+			var err error
+
+			BeforeEach(func() {
+				config := resourcebuilder.AWSFailureDomains().BuildFailureDomains()
+				config.AWS = nil
+
+				failureDomains, err = NewFailureDomains(config)
+			})
+
+			PIt("returns an error", func() {
+				Expect(err).To(MatchError("missing configuration for AWS failure domains"))
+			})
+
+			PIt("returns an empty list of failure domains", func() {
+				Expect(failureDomains).To(BeEmpty())
+			})
+		})
+
+		Context("With an unsupported platform type", func() {
+			var failureDomains []FailureDomain
+			var err error
+
+			BeforeEach(func() {
+				config := machinev1.FailureDomains{
+					Platform: configv1.BareMetalPlatformType,
+				}
+
+				failureDomains, err = NewFailureDomains(config)
+			})
+
+			It("returns an error", func() {
+				Expect(err).To(MatchError("unsupported platform type: BareMetal"))
+			})
+
+			PIt("returns an empty list of failure domains", func() {
+				Expect(failureDomains).To(BeEmpty())
+			})
+		})
+	})
+
+	Context("an AWS failure domain", func() {
+		var fd failureDomain
+
+		BeforeEach(func() {
+			fd = failureDomain{
+				platformType: configv1.AWSPlatformType,
+			}
+		})
+
+		Context("with an availability zone", func() {
+			BeforeEach(func() {
+				fd.aws = resourcebuilder.AWSFailureDomain().WithAvailabilityZone("us-east-1a").Build()
+			})
+
+			It("returns the availability zone for String()", func() {
+				Expect(fd.String()).To(Equal("us-east-1a"))
+			})
+		})
+
+		Context("with no availability zone", func() {
+			Context("with an ARN type subnet", func() {
+				BeforeEach(func() {
+					subnetARN := "subnet-us-east-1a"
+
+					fd.aws = resourcebuilder.AWSFailureDomain().WithSubnet(machinev1.AWSResourceReference{
+						Type: machinev1.AWSARNReferenceType,
+						ARN:  &subnetARN,
+					}).Build()
+				})
+
+				It("returns the subnet for String()", func() {
+					Expect(fd.String()).To(Equal("subnet-us-east-1a"))
+				})
+			})
+
+			Context("with a filter type subnet", func() {
+				BeforeEach(func() {
+					fd.aws = resourcebuilder.AWSFailureDomain().WithSubnet(machinev1.AWSResourceReference{
+						Type: machinev1.AWSFiltersReferenceType,
+						Filters: &[]machinev1.AWSResourceFilter{
+							{
+								Name:   "tag:Name",
+								Values: []string{"subnet-us-east-1b"},
+							},
+						},
+					}).Build()
+				})
+
+				It("returns the subnet for String()", func() {
+					Expect(fd.String()).To(Equal("[{Name:tag:Name Values:[subnet-us-east-1b]}]"))
+				})
+			})
+
+			Context("with an ID type subnet", func() {
+				BeforeEach(func() {
+					subnetID := "subnet-us-east-1c"
+
+					fd.aws = resourcebuilder.AWSFailureDomain().WithSubnet(machinev1.AWSResourceReference{
+						Type: machinev1.AWSIDReferenceType,
+						ID:   &subnetID,
+					}).Build()
+				})
+
+				It("returns the subnet for String()", func() {
+					Expect(fd.String()).To(Equal("subnet-us-east-1c"))
+				})
+			})
+		})
+	})
+})

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/failuredomain/suite_test.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/failuredomain/suite_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package failuredomain
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	//+kubebuilder:scaffold:imports
+)
+
+func TestFailureDomain(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Failure Domain Suite")
+}

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/aws.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/aws.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package providerconfig
+
+import (
+	machinev1 "github.com/openshift/api/machine/v1"
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// AWSProviderConfig holds the provider spec of an AWS Machine.
+// It allows external code to extract and inject failure domain information,
+// as well as gathering the stored config.
+type AWSProviderConfig struct {
+	providerConfig machinev1beta1.AWSMachineProviderConfig
+}
+
+// InjectFailureDomain returns a new AWSProviderConfig configured with the failure domain
+// information provided.
+func (a AWSProviderConfig) InjectFailureDomain(fd machinev1.AWSFailureDomain) AWSProviderConfig {
+	return a
+}
+
+// ExtractFailureDomain returns an AWSFailureDomain based on the failure domain
+// information stored within the AWSProviderConfig.
+func (a AWSProviderConfig) ExtractFailureDomain() machinev1.AWSFailureDomain {
+	return machinev1.AWSFailureDomain{}
+}
+
+// Config returns the stored AWSMachineProviderConfig.
+func (a AWSProviderConfig) Config() machinev1beta1.AWSMachineProviderConfig {
+	return a.providerConfig
+}
+
+// newAWSProviderConfig creates an AWSProviderConfig from the raw extension.
+// It should return an error if the provided RawExtension does not represent
+// an AWSMachineProviderConfig.
+func newAWSProviderConfig(raw *runtime.RawExtension) (ProviderConfig, error) {
+	// TODO: replace this with actual logic to create the provider config from the raw extension.
+	// This is here as a dummy to keep the linter happy.
+	return providerConfig{}, nil
+}

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/aws_test.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/aws_test.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package providerconfig
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	configv1 "github.com/openshift/api/config/v1"
+	machinev1 "github.com/openshift/api/machine/v1"
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+	"github.com/openshift/cluster-control-plane-machine-set-operator/pkg/test/resourcebuilder"
+)
+
+var _ = Describe("AWS Provider Config", func() {
+	var providerConfig AWSProviderConfig
+
+	var azUSEast1a = "us-east-1a"
+	var machinev1SubnetUSEast1a = machinev1.AWSResourceReference{
+		Type: machinev1.AWSFiltersReferenceType,
+		Filters: &[]machinev1.AWSResourceFilter{
+			{
+				Name:   "tag:Name",
+				Values: []string{"subnet-us-east-1a"},
+			},
+		},
+	}
+	var machinev1beta1SubnetUSEast1a = machinev1beta1.AWSResourceReference{
+		Filters: []machinev1beta1.Filter{
+			{
+				Name:   "tag:Name",
+				Values: []string{"subnet-us-east-1a"},
+			},
+		},
+	}
+
+	var azUSEast1b = "us-east-1b"
+	var machinev1SubnetUSEast1b = machinev1.AWSResourceReference{
+		Type: machinev1.AWSFiltersReferenceType,
+		Filters: &[]machinev1.AWSResourceFilter{
+			{
+				Name:   "tag:Name",
+				Values: []string{"subnet-us-east-1b"},
+			},
+		},
+	}
+	var machinev1beta1SubnetUSEast1b = machinev1beta1.AWSResourceReference{
+		Filters: []machinev1beta1.Filter{
+			{
+				Name:   "tag:Name",
+				Values: []string{"subnet-us-east-1b"},
+			},
+		},
+	}
+
+	BeforeEach(func() {
+		machineProviderConfig := resourcebuilder.AWSProviderSpec().
+			WithAvailabilityZone(azUSEast1a).
+			WithSubnet(machinev1beta1SubnetUSEast1a).
+			Build()
+
+		providerConfig = AWSProviderConfig{
+			providerConfig: *machineProviderConfig,
+		}
+	})
+
+	Context("ExtractFailureDomain", func() {
+		PIt("returns the configured failure domain", func() {
+			expected := resourcebuilder.AWSFailureDomain().
+				WithAvailabilityZone(azUSEast1a).
+				WithSubnet(machinev1SubnetUSEast1a).
+				Build()
+
+			Expect(providerConfig.ExtractFailureDomain()).To(Equal(expected))
+		})
+	})
+
+	Context("when the failuredomain is changed after initialisation", func() {
+		var changedProviderConfig AWSProviderConfig
+
+		BeforeEach(func() {
+			changedFailureDomain := resourcebuilder.AWSFailureDomain().
+				WithAvailabilityZone(azUSEast1b).
+				WithSubnet(machinev1SubnetUSEast1b).
+				Build()
+
+			changedProviderConfig = providerConfig.InjectFailureDomain(changedFailureDomain)
+		})
+
+		PIt("stores the new subnet in the provider config", func() {
+			Expect(changedProviderConfig.Config().Subnet).To(Equal(machinev1beta1SubnetUSEast1b))
+		})
+
+		PIt("does not modify the original provider config", func() {
+			Expect(providerConfig.Config().Subnet).To(Equal(machinev1beta1SubnetUSEast1a))
+		})
+
+		Context("ExtractFailureDomain", func() {
+			PIt("returns the changed failure domain from the changed config", func() {
+				expected := resourcebuilder.AWSFailureDomain().
+					WithAvailabilityZone(azUSEast1b).
+					WithSubnet(machinev1SubnetUSEast1b).
+					Build()
+
+				Expect(changedProviderConfig.ExtractFailureDomain()).To(Equal(expected))
+			})
+
+			PIt("returns the original failure domain from the original config", func() {
+				expected := resourcebuilder.AWSFailureDomain().
+					WithAvailabilityZone(azUSEast1b).
+					WithSubnet(machinev1SubnetUSEast1b).
+					Build()
+
+				Expect(providerConfig.ExtractFailureDomain()).To(Equal(expected))
+			})
+		})
+	})
+
+	Context("newAWSProviderConfig", func() {
+		var providerConfig ProviderConfig
+		var expectedAWSConfig machinev1beta1.AWSMachineProviderConfig
+
+		BeforeEach(func() {
+			configBuilder := resourcebuilder.AWSProviderSpec()
+			expectedAWSConfig = *configBuilder.Build()
+			rawConfig := configBuilder.BuildRawExtension()
+
+			var err error
+			providerConfig, err = newAWSProviderConfig(rawConfig)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		PIt("sets the type to AWS", func() {
+			Expect(providerConfig.Type()).To(Equal(configv1.AWSPlatformType))
+		})
+
+		PIt("returns the correct AWS config", func() {
+			Expect(providerConfig.AWS()).ToNot(BeNil())
+			Expect(providerConfig.AWS().Config()).To(Equal(expectedAWSConfig))
+		})
+	})
+})

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/providerconfig.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/providerconfig.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package providerconfig
+
+import (
+	"errors"
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+	machinev1 "github.com/openshift/api/machine/v1"
+)
+
+var (
+	// errUnsupportedPlatformType is an error used when an unknown platform
+	// type is configured within the failure domain config.
+	errUnsupportedPlatformType = errors.New("unsupported platform type")
+)
+
+// ProviderConfig is an interface that allows external code to interact
+// with provider configuration across different platform types.
+type ProviderConfig interface {
+	// Type returns the platform type of the provider config.
+	Type() configv1.PlatformType
+
+	// AWS returns the AWSProviderConfig if the platform type is AWS.
+	AWS() AWSProviderConfig
+}
+
+// NewProviderConfig creates a new ProviderConfig from the provided machine template.
+func NewProviderConfig(tmpl machinev1.OpenShiftMachineV1Beta1MachineTemplate) (ProviderConfig, error) {
+	platformType, err := getPlatformType(tmpl)
+	if err != nil {
+		return nil, fmt.Errorf("could not determine platform type: %w", err)
+	}
+
+	switch platformType {
+	case configv1.AWSPlatformType:
+		return newAWSProviderConfig(tmpl.Spec.ProviderSpec.Value)
+	default:
+		return nil, fmt.Errorf("%w: %s", errUnsupportedPlatformType, platformType)
+	}
+}
+
+// providerConfig is an implementation of the ProviderConfig interface.
+type providerConfig struct {
+	platformType configv1.PlatformType
+	aws          AWSProviderConfig
+}
+
+// Type returns the platform type of the provider config.
+func (p providerConfig) Type() configv1.PlatformType {
+	return p.platformType
+}
+
+// AWS returns the AWSProviderConfig if the platform type is AWS.
+func (p providerConfig) AWS() AWSProviderConfig {
+	return p.aws
+}
+
+// getPlatformType extracts the platform type from the Machine template.
+// This can either be gathered from the platform type within the template failure domains,
+// or if that isn't present, by inspecting the providerSpec kind and inferring from there
+// what the configured platform type is.
+func getPlatformType(tmpl machinev1.OpenShiftMachineV1Beta1MachineTemplate) (configv1.PlatformType, error) {
+	return "", nil
+}

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/providerconfig_test.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/providerconfig_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package providerconfig
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+
+	configv1 "github.com/openshift/api/config/v1"
+	machinev1 "github.com/openshift/api/machine/v1"
+	"github.com/openshift/cluster-control-plane-machine-set-operator/pkg/test/resourcebuilder"
+)
+
+var _ = Describe("Provider Config", func() {
+	Context("NewProviderConfig", func() {
+		type providerConfigTableInput struct {
+			failureDomainsBuilder resourcebuilder.OpenShiftMachineV1Beta1FailureDomainsBuilder
+			modifyTemplate        func(tmpl *machinev1.ControlPlaneMachineSetTemplate)
+			providerSpecBuilder   resourcebuilder.RawExtensionBuilder
+			providerConfigMatcher types.GomegaMatcher
+			expectedPlatformType  configv1.PlatformType
+			expectedError         error
+		}
+
+		DescribeTable("should extract the config", func(in providerConfigTableInput) {
+			tmpl := resourcebuilder.OpenShiftMachineV1Beta1Template().
+				WithFailureDomainsBuilder(in.failureDomainsBuilder).
+				WithProviderSpecBuilder(in.providerSpecBuilder).
+				BuildTemplate()
+
+			if in.modifyTemplate != nil {
+				// Modify the template to allow injection of errors where the resource builder does not.
+				in.modifyTemplate(&tmpl)
+			}
+
+			providerConfig, err := NewProviderConfig(*tmpl.OpenShiftMachineV1Beta1Machine)
+			if in.expectedError != nil {
+				Expect(err).To(MatchError(in.expectedError))
+				return
+			}
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(providerConfig.Type()).To(Equal(in.expectedPlatformType))
+			Expect(providerConfig).To(in.providerConfigMatcher)
+		},
+			PEntry("with an invalid platform type", providerConfigTableInput{
+				modifyTemplate: func(in *machinev1.ControlPlaneMachineSetTemplate) {
+					// The platform type should be inferred from here first.
+					in.OpenShiftMachineV1Beta1Machine.FailureDomains.Platform = configv1.PlatformType("invalid")
+				},
+				expectedError: fmt.Errorf("%w: %s", errUnsupportedPlatformType, "invalid"),
+			}),
+			PEntry("with an AWS config with failure domains", providerConfigTableInput{
+				expectedPlatformType:  configv1.AWSPlatformType,
+				failureDomainsBuilder: resourcebuilder.AWSFailureDomains(),
+				providerSpecBuilder:   resourcebuilder.AWSProviderSpec(),
+				providerConfigMatcher: HaveField(".AWS().Config()", *resourcebuilder.AWSProviderSpec().Build()),
+			}),
+			PEntry("with an AWS config without failure domains", providerConfigTableInput{
+				expectedPlatformType:  configv1.AWSPlatformType,
+				failureDomainsBuilder: nil,
+				providerSpecBuilder:   resourcebuilder.AWSProviderSpec(),
+				providerConfigMatcher: HaveField(".AWS().Config()", *resourcebuilder.AWSProviderSpec().Build()),
+			}),
+		)
+	})
+})

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/suite_test.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/suite_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package providerconfig
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	//+kubebuilder:scaffold:imports
+)
+
+func TestProviderConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Provider Config Suite")
+}

--- a/pkg/test/resourcebuilder/aws_provider_spec.go
+++ b/pkg/test/resourcebuilder/aws_provider_spec.go
@@ -41,6 +41,16 @@ func AWSProviderSpec() AWSProviderSpecBuilder {
 				},
 			},
 		},
+		subnet: machinev1beta1.AWSResourceReference{
+			Filters: []machinev1beta1.Filter{
+				{
+					Name: "tag:Name",
+					Values: []string{
+						"aws-subnet-12345678",
+					},
+				},
+			},
+		},
 	}
 }
 
@@ -48,6 +58,7 @@ func AWSProviderSpec() AWSProviderSpecBuilder {
 type AWSProviderSpecBuilder struct {
 	availabilityZone string
 	securityGroups   []machinev1beta1.AWSResourceReference
+	subnet           machinev1beta1.AWSResourceReference
 }
 
 // Build builds a new AWS machine config based on the configuration provided.
@@ -91,6 +102,7 @@ func (m AWSProviderSpecBuilder) Build() *machinev1beta1.AWSMachineProviderConfig
 			AvailabilityZone: m.availabilityZone,
 		},
 		SecurityGroups: m.securityGroups,
+		Subnet:         m.subnet,
 		UserDataSecret: &corev1.LocalObjectReference{
 			Name: "aws-user-data-12345678",
 		},
@@ -121,5 +133,11 @@ func (m AWSProviderSpecBuilder) WithAvailabilityZone(az string) AWSProviderSpecB
 // WithSecurityGroups sets the securityGroups for the AWS machine config builder.
 func (m AWSProviderSpecBuilder) WithSecurityGroups(sgs []machinev1beta1.AWSResourceReference) AWSProviderSpecBuilder {
 	m.securityGroups = sgs
+	return m
+}
+
+// WithSubnet sets the subnet for the AWS machine config builder.
+func (m AWSProviderSpecBuilder) WithSubnet(subnet machinev1beta1.AWSResourceReference) AWSProviderSpecBuilder {
+	m.subnet = subnet
 	return m
 }


### PR DESCRIPTION
To enable the core of the openshift machine v1beta1 machine provider to interact with provider configs and failure domains in a generic way, we need to have an interface in front of these that allows a common interface to represent the faliure domains and provider configs of all platforms that we support failure domains on.

This sketches out a skeleton and tests of how this is expected to behave on AWS.