### PR TITLE
Add generated files configuration

### DIFF
--- a/.generated_files
+++ b/.generated_files
@@ -1,0 +1,19 @@
+# Files that should be ignored by tools which do not want to consider generated
+# code.
+#
+# https://github.com/kubernetes/test-infra/blob/master/prow/plugins/size/size.go
+#
+# This file is a series of lines, each of the form:
+#     <type> <name>
+#
+# Type can be:
+#    path - an exact path to a single file
+#    file-name - an exact leaf filename, regardless of path
+#    path-prefix - a prefix match on the file path
+#    file-prefix - a prefix match of the leaf filename (no path)
+#    paths-from-repo - read a file from the repo and load file paths
+#
+
+file-prefix	zz_generated
+
+path-prefix	vendor/


### PR DESCRIPTION
This will allow us to ignore generated files and vendor projects while using the prow size plugin, which should add labels to PRs to size them, hopefully helping reviewers to understand how much time they need to spend on a particular review