### PR TITLE
[OCPCLOUD-1498]  Implement supporting functions for reconcileMachineUpdates

### DIFF
--- a/pkg/controllers/controlplanemachineset/updates.go
+++ b/pkg/controllers/controlplanemachineset/updates.go
@@ -156,7 +156,9 @@ func (r *ControlPlaneMachineSetReconciler) reconcileMachineOnDeleteUpdate(ctx co
 func machineInfosByIndex(machineInfos []machineproviders.MachineInfo) map[int32][]machineproviders.MachineInfo {
 	out := make(map[int32][]machineproviders.MachineInfo)
 
-	// TODO: Convert the list of machineInfos into a map that maps the index to a list of MachineInfos.
+	for _, machineInfo := range machineInfos {
+		out[machineInfo.Index] = append(out[machineInfo.Index], machineInfo)
+	}
 
 	return out
 }

--- a/pkg/controllers/controlplanemachineset/updates.go
+++ b/pkg/controllers/controlplanemachineset/updates.go
@@ -24,6 +24,8 @@ import (
 	"github.com/go-logr/logr"
 	machinev1 "github.com/openshift/api/machine/v1"
 	"github.com/openshift/cluster-control-plane-machine-set-operator/pkg/machineproviders"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -93,10 +95,23 @@ func (r *ControlPlaneMachineSetReconciler) reconcileMachineUpdates(ctx context.C
 	case machinev1.OnDelete:
 		return r.reconcileMachineOnDeleteUpdate(ctx, logger, cpms, machineProvider, indexedMachineInfos)
 	case machinev1.Recreate:
-		// TODO: Set CPMS condition degraded
+		meta.SetStatusCondition(&cpms.Status.Conditions, metav1.Condition{
+			Type:    conditionDegraded,
+			Status:  metav1.ConditionTrue,
+			Reason:  reasonInvalidStrategy,
+			Message: fmt.Sprintf("%s: %s", invalidStrategyMessage, errRecreateStrategyNotSupported),
+		})
+
 		logger.Error(errRecreateStrategyNotSupported, invalidStrategyMessage)
 	default:
-		// TODO: Set CPMS condition degraded
+		meta.SetStatusCondition(&cpms.Status.Conditions,
+			metav1.Condition{
+				Type:    conditionDegraded,
+				Status:  metav1.ConditionTrue,
+				Reason:  reasonInvalidStrategy,
+				Message: fmt.Sprintf("%s: %s: %s", invalidStrategyMessage, errUnknownStrategy, cpms.Spec.Strategy.Type),
+			})
+
 		logger.Error(fmt.Errorf("%w: %s", errUnknownStrategy, cpms.Spec.Strategy.Type), invalidStrategyMessage)
 	}
 

--- a/pkg/controllers/controlplanemachineset/updates_test.go
+++ b/pkg/controllers/controlplanemachineset/updates_test.go
@@ -1181,7 +1181,7 @@ var _ = Describe("machineInfosByIndex", func() {
 			in:       []machineproviders.MachineInfo{},
 			expected: map[int32][]machineproviders.MachineInfo{},
 		}),
-		PEntry("separately indexed machines", tableInput{
+		Entry("separately indexed machines", tableInput{
 			in: []machineproviders.MachineInfo{i0m0, i1m0, i2m0},
 			expected: map[int32][]machineproviders.MachineInfo{
 				0: {i0m0},
@@ -1189,7 +1189,7 @@ var _ = Describe("machineInfosByIndex", func() {
 				2: {i2m0},
 			},
 		}),
-		PEntry("a mixture of indexed machines", tableInput{
+		Entry("a mixture of indexed machines", tableInput{
 			in: []machineproviders.MachineInfo{i0m0, i1m0, i2m0, i0m1, i1m1, i0m2},
 			expected: map[int32][]machineproviders.MachineInfo{
 				0: {i0m0, i0m1, i0m2},
@@ -1197,7 +1197,7 @@ var _ = Describe("machineInfosByIndex", func() {
 				2: {i2m0},
 			},
 		}),
-		PEntry("all machines in the same index", tableInput{
+		Entry("all machines in the same index", tableInput{
 			in: []machineproviders.MachineInfo{i0m0, i0m1, i0m2},
 			expected: map[int32][]machineproviders.MachineInfo{
 				0: {i0m0, i0m1, i0m2},

--- a/pkg/controllers/controlplanemachineset/updates_test.go
+++ b/pkg/controllers/controlplanemachineset/updates_test.go
@@ -1108,7 +1108,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 			}))
 		})
 
-		PIt("Sets the degraded condition", func() {
+		It("Sets the degraded condition", func() {
 			Expect(cpms.Status.Conditions).To(ConsistOf(test.MatchCondition(metav1.Condition{
 				Type:    conditionDegraded,
 				Status:  metav1.ConditionTrue,
@@ -1143,7 +1143,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 			}))
 		})
 
-		PIt("Sets the degraded condition", func() {
+		It("Sets the degraded condition", func() {
 			Expect(cpms.Status.Conditions).To(ConsistOf(test.MatchCondition(metav1.Condition{
 				Type:    conditionDegraded,
 				Status:  metav1.ConditionTrue,


### PR DESCRIPTION
This PR: 

1. Sets conditionDegraded condition on CPMS CRD when using Recreate or Invalid strategy.
2. Implements machineInfosByIndex function