### PR TITLE
Add context and logger to MachineProvider interface funcs

### DIFF
--- a/pkg/controllers/controlplanemachineset/controller.go
+++ b/pkg/controllers/controlplanemachineset/controller.go
@@ -159,7 +159,7 @@ func (r *ControlPlaneMachineSetReconciler) reconcile(ctx context.Context, logger
 		return ctrl.Result{}, fmt.Errorf("error constructing machine provider: %w", err)
 	}
 
-	machineInfos, err := machineProvider.GetMachineInfos()
+	machineInfos, err := machineProvider.GetMachineInfos(ctx, logger)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("error fetching machine info: %w", err)
 	}

--- a/pkg/controllers/controlplanemachineset/updates_test.go
+++ b/pkg/controllers/controlplanemachineset/updates_test.go
@@ -127,8 +127,8 @@ var _ = Describe("reconcileMachineUpdates", func() {
 					healthyMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("node-2").Build(),
 				},
 				setupMock: func() {
-					mockMachineProvider.EXPECT().CreateMachine(gomock.Any()).Times(0)
-					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().CreateMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 				},
 				expectedLogs: []test.LogEntry{
 					{
@@ -148,8 +148,8 @@ var _ = Describe("reconcileMachineUpdates", func() {
 					healthyMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("node-2").Build(),
 				},
 				setupMock: func() {
-					mockMachineProvider.EXPECT().CreateMachine(1).Return(nil).Times(1)
-					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().CreateMachine(gomock.Any(), gomock.Any(), 1).Return(nil).Times(1)
+					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 				},
 				expectedLogs: []test.LogEntry{
 					{
@@ -173,8 +173,8 @@ var _ = Describe("reconcileMachineUpdates", func() {
 					healthyMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("node-2").Build(),
 				},
 				setupMock: func() {
-					mockMachineProvider.EXPECT().CreateMachine(1).Return(transientError).Times(1)
-					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().CreateMachine(gomock.Any(), gomock.Any(), 1).Return(transientError).Times(1)
+					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 				},
 				expectedLogs: []test.LogEntry{
 					{
@@ -198,8 +198,8 @@ var _ = Describe("reconcileMachineUpdates", func() {
 					healthyMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("node-2").Build(),
 				},
 				setupMock: func() {
-					mockMachineProvider.EXPECT().CreateMachine(gomock.Any()).Times(0)
-					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().CreateMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 				},
 				expectedLogs: []test.LogEntry{
 					{
@@ -224,11 +224,11 @@ var _ = Describe("reconcileMachineUpdates", func() {
 					healthyMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("node-2").Build(),
 				},
 				setupMock: func() {
-					mockMachineProvider.EXPECT().CreateMachine(gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().CreateMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 
 					// We expect this particular machine to be called for deletion.
 					machineInfo := healthyMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").WithNeedsUpdate(true).Build()
-					mockMachineProvider.EXPECT().DeleteMachine(machineInfo.MachineRef).Return(nil).Times(1)
+					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any(), gomock.Any(), machineInfo.MachineRef).Return(nil).Times(1)
 				},
 				expectedLogs: []test.LogEntry{
 					{
@@ -253,11 +253,11 @@ var _ = Describe("reconcileMachineUpdates", func() {
 					healthyMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("node-2").Build(),
 				},
 				setupMock: func() {
-					mockMachineProvider.EXPECT().CreateMachine(gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().CreateMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 
 					// We expect this particular machine to be called for deletion.
 					machineInfo := healthyMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").WithNeedsUpdate(true).Build()
-					mockMachineProvider.EXPECT().DeleteMachine(machineInfo.MachineRef).Return(transientError).Times(1)
+					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any(), gomock.Any(), machineInfo.MachineRef).Return(transientError).Times(1)
 				},
 				expectedLogs: []test.LogEntry{
 					{
@@ -281,8 +281,8 @@ var _ = Describe("reconcileMachineUpdates", func() {
 					healthyMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("node-2").Build(),
 				},
 				setupMock: func() {
-					mockMachineProvider.EXPECT().CreateMachine(gomock.Any()).Times(0)
-					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().CreateMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 				},
 				expectedLogs: []test.LogEntry{
 					{
@@ -306,8 +306,8 @@ var _ = Describe("reconcileMachineUpdates", func() {
 				},
 				setupMock: func() {
 					// Note, in this case it should only create a single machine.
-					mockMachineProvider.EXPECT().CreateMachine(0).Return(nil).Times(1)
-					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().CreateMachine(gomock.Any(), gomock.Any(), 0).Return(nil).Times(1)
+					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 				},
 				expectedLogs: []test.LogEntry{
 					{
@@ -332,8 +332,8 @@ var _ = Describe("reconcileMachineUpdates", func() {
 				},
 				setupMock: func() {
 					// Note, in this case it should not create anything new because we are at surge capacity.
-					mockMachineProvider.EXPECT().CreateMachine(gomock.Any()).Times(0)
-					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().CreateMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 				},
 				expectedLogs: []test.LogEntry{
 					{
@@ -359,11 +359,11 @@ var _ = Describe("reconcileMachineUpdates", func() {
 				},
 				setupMock: func() {
 					// Note, in this case, it should wait for the old Machine to go away before starting a new update.
-					mockMachineProvider.EXPECT().CreateMachine(gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().CreateMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 
 					// We expect this particular machine to be called for deletion.
 					machineInfo := healthyMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").WithNeedsUpdate(true).Build()
-					mockMachineProvider.EXPECT().DeleteMachine(machineInfo.MachineRef).Return(nil).Times(1)
+					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any(), gomock.Any(), machineInfo.MachineRef).Return(nil).Times(1)
 				},
 
 				expectedLogs: []test.LogEntry{
@@ -388,8 +388,8 @@ var _ = Describe("reconcileMachineUpdates", func() {
 					healthyMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("node-2").Build(),
 				},
 				setupMock: func() {
-					mockMachineProvider.EXPECT().CreateMachine(gomock.Any()).Times(0)
-					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().CreateMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 				},
 				expectedLogs: []test.LogEntry{
 					{
@@ -411,8 +411,8 @@ var _ = Describe("reconcileMachineUpdates", func() {
 					healthyMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").Build(),
 				},
 				setupMock: func() {
-					mockMachineProvider.EXPECT().CreateMachine(2).Return(nil).Times(1)
-					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().CreateMachine(gomock.Any(), gomock.Any(), 2).Return(nil).Times(1)
+					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 				},
 				expectedLogs: []test.LogEntry{
 					{
@@ -435,8 +435,8 @@ var _ = Describe("reconcileMachineUpdates", func() {
 					pendingMachineBuilder.WithIndex(2).WithMachineName("machine-replacement-2").Build(),
 				},
 				setupMock: func() {
-					mockMachineProvider.EXPECT().CreateMachine(gomock.Any()).Times(0)
-					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().CreateMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 				},
 				expectedLogs: []test.LogEntry{
 					{
@@ -459,8 +459,8 @@ var _ = Describe("reconcileMachineUpdates", func() {
 				},
 				setupMock: func() {
 					// The missing index should take priority over the index in need of an update.
-					mockMachineProvider.EXPECT().CreateMachine(2).Return(nil).Times(1)
-					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().CreateMachine(gomock.Any(), gomock.Any(), 2).Return(nil).Times(1)
+					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 				},
 				expectedLogs: []test.LogEntry{
 					{
@@ -483,8 +483,8 @@ var _ = Describe("reconcileMachineUpdates", func() {
 					pendingMachineBuilder.WithIndex(2).WithMachineName("machine-replacement-2").Build(),
 				},
 				setupMock: func() {
-					mockMachineProvider.EXPECT().CreateMachine(gomock.Any()).Times(0)
-					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().CreateMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 				},
 				expectedLogs: []test.LogEntry{
 					{
@@ -541,8 +541,8 @@ var _ = Describe("reconcileMachineUpdates", func() {
 					healthyMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("node-2").Build(),
 				},
 				setupMock: func() {
-					mockMachineProvider.EXPECT().CreateMachine(gomock.Any()).Times(0)
-					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().CreateMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 				},
 				expectedLogs: []test.LogEntry{
 					{
@@ -562,8 +562,8 @@ var _ = Describe("reconcileMachineUpdates", func() {
 					healthyMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("node-2").Build(),
 				},
 				setupMock: func() {
-					mockMachineProvider.EXPECT().CreateMachine(gomock.Any()).Times(0)
-					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().CreateMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 				},
 				expectedLogs: []test.LogEntry{
 					{
@@ -586,8 +586,8 @@ var _ = Describe("reconcileMachineUpdates", func() {
 					healthyMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("node-2").Build(),
 				},
 				setupMock: func() {
-					mockMachineProvider.EXPECT().CreateMachine(1).Return(nil).Times(0)
-					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().CreateMachine(gomock.Any(), gomock.Any(), 1).Return(nil).Times(0)
+					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 				},
 				expectedLogs: []test.LogEntry{
 					{
@@ -610,8 +610,8 @@ var _ = Describe("reconcileMachineUpdates", func() {
 					healthyMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("node-2").Build(),
 				},
 				setupMock: func() {
-					mockMachineProvider.EXPECT().CreateMachine(1).Return(nil).Times(0)
-					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().CreateMachine(gomock.Any(), gomock.Any(), 1).Return(nil).Times(0)
+					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 				},
 				expectedLogs: []test.LogEntry{
 					{
@@ -635,8 +635,8 @@ var _ = Describe("reconcileMachineUpdates", func() {
 					healthyMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("node-2").Build(),
 				},
 				setupMock: func() {
-					mockMachineProvider.EXPECT().CreateMachine(0).Times(0)
-					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().CreateMachine(gomock.Any(), gomock.Any(), 0).Times(0)
+					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 				},
 				expectedLogs: []test.LogEntry{
 					{
@@ -661,8 +661,8 @@ var _ = Describe("reconcileMachineUpdates", func() {
 					healthyMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("node-2").Build(),
 				},
 				setupMock: func() {
-					mockMachineProvider.EXPECT().CreateMachine(0).Times(0)
-					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().CreateMachine(gomock.Any(), gomock.Any(), 0).Times(0)
+					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 				},
 				expectedLogs: []test.LogEntry{
 					{
@@ -685,8 +685,8 @@ var _ = Describe("reconcileMachineUpdates", func() {
 					healthyMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("node-2").Build(),
 				},
 				setupMock: func() {
-					mockMachineProvider.EXPECT().CreateMachine(gomock.Any()).Times(0)
-					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().CreateMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 				},
 				expectedLogs: []test.LogEntry{
 					{
@@ -719,8 +719,8 @@ var _ = Describe("reconcileMachineUpdates", func() {
 					healthyMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("node-2").Build(),
 				},
 				setupMock: func() {
-					mockMachineProvider.EXPECT().CreateMachine(1).Return(nil).Times(0)
-					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().CreateMachine(gomock.Any(), gomock.Any(), 1).Return(nil).Times(0)
+					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 				},
 				expectedLogs: []test.LogEntry{
 					{
@@ -753,8 +753,8 @@ var _ = Describe("reconcileMachineUpdates", func() {
 					healthyMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("node-2").Build(),
 				},
 				setupMock: func() {
-					mockMachineProvider.EXPECT().CreateMachine(1).Return(nil).Times(0)
-					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().CreateMachine(gomock.Any(), gomock.Any(), 1).Return(nil).Times(0)
+					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 				},
 				expectedLogs: []test.LogEntry{
 					{
@@ -787,9 +787,9 @@ var _ = Describe("reconcileMachineUpdates", func() {
 					healthyMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("node-2").Build(),
 				},
 				setupMock: func() {
-					mockMachineProvider.EXPECT().CreateMachine(0).Return(nil).Times(0)
-					mockMachineProvider.EXPECT().CreateMachine(1).Return(nil).Times(0)
-					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().CreateMachine(gomock.Any(), gomock.Any(), 0).Return(nil).Times(0)
+					mockMachineProvider.EXPECT().CreateMachine(gomock.Any(), gomock.Any(), 1).Return(nil).Times(0)
+					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 				},
 				expectedLogs: []test.LogEntry{
 					{
@@ -823,8 +823,8 @@ var _ = Describe("reconcileMachineUpdates", func() {
 					healthyMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("node-2").Build(),
 				},
 				setupMock: func() {
-					mockMachineProvider.EXPECT().CreateMachine(gomock.Any()).Times(0)
-					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().CreateMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 				},
 				expectedLogs: []test.LogEntry{
 					{
@@ -860,8 +860,8 @@ var _ = Describe("reconcileMachineUpdates", func() {
 					healthyMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("node-2").Build(),
 				},
 				setupMock: func() {
-					mockMachineProvider.EXPECT().CreateMachine(gomock.Any()).Times(0)
-					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().CreateMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 				},
 				expectedLogs: []test.LogEntry{
 					{
@@ -897,8 +897,8 @@ var _ = Describe("reconcileMachineUpdates", func() {
 					healthyMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("node-2").Build(),
 				},
 				setupMock: func() {
-					mockMachineProvider.EXPECT().CreateMachine(gomock.Any()).Times(0)
-					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().CreateMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 				},
 				expectedLogs: []test.LogEntry{
 					{
@@ -933,8 +933,8 @@ var _ = Describe("reconcileMachineUpdates", func() {
 					healthyMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("node-2").Build(),
 				},
 				setupMock: func() {
-					mockMachineProvider.EXPECT().CreateMachine(gomock.Any()).Times(0)
-					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().CreateMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 				},
 				expectedLogs: []test.LogEntry{
 					{
@@ -970,8 +970,8 @@ var _ = Describe("reconcileMachineUpdates", func() {
 					healthyMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("node-2").Build(),
 				},
 				setupMock: func() {
-					mockMachineProvider.EXPECT().CreateMachine(gomock.Any()).Times(0)
-					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().CreateMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 				},
 				expectedLogs: []test.LogEntry{
 					{
@@ -1003,8 +1003,8 @@ var _ = Describe("reconcileMachineUpdates", func() {
 					healthyMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").Build(),
 				},
 				setupMock: func() {
-					mockMachineProvider.EXPECT().CreateMachine(2).Return(nil).Times(1)
-					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().CreateMachine(gomock.Any(), gomock.Any(), 2).Return(nil).Times(1)
+					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 				},
 				expectedLogs: []test.LogEntry{
 					{
@@ -1027,8 +1027,8 @@ var _ = Describe("reconcileMachineUpdates", func() {
 					pendingMachineBuilder.WithIndex(2).WithMachineName("machine-replacement-2").Build(),
 				},
 				setupMock: func() {
-					mockMachineProvider.EXPECT().CreateMachine(gomock.Any()).Times(0)
-					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().CreateMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 				},
 				expectedLogs: []test.LogEntry{
 					{
@@ -1050,8 +1050,8 @@ var _ = Describe("reconcileMachineUpdates", func() {
 					healthyMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").WithNeedsUpdate(true).Build(),
 				},
 				setupMock: func() {
-					mockMachineProvider.EXPECT().CreateMachine(2).Return(nil).Times(1)
-					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().CreateMachine(gomock.Any(), gomock.Any(), 2).Return(nil).Times(1)
+					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 				},
 				expectedLogs: []test.LogEntry{
 					{
@@ -1084,8 +1084,8 @@ var _ = Describe("reconcileMachineUpdates", func() {
 					pendingMachineBuilder.WithIndex(2).WithMachineName("machine-replacement-2").Build(),
 				},
 				setupMock: func() {
-					mockMachineProvider.EXPECT().CreateMachine(gomock.Any()).Times(0)
-					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().CreateMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 				},
 				expectedLogs: []test.LogEntry{
 					{

--- a/pkg/machineproviders/mock/zz_generated_machine_provider_mock.go
+++ b/pkg/machineproviders/mock/zz_generated_machine_provider_mock.go
@@ -5,8 +5,10 @@
 package mock
 
 import (
+	context "context"
 	reflect "reflect"
 
+	logr "github.com/go-logr/logr"
 	gomock "github.com/golang/mock/gomock"
 	machineproviders "github.com/openshift/cluster-control-plane-machine-set-operator/pkg/machineproviders"
 )
@@ -35,44 +37,44 @@ func (m *MockMachineProvider) EXPECT() *MockMachineProviderMockRecorder {
 }
 
 // CreateMachine mocks base method.
-func (m *MockMachineProvider) CreateMachine(arg0 int32) error {
+func (m *MockMachineProvider) CreateMachine(arg0 context.Context, arg1 logr.Logger, arg2 int32) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateMachine", arg0)
+	ret := m.ctrl.Call(m, "CreateMachine", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreateMachine indicates an expected call of CreateMachine.
-func (mr *MockMachineProviderMockRecorder) CreateMachine(arg0 interface{}) *gomock.Call {
+func (mr *MockMachineProviderMockRecorder) CreateMachine(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateMachine", reflect.TypeOf((*MockMachineProvider)(nil).CreateMachine), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateMachine", reflect.TypeOf((*MockMachineProvider)(nil).CreateMachine), arg0, arg1, arg2)
 }
 
 // DeleteMachine mocks base method.
-func (m *MockMachineProvider) DeleteMachine(arg0 *machineproviders.ObjectRef) error {
+func (m *MockMachineProvider) DeleteMachine(arg0 context.Context, arg1 logr.Logger, arg2 *machineproviders.ObjectRef) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteMachine", arg0)
+	ret := m.ctrl.Call(m, "DeleteMachine", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteMachine indicates an expected call of DeleteMachine.
-func (mr *MockMachineProviderMockRecorder) DeleteMachine(arg0 interface{}) *gomock.Call {
+func (mr *MockMachineProviderMockRecorder) DeleteMachine(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMachine", reflect.TypeOf((*MockMachineProvider)(nil).DeleteMachine), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMachine", reflect.TypeOf((*MockMachineProvider)(nil).DeleteMachine), arg0, arg1, arg2)
 }
 
 // GetMachineInfos mocks base method.
-func (m *MockMachineProvider) GetMachineInfos() ([]machineproviders.MachineInfo, error) {
+func (m *MockMachineProvider) GetMachineInfos(arg0 context.Context, arg1 logr.Logger) ([]machineproviders.MachineInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMachineInfos")
+	ret := m.ctrl.Call(m, "GetMachineInfos", arg0, arg1)
 	ret0, _ := ret[0].([]machineproviders.MachineInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetMachineInfos indicates an expected call of GetMachineInfos.
-func (mr *MockMachineProviderMockRecorder) GetMachineInfos() *gomock.Call {
+func (mr *MockMachineProviderMockRecorder) GetMachineInfos(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMachineInfos", reflect.TypeOf((*MockMachineProvider)(nil).GetMachineInfos))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMachineInfos", reflect.TypeOf((*MockMachineProvider)(nil).GetMachineInfos), arg0, arg1)
 }

--- a/pkg/machineproviders/types.go
+++ b/pkg/machineproviders/types.go
@@ -17,6 +17,9 @@ limitations under the License.
 package machineproviders
 
 import (
+	"context"
+
+	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -66,15 +69,15 @@ type ObjectRef struct {
 type MachineProvider interface {
 	// GetMachineInfos is used to collect information about the Control Plane Machines and Nodes that currently exist
 	// within the Cluster, as referred to by the ControlPlaneMachineSet.
-	GetMachineInfos() ([]MachineInfo, error)
+	GetMachineInfos(context.Context, logr.Logger) ([]MachineInfo, error)
 
 	// CreateMachine is used to instruct the Machine Provider to create a new Machine. The only input is the index for
 	// the new Machine. During construction of the MachineProvider, it should map indexes to failure domains so that it
 	// has all the required information for creating a new Machine stored, based solely on the index.
-	CreateMachine(int32) error
+	CreateMachine(context.Context, logr.Logger, int32) error
 
 	// DeleteMachine is used to instruct the Machine Provider to delete a paritcular Machine. This is used by the
 	// RollingUpdate strategy of the ControlPlaneMachineSet so that it can remove old Machines once they have been
 	// replaced.
-	DeleteMachine(*ObjectRef) error
+	DeleteMachine(context.Context, logr.Logger, *ObjectRef) error
 }


### PR DESCRIPTION
This means that the context and logger can be passed in for each call to the various MachineProvider functions. Meaning the caller can customise the context and logger rather than having it pinned to the originals passed in when the MachineProvider is constructed.

This is a better pattern as we shouldn't be storing objects like contexts and loggers which have additional context added to them through different callers