### PR TITLE
[OCPCLOUD-1543] Failure domain mapping

### DIFF
--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/failuredomain/failuredomain.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/failuredomain/failuredomain.go
@@ -82,6 +82,9 @@ func NewFailureDomains(failureDomains machinev1.FailureDomains) ([]FailureDomain
 	switch failureDomains.Platform {
 	case configv1.AWSPlatformType:
 		return newAWSFailureDomains(failureDomains)
+	case configv1.PlatformType(""):
+		// An empty failure domains definition is allowed.
+		return nil, nil
 	default:
 		return nil, fmt.Errorf("%w: %s", errUnsupportedPlatformType, failureDomains.Platform)
 	}

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/failuredomain/failuredomain.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/failuredomain/failuredomain.go
@@ -102,6 +102,16 @@ func newAWSFailureDomains(failureDomains machinev1.FailureDomains) ([]FailureDom
 	return []FailureDomain{dummyFailureDomains}, nil
 }
 
+// NewAWSFailureDomain creates an AWS failure domain from the machinev1.AWSFailureDomain.
+// Note this is exported to allow other packages to construct individual failure domains
+// in tests.
+func NewAWSFailureDomain(fd machinev1.AWSFailureDomain) FailureDomain {
+	return &failureDomain{
+		platformType: configv1.AWSPlatformType,
+		aws:          fd,
+	}
+}
+
 // awsFailureDomainToString converts the AWSFailureDomain into a string.
 // Typically most failure domains are represented by their availability zone,
 // so we return the AWS AvailabilityZone if it is set.

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/failuredomain/failuredomain_test.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/failuredomain/failuredomain_test.go
@@ -27,6 +27,23 @@ import (
 
 var _ = Describe("FailureDomains", func() {
 	Context("NewFailureDomains", func() {
+		Context("with no failure domains configuration", func() {
+			var failureDomains []FailureDomain
+			var err error
+
+			BeforeEach(func() {
+				failureDomains, err = NewFailureDomains(machinev1.FailureDomains{})
+			})
+
+			It("should not error", func() {
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should return a nil list", func() {
+				Expect(failureDomains).To(BeNil())
+			})
+		})
+
 		Context("With AWS failure domain configuration", func() {
 			var failureDomains []FailureDomain
 			var err error

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/mapping.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/mapping.go
@@ -19,6 +19,7 @@ package v1beta1
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/go-logr/logr"
 	machinev1 "github.com/openshift/api/machine/v1"
@@ -29,6 +30,10 @@ import (
 )
 
 var (
+	// errReplicasRequired is used to inform users that the replicas field is currently unset, and
+	// must be set to continue operation.
+	errReplicasRequired = errors.New("spec.replicas is unset: replicas is required")
+
 	// errNoFailureDomains is used to indicate that no failure domain mapping is required in the
 	// provider because no failure domains are configured on the ControlPlaneMachineSet.
 	errNoFailureDomains = errors.New("no failure domains configured")
@@ -39,7 +44,61 @@ var (
 // then use existing Machine information to map failure domains, if possible, so that the Machine names match the
 // index of the failure domain in which they currently reside.
 func mapMachineIndexesToFailureDomains(ctx context.Context, logger logr.Logger, cl client.Client, cpms *machinev1.ControlPlaneMachineSet, failureDomains []failuredomain.FailureDomain) (map[int32]failuredomain.FailureDomain, error) {
+	if len(failureDomains) == 0 {
+		return nil, errNoFailureDomains
+	}
+
+	baseMapping, err := createBaseFailureDomainMapping(cpms, failureDomains)
+	if err != nil {
+		return nil, fmt.Errorf("could not construct base failure domain mapping: %w", err)
+	}
+
+	machineMapping, err := createMachineMapping(ctx, logger, cl, cpms)
+	if err != nil {
+		return nil, fmt.Errorf("could not construct machine mapping: %w", err)
+	}
+
+	outputMapping := reconcileMappings(logger, baseMapping, machineMapping)
+
+	return outputMapping, nil
+}
+
+// createBaseFailureDomainMapping is used to create the basic failure domain mapping based on the number of failure
+// domains provided and the number of replicas within the ControlPlaneMachineSet.
+// To ensure consistency, we expect the function to create a stable output no matter the order of the input failure
+// domains.
+func createBaseFailureDomainMapping(cpms *machinev1.ControlPlaneMachineSet, failureDomains []failuredomain.FailureDomain) (map[int32]failuredomain.FailureDomain, error) {
 	out := make(map[int32]failuredomain.FailureDomain)
 
+	// TODO: Check replicas is set, then sort the failure domains alphabetically, and use modulo arithmetic to set up the
+	// output map.
+
 	return out, nil
+}
+
+// createMachineMapping inspects the state of the Machines on the cluster, selected by the ControlPlaneMachineSet, and
+// creates a mapping of their indexes (if available) to their failure domain to allow the mapping to be customised
+// to the state of the cluster.
+func createMachineMapping(ctx context.Context, logger logr.Logger, cl client.Client, cpms *machinev1.ControlPlaneMachineSet) (map[int32]failuredomain.FailureDomain, error) {
+	out := make(map[int32]failuredomain.FailureDomain)
+
+	// TODO: Use the CPMS selector to fetch Machines from the API. Extract the providerconfig from these to then get the
+	// failure domain information out of the Machine. Inspect the Machine name, if it ends with an integer, take that as
+	// its index and set the failure domain in the output map. Newest machines should take precedence when inferring the
+	// failure domain if multiple machines match an index.
+	// If the Machine name does not end in an integer (or it is out of bounds of the replicas expected), then ignore the
+	// Machine.
+	// To test "Newest machines should take precedence", the logic after fetching the machines should be in a helper
+	// function that can be unit tested separately.
+
+	return out, nil
+}
+
+// reconcileMappings takes a base mapping and a machines mapping and reconciles the differences. If any machine failure
+// domain has an identical failure domain in the base mapping, the mapping from the Machine should take precedence.
+// When overwriting a mapping, the mapping in place must be swapped to avoid losing information.
+func reconcileMappings(logger logr.Logger, base, machines map[int32]failuredomain.FailureDomain) map[int32]failuredomain.FailureDomain {
+	out := make(map[int32]failuredomain.FailureDomain)
+
+	return out
 }

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/mapping_test.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/mapping_test.go
@@ -1,0 +1,1013 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	machinev1 "github.com/openshift/api/machine/v1"
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+	"github.com/openshift/cluster-control-plane-machine-set-operator/pkg/machineproviders/providers/openshift/machine/v1beta1/failuredomain"
+	"github.com/openshift/cluster-control-plane-machine-set-operator/pkg/test"
+	"github.com/openshift/cluster-control-plane-machine-set-operator/pkg/test/resourcebuilder"
+)
+
+var _ = Describe("Failure Domain Mapping", func() {
+	var namespaceName string
+
+	cpmsBuilder := resourcebuilder.ControlPlaneMachineSet().WithReplicas(3)
+	machineBuilder := resourcebuilder.Machine().AsMaster()
+
+	usEast1aProviderSpecBuilder := resourcebuilder.AWSProviderSpec().
+		WithAvailabilityZone("us-east-1a").
+		WithSecurityGroups([]machinev1beta1.AWSResourceReference{
+			{
+				Filters: []machinev1beta1.Filter{
+					{
+						Name:   "tag:Name",
+						Values: []string{"subnet-us-east-1a"},
+					},
+				},
+			},
+		})
+
+	usEast1bProviderSpecBuilder := resourcebuilder.AWSProviderSpec().
+		WithAvailabilityZone("us-east-1b").
+		WithSecurityGroups([]machinev1beta1.AWSResourceReference{
+			{
+				Filters: []machinev1beta1.Filter{
+					{
+						Name:   "tag:Name",
+						Values: []string{"subnet-us-east-1b"},
+					},
+				},
+			},
+		})
+
+	usEast1cProviderSpecBuilder := resourcebuilder.AWSProviderSpec().
+		WithAvailabilityZone("us-east-1c").
+		WithSecurityGroups([]machinev1beta1.AWSResourceReference{
+			{
+				Filters: []machinev1beta1.Filter{
+					{
+						Name:   "tag:Name",
+						Values: []string{"subnet-us-east-1c"},
+					},
+				},
+			},
+		})
+
+	usEast1aFailureDomainBuilder := resourcebuilder.AWSFailureDomain().
+		WithAvailabilityZone("us-east-1a").
+		WithSubnet(machinev1.AWSResourceReference{
+			Type: machinev1.AWSFiltersReferenceType,
+			Filters: &[]machinev1.AWSResourceFilter{
+				{
+					Name:   "tag:Name",
+					Values: []string{"subnet-us-east-1a"},
+				},
+			},
+		})
+
+	usEast1bFailureDomainBuilder := resourcebuilder.AWSFailureDomain().
+		WithAvailabilityZone("us-east-1b").
+		WithSubnet(machinev1.AWSResourceReference{
+			Type: machinev1.AWSFiltersReferenceType,
+			Filters: &[]machinev1.AWSResourceFilter{
+				{
+					Name:   "tag:Name",
+					Values: []string{"subnet-us-east-1b"},
+				},
+			},
+		})
+
+	usEast1cFailureDomainBuilder := resourcebuilder.AWSFailureDomain().
+		WithAvailabilityZone("us-east-1c").
+		WithSubnet(machinev1.AWSResourceReference{
+			Type: machinev1.AWSFiltersReferenceType,
+			Filters: &[]machinev1.AWSResourceFilter{
+				{
+					Name:   "tag:Name",
+					Values: []string{"subnet-us-east-1c"},
+				},
+			},
+		})
+
+	BeforeEach(func() {
+		By("Setting up a namespace for the test")
+		ns := resourcebuilder.Namespace().WithGenerateName("control-plane-machine-set-controller-").Build()
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+		namespaceName = ns.GetName()
+	})
+
+	AfterEach(func() {
+		test.CleanupResources(Default, ctx, cfg, k8sClient, namespaceName,
+			&machinev1beta1.Machine{},
+		)
+	})
+
+	Context("mappingMachineIndexesToFailureDomains", func() {
+		type mappingMachineIndexesTableInput struct {
+			cpms            *machinev1.ControlPlaneMachineSet
+			failureDomains  machinev1.FailureDomains
+			machines        []*machinev1beta1.Machine
+			expectedError   error
+			expectedMapping map[int32]failuredomain.FailureDomain
+			expectedLogs    []test.LogEntry
+		}
+
+		DescribeTable("should map failure domains to indexes", func(in mappingMachineIndexesTableInput) {
+			failureDomains, err := failuredomain.NewFailureDomains(in.failureDomains)
+			Expect(err).ToNot(HaveOccurred())
+
+			logger := test.NewTestLogger()
+
+			// Make sure all resources use the right namespace.
+			in.cpms.SetNamespace(namespaceName)
+
+			for _, machine := range in.machines {
+				machine.SetNamespace(namespaceName)
+				Expect(k8sClient.Create(ctx, machine)).To(Succeed())
+			}
+
+			originalCPMS := in.cpms.DeepCopy()
+
+			mapping, err := mapMachineIndexesToFailureDomains(ctx, logger.Logger(), k8sClient, in.cpms, failureDomains)
+			if in.expectedError != nil {
+				Expect(err).To(MatchError(in.expectedError))
+			} else {
+				Expect(err).ToNot(HaveOccurred())
+			}
+
+			Expect(mapping).To(Equal(in.expectedMapping))
+			Expect(logger.Entries()).To(ConsistOf(in.expectedLogs))
+			Expect(in.cpms).To(Equal(originalCPMS), "The update functions should not modify the ControlPlaneMachineSet in any way")
+		},
+			PEntry("with no failure domains defined, returns an empty mapping", mappingMachineIndexesTableInput{
+				cpms:           cpmsBuilder.Build(),
+				failureDomains: machinev1.FailureDomains{},
+				machines: []*machinev1beta1.Machine{
+					machineBuilder.WithName("machine-0").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-1").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-2").WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build(),
+				},
+				expectedError:   errNoFailureDomains,
+				expectedMapping: map[int32]failuredomain.FailureDomain{},
+				expectedLogs: []test.LogEntry{
+					{
+						Level:   4,
+						Message: "No failure domains provided",
+					},
+				},
+			}),
+			PEntry("with three failure domains matching three machines in order (a,b,c)", mappingMachineIndexesTableInput{
+				cpms: cpmsBuilder.Build(),
+				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
+					usEast1aFailureDomainBuilder,
+					usEast1bFailureDomainBuilder,
+					usEast1cFailureDomainBuilder,
+				).BuildFailureDomains(),
+				machines: []*machinev1beta1.Machine{
+					machineBuilder.WithName("machine-0").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-1").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-2").WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build(),
+				},
+				expectedMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+				},
+				expectedLogs: []test.LogEntry{
+					{
+						Level: 4,
+						KeysAndValues: []interface{}{
+							"mapping", map[int32]failuredomain.FailureDomain{
+								0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+								1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+								2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+							},
+						},
+						Message: "Mapped provided failure domains",
+					},
+				},
+			}),
+			PEntry("with three failure domains matching three machines in a order (b,c,a)", mappingMachineIndexesTableInput{
+				cpms: cpmsBuilder.Build(),
+				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
+					usEast1aFailureDomainBuilder,
+					usEast1bFailureDomainBuilder,
+					usEast1cFailureDomainBuilder,
+				).BuildFailureDomains(),
+				machines: []*machinev1beta1.Machine{
+					machineBuilder.WithName("machine-0").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-1").WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-2").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build(),
+				},
+				expectedMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					1: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+				},
+				expectedLogs: []test.LogEntry{
+					{
+						Level: 4,
+						KeysAndValues: []interface{}{
+							"mapping", map[int32]failuredomain.FailureDomain{
+								0: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+								1: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+								2: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+							},
+						},
+						Message: "Mapped provided failure domains",
+					},
+				},
+			}),
+			PEntry("with three failure domains matching three machines in a order (b,a,c)", mappingMachineIndexesTableInput{
+				cpms: cpmsBuilder.Build(),
+				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
+					usEast1aFailureDomainBuilder,
+					usEast1bFailureDomainBuilder,
+					usEast1cFailureDomainBuilder,
+				).BuildFailureDomains(),
+				machines: []*machinev1beta1.Machine{
+					machineBuilder.WithName("machine-0").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-1").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-2").WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build(),
+				},
+				expectedMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					1: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+				},
+				expectedLogs: []test.LogEntry{
+					{
+						Level: 4,
+						KeysAndValues: []interface{}{
+							"mapping", map[int32]failuredomain.FailureDomain{
+								0: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+								1: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+								2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+							},
+						},
+						Message: "Mapped provided failure domains",
+					},
+				},
+			}),
+			PEntry("with three failure domains matching five machines in order (a,b,c,a,b)", mappingMachineIndexesTableInput{
+				cpms: cpmsBuilder.WithReplicas(5).Build(),
+				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
+					usEast1aFailureDomainBuilder,
+					usEast1bFailureDomainBuilder,
+					usEast1cFailureDomainBuilder,
+				).BuildFailureDomains(),
+				machines: []*machinev1beta1.Machine{
+					machineBuilder.WithName("machine-0").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-1").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-2").WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-3").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-4").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build(),
+				},
+				expectedMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+					3: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					4: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+				},
+				expectedLogs: []test.LogEntry{
+					{
+						Level: 4,
+						KeysAndValues: []interface{}{
+							"mapping", map[int32]failuredomain.FailureDomain{
+								0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+								1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+								2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+								3: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+								4: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+							},
+						},
+						Message: "Mapped provided failure domains",
+					},
+				},
+			}),
+			PEntry("with three failure domains matching five machines in order (b,c,a,c,b)", mappingMachineIndexesTableInput{
+				cpms: cpmsBuilder.WithReplicas(5).Build(),
+				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
+					usEast1aFailureDomainBuilder,
+					usEast1bFailureDomainBuilder,
+					usEast1cFailureDomainBuilder,
+				).BuildFailureDomains(),
+				machines: []*machinev1beta1.Machine{
+					machineBuilder.WithName("machine-0").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-1").WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-2").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-3").WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-4").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build(),
+				},
+				expectedMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					1: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					3: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+					4: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+				},
+				expectedLogs: []test.LogEntry{
+					{
+						Level: 4,
+						KeysAndValues: []interface{}{
+							"mapping", map[int32]failuredomain.FailureDomain{
+								0: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+								1: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+								2: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+								3: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+								4: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+							},
+						},
+						Message: "Mapped provided failure domains",
+					},
+				},
+			}),
+			PEntry("with three failure domains matching five machines in order (b,a,c,c,a)", mappingMachineIndexesTableInput{
+				cpms: cpmsBuilder.WithReplicas(5).Build(),
+				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
+					usEast1aFailureDomainBuilder,
+					usEast1bFailureDomainBuilder,
+					usEast1cFailureDomainBuilder,
+				).BuildFailureDomains(),
+				machines: []*machinev1beta1.Machine{
+					machineBuilder.WithName("machine-0").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-1").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-2").WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-3").WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-4").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build(),
+				},
+				expectedMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					1: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+					3: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+					4: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+				},
+				expectedLogs: []test.LogEntry{
+					{
+						Level: 4,
+						KeysAndValues: []interface{}{
+							"mapping", map[int32]failuredomain.FailureDomain{
+								0: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+								1: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+								2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+								3: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+								4: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+							},
+						},
+						Message: "Mapped provided failure domains",
+					},
+				},
+			}),
+			PEntry("with a machine in an unrecognised failure domain (failure domains ordered a,b)", mappingMachineIndexesTableInput{
+				cpms: cpmsBuilder.Build(),
+				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
+					usEast1aFailureDomainBuilder,
+					usEast1bFailureDomainBuilder,
+				).BuildFailureDomains(),
+				machines: []*machinev1beta1.Machine{
+					machineBuilder.WithName("machine-0").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-1").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-2").WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build(),
+				},
+				expectedMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()), // The extra failure domain must be the first alphabetically in this case.
+				},
+				expectedLogs: []test.LogEntry{
+					{
+						Level: 4,
+						KeysAndValues: []interface{}{
+							"mapping", map[int32]failuredomain.FailureDomain{
+								0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+								1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+								2: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+							},
+						},
+						Message: "Mapped provided failure domains",
+					},
+				},
+			}),
+			PEntry("with a machine in an unrecognised failure domain (failure domains ordered b,a)", mappingMachineIndexesTableInput{
+				cpms: cpmsBuilder.Build(),
+				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
+					usEast1bFailureDomainBuilder,
+					usEast1aFailureDomainBuilder,
+				).BuildFailureDomains(),
+				machines: []*machinev1beta1.Machine{
+					machineBuilder.WithName("machine-0").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-1").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-2").WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build(),
+				},
+				expectedMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()), // The extra failure domain must be the first alphabetically in this case.
+				},
+				expectedLogs: []test.LogEntry{
+					{
+						Level: 4,
+						KeysAndValues: []interface{}{
+							"mapping", map[int32]failuredomain.FailureDomain{
+								0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+								1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+								2: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+							},
+						},
+						Message: "Mapped provided failure domains",
+					},
+				},
+			}),
+			PEntry("with multiple machines in unrecognised failure domains ", mappingMachineIndexesTableInput{
+				cpms: cpmsBuilder.Build(),
+				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
+					usEast1aFailureDomainBuilder,
+				).BuildFailureDomains(),
+				machines: []*machinev1beta1.Machine{
+					machineBuilder.WithName("machine-0").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-1").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-2").WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build(),
+				},
+				expectedMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					1: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+				},
+				expectedLogs: []test.LogEntry{
+					{
+						Level: 4,
+						KeysAndValues: []interface{}{
+							"mapping", map[int32]failuredomain.FailureDomain{
+								0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+								1: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+								2: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+							},
+						},
+						Message: "Mapped provided failure domains",
+					},
+				},
+			}),
+			PEntry("with multiple machines in the same failure domain", mappingMachineIndexesTableInput{
+				cpms: cpmsBuilder.Build(),
+				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
+					usEast1aFailureDomainBuilder,
+					usEast1bFailureDomainBuilder,
+					usEast1cFailureDomainBuilder,
+				).BuildFailureDomains(),
+				machines: []*machinev1beta1.Machine{
+					machineBuilder.WithName("machine-0").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-1").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-2").WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build(),
+				},
+				expectedMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					1: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()), // The missing failure domain fills in for the last Machine alphabetically.
+					2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+				},
+				expectedLogs: []test.LogEntry{
+					{
+						Level: 4,
+						KeysAndValues: []interface{}{
+							"mapping", map[int32]failuredomain.FailureDomain{
+								0: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+								1: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+								2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+							},
+						},
+						Message: "Mapped provided failure domains",
+					},
+				},
+			}),
+			PEntry("with a machine name does not indicate its index (a,b,c)", mappingMachineIndexesTableInput{
+				cpms: cpmsBuilder.Build(),
+				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
+					usEast1aFailureDomainBuilder,
+					usEast1bFailureDomainBuilder,
+					usEast1cFailureDomainBuilder,
+				).BuildFailureDomains(),
+				machines: []*machinev1beta1.Machine{
+					machineBuilder.WithName("machine-a").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-1").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-2").WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build(),
+				},
+				expectedMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+				},
+				expectedLogs: []test.LogEntry{
+					{
+						Level: 4,
+						KeysAndValues: []interface{}{
+							"mapping", map[int32]failuredomain.FailureDomain{
+								0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+								1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+								2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+							},
+						},
+						Message: "Mapped provided failure domains",
+					},
+				},
+			}),
+			PEntry("with a machine name does not indicate its index (b,c,a)", mappingMachineIndexesTableInput{
+				cpms: cpmsBuilder.Build(),
+				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
+					usEast1aFailureDomainBuilder,
+					usEast1bFailureDomainBuilder,
+					usEast1cFailureDomainBuilder,
+				).BuildFailureDomains(),
+				machines: []*machinev1beta1.Machine{
+					machineBuilder.WithName("machine-a").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-1").WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-2").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build(),
+				},
+				expectedMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					1: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+				},
+				expectedLogs: []test.LogEntry{
+					{
+						Level: 4,
+						KeysAndValues: []interface{}{
+							"mapping", map[int32]failuredomain.FailureDomain{
+								0: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+								1: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+								2: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+							},
+						},
+						Message: "Mapped provided failure domains",
+					},
+				},
+			}),
+		)
+	})
+
+	Context("createBaseFailureDomainMapping", func() {
+		type createBaseMappingTableInput struct {
+			cpms            *machinev1.ControlPlaneMachineSet
+			failureDomains  machinev1.FailureDomains
+			expectedMapping map[int32]failuredomain.FailureDomain
+			expectedError   error
+		}
+
+		DescribeTable("should map the failure domains based on the replicas", func(in createBaseMappingTableInput) {
+			failureDomains, err := failuredomain.NewFailureDomains(in.failureDomains)
+			Expect(err).ToNot(HaveOccurred())
+
+			mapping, err := createBaseFailureDomainMapping(in.cpms, failureDomains)
+			if in.expectedError != nil {
+				Expect(err).To(MatchError(in.expectedError))
+			} else {
+				Expect(err).ToNot(HaveOccurred())
+			}
+
+			Expect(mapping).To(Equal(in.expectedMapping))
+		},
+			PEntry("with no replicas set", createBaseMappingTableInput{
+				cpms: &machinev1.ControlPlaneMachineSet{},
+				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
+					usEast1aFailureDomainBuilder,
+					usEast1bFailureDomainBuilder,
+					usEast1cFailureDomainBuilder,
+				).BuildFailureDomains(),
+				expectedError: errReplicasRequired,
+			}),
+			PEntry("with three replicas and three failure domains (order a,b,c)", createBaseMappingTableInput{
+				cpms: cpmsBuilder.WithReplicas(3).Build(),
+				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
+					usEast1aFailureDomainBuilder,
+					usEast1bFailureDomainBuilder,
+					usEast1cFailureDomainBuilder,
+				).BuildFailureDomains(),
+				expectedMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+				},
+			}),
+			PEntry("with three replicas and three failure domains (order b,c,a)", createBaseMappingTableInput{
+				cpms: cpmsBuilder.WithReplicas(3).Build(),
+				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
+					usEast1bFailureDomainBuilder,
+					usEast1cFailureDomainBuilder,
+					usEast1aFailureDomainBuilder,
+				).BuildFailureDomains(),
+				expectedMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+				},
+			}),
+			PEntry("with three replicas and three failure domains (order b,a,c)", createBaseMappingTableInput{
+				cpms: cpmsBuilder.WithReplicas(3).Build(),
+				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
+					usEast1bFailureDomainBuilder,
+					usEast1aFailureDomainBuilder,
+					usEast1cFailureDomainBuilder,
+				).BuildFailureDomains(),
+				expectedMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+				},
+			}),
+			PEntry("with three replicas and one failure domains", createBaseMappingTableInput{
+				cpms: cpmsBuilder.WithReplicas(3).Build(),
+				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
+					usEast1aFailureDomainBuilder,
+				).BuildFailureDomains(),
+				expectedMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					1: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+				},
+			}),
+			PEntry("with three replicas and two failure domains (order a,b)", createBaseMappingTableInput{
+				cpms: cpmsBuilder.WithReplicas(3).Build(),
+				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
+					usEast1aFailureDomainBuilder,
+					usEast1bFailureDomainBuilder,
+				).BuildFailureDomains(),
+				expectedMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+				},
+			}),
+			PEntry("with three replicas and two failure domains (order b,a)", createBaseMappingTableInput{
+				cpms: cpmsBuilder.WithReplicas(3).Build(),
+				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
+					usEast1bFailureDomainBuilder,
+					usEast1aFailureDomainBuilder,
+				).BuildFailureDomains(),
+				expectedMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+				},
+			}),
+			PEntry("with five replicas and three failure domains (order a,b,c)", createBaseMappingTableInput{
+				cpms: cpmsBuilder.WithReplicas(3).Build(),
+				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
+					usEast1aFailureDomainBuilder,
+					usEast1bFailureDomainBuilder,
+					usEast1cFailureDomainBuilder,
+				).BuildFailureDomains(),
+				expectedMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+					3: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					4: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+				},
+			}),
+			PEntry("with five replicas and three failure domains (order b,c,a)", createBaseMappingTableInput{
+				cpms: cpmsBuilder.WithReplicas(3).Build(),
+				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
+					usEast1bFailureDomainBuilder,
+					usEast1cFailureDomainBuilder,
+					usEast1aFailureDomainBuilder,
+				).BuildFailureDomains(),
+				expectedMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+					3: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					4: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+				},
+			}),
+			PEntry("with five replicas and two failure domains (order a,b)", createBaseMappingTableInput{
+				cpms: cpmsBuilder.WithReplicas(3).Build(),
+				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
+					usEast1aFailureDomainBuilder,
+					usEast1bFailureDomainBuilder,
+				).BuildFailureDomains(),
+				expectedMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					3: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					4: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+				},
+			}),
+			PEntry("with five replicas and two failure domains (order b,a)", createBaseMappingTableInput{
+				cpms: cpmsBuilder.WithReplicas(3).Build(),
+				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
+					usEast1bFailureDomainBuilder,
+					usEast1aFailureDomainBuilder,
+				).BuildFailureDomains(),
+				expectedMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					3: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					4: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+				},
+			}),
+		)
+	})
+
+	Context("createMachineMapping", func() {
+		type machineMappingTableInput struct {
+			cpms            *machinev1.ControlPlaneMachineSet
+			machines        []*machinev1beta1.Machine
+			expectedError   error
+			expectedMapping map[int32]failuredomain.FailureDomain
+			expectedLogs    []test.LogEntry
+		}
+
+		DescribeTable("maps Machines based on their failure domain", func(in machineMappingTableInput) {
+			logger := test.NewTestLogger()
+
+			// Make sure all resources use the right namespace.
+			in.cpms.SetNamespace(namespaceName)
+
+			for _, machine := range in.machines {
+				machine.SetNamespace(namespaceName)
+				Expect(k8sClient.Create(ctx, machine)).To(Succeed())
+			}
+
+			originalCPMS := in.cpms.DeepCopy()
+
+			mapping, err := createMachineMapping(ctx, logger.Logger(), k8sClient, in.cpms)
+			if in.expectedError != nil {
+				Expect(err).To(MatchError(in.expectedError))
+			} else {
+				Expect(err).ToNot(HaveOccurred())
+			}
+
+			Expect(mapping).To(Equal(in.expectedMapping))
+			Expect(logger.Entries()).To(ConsistOf(in.expectedLogs))
+			Expect(in.cpms).To(Equal(originalCPMS), "The update functions should not modify the ControlPlaneMachineSet in any way")
+		},
+			PEntry("with machines in three failure domains (order a,b,c)", machineMappingTableInput{
+				cpms: cpmsBuilder.Build(),
+				machines: []*machinev1beta1.Machine{
+					machineBuilder.WithName("machine-0").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-1").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-2").WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build(),
+				},
+				expectedMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+				},
+				expectedLogs: []test.LogEntry{},
+			}),
+			PEntry("with machines in three failure domains (order b,c,a)", machineMappingTableInput{
+				cpms: cpmsBuilder.Build(),
+				machines: []*machinev1beta1.Machine{
+					machineBuilder.WithName("machine-0").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-1").WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-2").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build(),
+				},
+				expectedMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					1: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+				},
+				expectedLogs: []test.LogEntry{},
+			}),
+			PEntry("with machines in not matched by the selector, they are ignored", machineMappingTableInput{
+				cpms: cpmsBuilder.Build(),
+				machines: []*machinev1beta1.Machine{
+					machineBuilder.WithName("machine-0").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build(),
+					resourcebuilder.Machine().WithName("machine-1").WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build(),
+					resourcebuilder.Machine().WithName("machine-2").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build(),
+				},
+				expectedMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+				},
+				expectedLogs: []test.LogEntry{},
+			}),
+			PEntry("with machines with non-index names", machineMappingTableInput{
+				cpms: cpmsBuilder.Build(),
+				machines: []*machinev1beta1.Machine{
+					machineBuilder.WithName("machine-a").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-1").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-c").WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build(),
+				},
+				expectedMapping: map[int32]failuredomain.FailureDomain{
+					1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+				},
+				expectedLogs: []test.LogEntry{
+					{
+						Level: 4,
+						KeysAndValues: []interface{}{
+							"machine", "machine-a",
+						},
+						Message: "Ignoring machine in failure domain mapping with unexpected name",
+					},
+					{
+						Level: 4,
+						KeysAndValues: []interface{}{
+							"machine", "machine-c",
+						},
+						Message: "Ignoring machine in failure domain mapping with unexpected name",
+					},
+				},
+			}),
+			PEntry("with multiple machines in a failure domains", machineMappingTableInput{
+				cpms: cpmsBuilder.Build(),
+				machines: []*machinev1beta1.Machine{
+					machineBuilder.WithName("machine-0").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-1").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-2").WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build(),
+				},
+				expectedMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					1: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+				},
+				expectedLogs: []test.LogEntry{},
+			}),
+			PEntry("with multiple machines in the same index in the same failure domain", machineMappingTableInput{
+				cpms: cpmsBuilder.Build(),
+				machines: []*machinev1beta1.Machine{
+					machineBuilder.WithName("machine-0").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-replacement-0").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-2").WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build(),
+				},
+				expectedMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+				},
+				expectedLogs: []test.LogEntry{},
+			}),
+			PEntry("with multiple machines in the same index in different failure domains", machineMappingTableInput{
+				cpms: cpmsBuilder.Build(),
+				machines: []*machinev1beta1.Machine{
+					machineBuilder.WithName("machine-0").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-replacement-0").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-2").WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build(),
+				},
+				expectedMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+				},
+				expectedLogs: []test.LogEntry{
+					{
+						Level: 4,
+						KeysAndValues: []interface{}{
+							"oldMachine", "machine-0",
+							"oldFaliureDomain", "us-east-1a",
+							"newerMachine", "machine-replacement-0",
+							"newerFailureDomain", "us-east-1b",
+						},
+						Message: "Conflicting failure domains found for the same index, relying on the newer machine",
+					},
+				},
+			}),
+		)
+	})
+
+	Context("reconcileMappings", func() {
+		type reconcileMappingsTableInput struct {
+			baseMapping     map[int32]failuredomain.FailureDomain
+			machineMapping  map[int32]failuredomain.FailureDomain
+			expectedMapping map[int32]failuredomain.FailureDomain
+			expectedLogs    []test.LogEntry
+		}
+
+		DescribeTable("should keep the machine indexes stable where possible", func(in reconcileMappingsTableInput) {
+			logger := test.NewTestLogger()
+
+			mapping := reconcileMappings(logger.Logger(), in.baseMapping, in.expectedMapping)
+
+			Expect(mapping).To(Equal(in.expectedMapping))
+			Expect(logger.Entries()).To(Equal(in.expectedLogs))
+		},
+			PEntry("when the mappings match", reconcileMappingsTableInput{
+				baseMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+				},
+				machineMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+				},
+				expectedMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+				},
+				expectedLogs: []test.LogEntry{},
+			}),
+			PEntry("when the mappings differ, machines take precedence (order b,c,a)", reconcileMappingsTableInput{
+				baseMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+				},
+				machineMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					1: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+				},
+				expectedMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					1: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+				},
+				expectedLogs: []test.LogEntry{},
+			}),
+			PEntry("when the mappings differ, machines take precedence (order b,a,c)", reconcileMappingsTableInput{
+				baseMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+				},
+				machineMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					1: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+				},
+				expectedMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					1: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+				},
+				expectedLogs: []test.LogEntry{},
+			}),
+			PEntry("when a machine has a failure domain not in the base mapping", reconcileMappingsTableInput{
+				baseMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+				},
+				machineMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					1: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+				},
+				expectedMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					1: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+				},
+				expectedLogs: []test.LogEntry{
+					{
+						Level: 4,
+						KeysAndValues: []interface{}{
+							"index", 2,
+							"failureDomain", "us-east-1c",
+						},
+						Message: "Ignoring unknown failure domain",
+					},
+				},
+			}),
+			PEntry("when the base mapping has a failure domain not in the machine mapping", reconcileMappingsTableInput{
+				baseMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+				},
+				machineMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					1: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+				},
+				expectedMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					1: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+				},
+				expectedLogs: []test.LogEntry{
+					{
+						Level: 4,
+						KeysAndValues: []interface{}{
+							"index", 2,
+							"oldFailureDomain", "us-east-1a",
+							"newFailureDomain", "us-east-1c",
+						},
+						Message: "Failure domain changed for index",
+					},
+				},
+			}),
+		)
+	})
+})


### PR DESCRIPTION
This PR expands on how the mapping will work for the failure domains to Machine indexes.
This should give some structure and an outline of the behaviour through the tests that have been added.

Primarily it breaks the mapping down into three stages to be implemented:
- Enumerating the CPMS defined failure domains
- Enumerating the Machine defined failure domains
- Reconciling the two sets of failure domains making sure Machines take precedence