### PR TITLE
[OCPCLOUD-1558] Extend provider config abstraction to be platform agnostic

### DIFF
--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/failuredomain/failuredomain.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/failuredomain/failuredomain.go
@@ -99,6 +99,16 @@ func newAWSFailureDomains(failureDomains machinev1.FailureDomains) ([]FailureDom
 	return []FailureDomain{dummyFailureDomains}, nil
 }
 
+// NewAWSFailureDomain creates an AWS failure domain from the machinev1.AWSFailureDomain.
+// Note this is exported to allow other packages to construct individual failure domains
+// in tests.
+func NewAWSFailureDomain(fd machinev1.AWSFailureDomain) FailureDomain {
+	return &failureDomain{
+		platformType: configv1.AWSPlatformType,
+		aws:          fd,
+	}
+}
+
 // awsFailureDomainToString converts the AWSFailureDomain into a string.
 // Typically most failure domains are represented by their availability zone,
 // so we return the AWS AvailabilityZone if it is set.

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/providerconfig.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/providerconfig.go
@@ -22,9 +22,14 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	machinev1 "github.com/openshift/api/machine/v1"
+	"github.com/openshift/cluster-control-plane-machine-set-operator/pkg/machineproviders/providers/openshift/machine/v1beta1/failuredomain"
 )
 
 var (
+	// errMismatchedPlatformTypes is an error used when two provider configs
+	// are being compared but are from different platform types.
+	errMismatchedPlatformTypes = errors.New("mistmatched platform types")
+
 	// errUnsupportedPlatformType is an error used when an unknown platform
 	// type is configured within the failure domain config.
 	errUnsupportedPlatformType = errors.New("unsupported platform type")
@@ -33,6 +38,20 @@ var (
 // ProviderConfig is an interface that allows external code to interact
 // with provider configuration across different platform types.
 type ProviderConfig interface {
+	// InjectFailureDomain is used to inject a failure domain into the ProviderConfig.
+	// The returned ProviderConfig will be a copy of the current ProviderConfig with
+	// the new failure domain injected.
+	InjectFailureDomain(failuredomain.FailureDomain) (ProviderConfig, error)
+
+	// ExtractFailureDomain is used to extract a failure domain from the ProviderConfig.
+	ExtractFailureDomain() failuredomain.FailureDomain
+
+	// Equal compares two ProviderConfigs to determine whether or not they are equal.
+	Equal(ProviderConfig) (bool, error)
+
+	// RawConfig marshalls the configuration into a JSON byte slice.
+	RawConfig() ([]byte, error)
+
 	// Type returns the platform type of the provider config.
 	Type() configv1.PlatformType
 
@@ -59,6 +78,28 @@ func NewProviderConfig(tmpl machinev1.OpenShiftMachineV1Beta1MachineTemplate) (P
 type providerConfig struct {
 	platformType configv1.PlatformType
 	aws          AWSProviderConfig
+}
+
+// InjectFailureDomain is used to inject a failure domain into the ProviderConfig.
+// The returned ProviderConfig will be a copy of the current ProviderConfig with
+// the new failure domain injected.
+func (p providerConfig) InjectFailureDomain(failuredomain.FailureDomain) (ProviderConfig, error) {
+	return p, nil
+}
+
+// ExtractFailureDomain is used to extract a failure domain from the ProviderConfig.
+func (p providerConfig) ExtractFailureDomain() failuredomain.FailureDomain {
+	return nil
+}
+
+// Equal compares two ProviderConfigs to determine whether or not they are equal.
+func (p providerConfig) Equal(ProviderConfig) (bool, error) {
+	return false, nil
+}
+
+// RawConfig marshalls the configuration into a JSON byte slice.
+func (p providerConfig) RawConfig() ([]byte, error) {
+	return []byte{}, nil
 }
 
 // Type returns the platform type of the provider config.


### PR DESCRIPTION
This adds the Inject, Extract, Equal and Raw functionality to the provider config abstraction to allow the core of the MachineProvider to be platform agnostic.

These 4 functions represent the needs of the MachineProvider on the provider config.

It will use InjectFailureDomain to take the base provider config and set the correct failure domain before converting it to raw and creating a new machine from it.

It will use ExtractFailureDomain to determine if the failure domain of a Machine is similar to a failure domain it has defined within the CPMS.

It will use Equal to determine if the desired provider config matches that of the Machines it gathers to work out whether they are in need of an update