### PR TITLE
[OCPCLOUD-1544] Add OpenShift MachineProvider interface implementation tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	k8s.io/api v0.23.5
 	k8s.io/apimachinery v0.23.5
 	k8s.io/client-go v0.23.4
+	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9
 	sigs.k8s.io/controller-runtime v0.11.1-0.20220304125252-9ee63fc65a97
 	sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20220222144948-ce8bdd3d81ab
 	sigs.k8s.io/controller-tools v0.8.0
@@ -211,6 +212,5 @@ require (
 	github.com/openshift/library-go v0.0.0-20220419144511-5b7d3d77b85e
 	golang.org/x/net v0.0.0-20220403103023-749bd193bc2b // indirect
 	k8s.io/klog/v2 v2.60.1 // indirect
-	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect
 )

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/provider.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/provider.go
@@ -34,6 +34,12 @@ import (
 )
 
 var (
+	// errCouldNotDetermineMachineIndex is used to denote that the MachineProvider could not infer an
+	// index to assign to a Machine based on either the name or the failure domain.
+	// This means the Machine has been created in some manor outside of OpenShift norms and is in a failure domain
+	// not currently specified in the ControlPlaneMachineSet definition. User intervention is required here.
+	errCouldNotDetermineMachineIndex = errors.New("could not determine Machine index from name or failure domain")
+
 	// errEmptyConfig is used to denote that the machine provider could not be constructed
 	// because no configuration was provided by the user.
 	errEmptyConfig = fmt.Errorf("cannot initialise %s provider with empty config", machinev1.OpenShiftMachineV1Beta1MachineType)

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/provider.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/provider.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/go-logr/logr"
 	machinev1 "github.com/openshift/api/machine/v1"
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openshift/cluster-control-plane-machine-set-operator/pkg/machineproviders"
@@ -36,6 +37,11 @@ var (
 	// errEmptyConfig is used to denote that the machine provider could not be constructed
 	// because no configuration was provided by the user.
 	errEmptyConfig = fmt.Errorf("cannot initialise %s provider with empty config", machinev1.OpenShiftMachineV1Beta1MachineType)
+
+	// errMissingClusterIDLabel is used to denote that the cluster ID label, expected to be on the Machine template
+	// is not present and therefore a Machine cannot be created. The Cluster ID is required to construct the name for
+	// the new Machines.
+	errMissingClusterIDLabel = fmt.Errorf("missing required label on machine template metadata: %s", machinev1beta1.MachineClusterIDLabel)
 
 	// errUnexpectedMachineType is used to denote that the machine provider was requested
 	// for an unsupported machine provider type (ie not OpenShift Machine v1beta1).

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/provider.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/provider.go
@@ -40,6 +40,10 @@ var (
 	// errUnexpectedMachineType is used to denote that the machine provider was requested
 	// for an unsupported machine provider type (ie not OpenShift Machine v1beta1).
 	errUnexpectedMachineType = fmt.Errorf("unexpected machine type while initialising %s provider", machinev1.OpenShiftMachineV1Beta1MachineType)
+
+	// errUnknownGroupVersionResource is used to denote that the machine provider received an
+	// unknown GroupVersionResource while processing a Machine deletion request.
+	errUnknownGroupVersionResource = fmt.Errorf("unknown group/version/resource")
 )
 
 // NewMachineProvider creates a new OpenShift Machine v1beta1 machine provider implementation.

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/provider_test.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/provider_test.go
@@ -1,0 +1,219 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	machinev1 "github.com/openshift/api/machine/v1"
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+	"github.com/openshift/cluster-control-plane-machine-set-operator/pkg/machineproviders"
+	"github.com/openshift/cluster-control-plane-machine-set-operator/pkg/machineproviders/providers/openshift/machine/v1beta1/failuredomain"
+	"github.com/openshift/cluster-control-plane-machine-set-operator/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig"
+	"github.com/openshift/cluster-control-plane-machine-set-operator/pkg/test"
+	"github.com/openshift/cluster-control-plane-machine-set-operator/pkg/test/resourcebuilder"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
+)
+
+var _ = Describe("MachineProvider", func() {
+	const ownerUID = "uid-1234abcd"
+
+	var namespaceName string
+	var logger test.TestLogger
+
+	BeforeEach(func() {
+		By("Setting up a namespace for the test")
+		ns := resourcebuilder.Namespace().WithGenerateName("control-plane-machine-set-controller-").Build()
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+		namespaceName = ns.GetName()
+
+		logger = test.NewTestLogger()
+	})
+
+	AfterEach(func() {
+		test.CleanupResources(Default, ctx, cfg, k8sClient, namespaceName,
+			&corev1.Node{},
+			&machinev1beta1.Machine{},
+		)
+	})
+
+	Context("DeleteMachine", func() {
+		var machineName string
+		var machineRef *machineproviders.ObjectRef
+		var machineProvider machineproviders.MachineProvider
+
+		BeforeEach(func() {
+			By("Setting up the MachineProvider")
+			cpms := resourcebuilder.ControlPlaneMachineSet().Build()
+
+			template := resourcebuilder.OpenShiftMachineV1Beta1Template().
+				WithProviderSpecBuilder(resourcebuilder.AWSProviderSpec()).
+				BuildTemplate().OpenShiftMachineV1Beta1Machine
+			Expect(template).ToNot(BeNil())
+
+			providerConfig, err := providerconfig.NewProviderConfig(*template)
+			Expect(err).ToNot(HaveOccurred())
+
+			machineProvider = &openshiftMachineProvider{
+				client:               k8sClient,
+				indexToFailureDomain: map[int32]failuredomain.FailureDomain{},
+				machineSelector:      cpms.Spec.Selector,
+				machineTemplate:      *template,
+				ownerMetadata: metav1.ObjectMeta{
+					UID: types.UID(ownerUID),
+				},
+				providerConfig: providerConfig,
+			}
+
+			machineBuilder := resourcebuilder.Machine().AsMaster().
+				WithGenerateName("control-plane-machine-").
+				WithNamespace(namespaceName)
+
+			machine := machineBuilder.Build()
+			Expect(k8sClient.Create(ctx, machine)).To(Succeed())
+			machineName = machine.Name
+		})
+
+		Context("with the correct GVR", func() {
+			BeforeEach(func() {
+				machineRef = &machineproviders.ObjectRef{
+					GroupVersionResource: machinev1beta1.GroupVersion.WithResource("machines"),
+				}
+			})
+
+			Context("with an existing machine", func() {
+				var err error
+
+				BeforeEach(func() {
+					machineRef.ObjectMeta.Name = machineName
+
+					err = machineProvider.DeleteMachine(ctx, logger.Logger(), machineRef)
+				})
+
+				PIt("deletes the Machine", func() {
+					machine := resourcebuilder.Machine().
+						WithNamespace(namespaceName).
+						WithName(machineName).
+						Build()
+
+					notFoundErr := apierrors.NewNotFound(machineRef.GroupVersionResource.GroupResource(), machineName)
+
+					Eventually(komega.Get(machine)).Should(MatchError(notFoundErr))
+				})
+
+				PIt("does not error", func() {
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				PIt("logs that the machine was deleted", func() {
+					Expect(logger.Entries()).To(ConsistOf(
+						test.LogEntry{
+							Level: 2,
+							KeysAndValues: []interface{}{
+								"namespace", namespaceName,
+								"machineName", machineName,
+								"group", machinev1beta1.GroupVersion.Group,
+								"version", machinev1beta1.GroupVersion.Version,
+							},
+							Message: "Deleted machine",
+						},
+					))
+				})
+			})
+
+			Context("with an non-existent machine", func() {
+				var err error
+				const unknown = "unknown"
+
+				BeforeEach(func() {
+					machineRef.ObjectMeta.Name = unknown
+
+					err = machineProvider.DeleteMachine(ctx, logger.Logger(), machineRef)
+				})
+
+				PIt("does not delete the existing Machine", func() {
+					machine := resourcebuilder.Machine().
+						WithNamespace(namespaceName).
+						WithName(machineName).
+						Build()
+
+					Consistently(komega.Get(machine)).Should(Succeed())
+				})
+
+				PIt("does not error", func() {
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				PIt("logs that the machine was already deleted", func() {
+					Expect(logger.Entries()).To(ConsistOf(
+						test.LogEntry{
+							Level: 2,
+							KeysAndValues: []interface{}{
+								"namespace", namespaceName,
+								"machineName", unknown,
+								"group", machinev1beta1.GroupVersion.Group,
+								"version", machinev1beta1.GroupVersion.Version,
+							},
+							Message: "Machine not found",
+						},
+					))
+				})
+			})
+		})
+
+		Context("with an incorrect GVR", func() {
+			var err error
+
+			BeforeEach(func() {
+				machineRef := &machineproviders.ObjectRef{
+					GroupVersionResource: machinev1.GroupVersion.WithResource("machines"),
+					ObjectMeta: metav1.ObjectMeta{
+						Name: machineName,
+					},
+				}
+
+				err = machineProvider.DeleteMachine(ctx, logger.Logger(), machineRef)
+			})
+
+			PIt("returns an error", func() {
+				Expect(err).To(MatchError(fmt.Errorf("%w: expected %s, got %s", errUnknownGroupVersionResource, machinev1beta1.GroupVersion.WithResource("machines").String(), machinev1.GroupVersion.WithResource("machines").String())))
+			})
+
+			PIt("logs the error", func() {
+				Expect(logger.Entries()).To(ConsistOf(
+					test.LogEntry{
+						Error: errUnknownGroupVersionResource,
+						KeysAndValues: []interface{}{
+							"expectedGVR", machinev1beta1.GroupVersion.WithResource("machines").String(),
+							"gotGVR", machinev1.GroupVersion.WithResource("machines").String(),
+						},
+						Message: "Could not delete machine",
+					},
+				))
+			})
+		})
+	})
+})

--- a/pkg/test/resourcebuilder/aws_provider_spec.go
+++ b/pkg/test/resourcebuilder/aws_provider_spec.go
@@ -29,6 +29,7 @@ import (
 func AWSProviderSpec() AWSProviderSpecBuilder {
 	return AWSProviderSpecBuilder{
 		availabilityZone: "us-east-1a",
+		instanceType:     "m6i.xlarge",
 		securityGroups: []machinev1beta1.AWSResourceReference{
 			{
 				Filters: []machinev1beta1.Filter{
@@ -57,6 +58,7 @@ func AWSProviderSpec() AWSProviderSpecBuilder {
 // AWSProviderSpecBuilder is used to build out a AWS machine config object.
 type AWSProviderSpecBuilder struct {
 	availabilityZone string
+	instanceType     string
 	securityGroups   []machinev1beta1.AWSResourceReference
 	subnet           machinev1beta1.AWSResourceReference
 }
@@ -86,7 +88,7 @@ func (m AWSProviderSpecBuilder) Build() *machinev1beta1.AWSMachineProviderConfig
 		IAMInstanceProfile: &machinev1beta1.AWSResourceReference{
 			ID: stringPtr("aws-iam-instance-profile-12345678"),
 		},
-		InstanceType: "m6i.xlarge",
+		InstanceType: m.instanceType,
 		LoadBalancers: []machinev1beta1.LoadBalancerReference{
 			{
 				Type: "network",
@@ -127,6 +129,12 @@ func (m AWSProviderSpecBuilder) BuildRawExtension() *runtime.RawExtension {
 // WithAvailabilityZone sets the availabilityZone for the AWS machine config builder.
 func (m AWSProviderSpecBuilder) WithAvailabilityZone(az string) AWSProviderSpecBuilder {
 	m.availabilityZone = az
+	return m
+}
+
+// WithInstanceType sets the isntanceType for the AWS machine config builder.
+func (m AWSProviderSpecBuilder) WithInstanceType(instanceType string) AWSProviderSpecBuilder {
+	m.instanceType = instanceType
 	return m
 }
 

--- a/pkg/test/resourcebuilder/machine.go
+++ b/pkg/test/resourcebuilder/machine.go
@@ -18,6 +18,7 @@ package resourcebuilder
 
 import (
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -38,6 +39,11 @@ type MachineBuilder struct {
 	namespace           string
 	labels              map[string]string
 	providerSpecBuilder RawExtensionBuilder
+
+	// status fields
+	errorMessage *string
+	nodeRef      *corev1.ObjectReference
+	phase        *string
 }
 
 // Build builds a new machine based on the configuration provided.
@@ -48,6 +54,11 @@ func (m MachineBuilder) Build() *machinev1beta1.Machine {
 			Name:         m.name,
 			Namespace:    m.namespace,
 			Labels:       m.labels,
+		},
+		Status: machinev1beta1.MachineStatus{
+			ErrorMessage: m.errorMessage,
+			Phase:        m.phase,
+			NodeRef:      m.nodeRef,
 		},
 	}
 
@@ -110,5 +121,25 @@ func (m MachineBuilder) WithNamespace(namespace string) MachineBuilder {
 // WithProviderSpecBuilder sets the providerSpec builder for the machine builder.
 func (m MachineBuilder) WithProviderSpecBuilder(builder RawExtensionBuilder) MachineBuilder {
 	m.providerSpecBuilder = builder
+	return m
+}
+
+// Status Fields
+
+// WithErrorMessage sets the error message status field for the machine builder.
+func (m MachineBuilder) WithErrorMessage(errorMsg string) MachineBuilder {
+	m.errorMessage = &errorMsg
+	return m
+}
+
+// WithPhase sets the phase status field for the machine builder.
+func (m MachineBuilder) WithPhase(phase string) MachineBuilder {
+	m.phase = &phase
+	return m
+}
+
+// WithNodeRef sets the node ref status field for the machine builder.
+func (m MachineBuilder) WithNodeRef(nodeRef corev1.ObjectReference) MachineBuilder {
+	m.nodeRef = &nodeRef
 	return m
 }

--- a/pkg/test/resourcebuilder/machine_info.go
+++ b/pkg/test/resourcebuilder/machine_info.go
@@ -35,6 +35,8 @@ type MachineInfoBuilder struct {
 	machineDeletiontimestamp *metav1.Time
 	machineGVR               schema.GroupVersionResource
 	machineName              string
+	machineNamespace         string
+	machineLabels            map[string]string
 	machineOwnerRefs         []metav1.OwnerReference
 
 	nodeGVR  schema.GroupVersionResource
@@ -60,7 +62,9 @@ func (m MachineInfoBuilder) Build() machineproviders.MachineInfo {
 			GroupVersionResource: m.machineGVR,
 			ObjectMeta: metav1.ObjectMeta{
 				DeletionTimestamp: m.machineDeletiontimestamp,
+				Labels:            m.machineLabels,
 				Name:              m.machineName,
+				Namespace:         m.machineNamespace,
 				OwnerReferences:   m.machineOwnerRefs,
 			},
 		}
@@ -90,9 +94,21 @@ func (m MachineInfoBuilder) WithMachineGVR(gvr schema.GroupVersionResource) Mach
 	return m
 }
 
+// WithMachineLabels sets the machine labels for the machineinfo builder.
+func (m MachineInfoBuilder) WithMachineLabels(labels map[string]string) MachineInfoBuilder {
+	m.machineLabels = labels
+	return m
+}
+
 // WithMachineName sets the machine name for the machineinfo builder.
 func (m MachineInfoBuilder) WithMachineName(name string) MachineInfoBuilder {
 	m.machineName = name
+	return m
+}
+
+// WithMachineNamespace sets the machine namespace for the machineinfo builder.
+func (m MachineInfoBuilder) WithMachineNamespace(namespace string) MachineInfoBuilder {
+	m.machineNamespace = namespace
 	return m
 }
 

--- a/pkg/test/resourcebuilder/metadata.go
+++ b/pkg/test/resourcebuilder/metadata.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcebuilder
+
+// NewMachineRoleLabels creates a new map of standard Machine labels
+// for the given role.
+func NewMachineRoleLabels(role string) map[string]string {
+	return map[string]string{
+		machineRoleLabelName: role,
+		machineTypeLabelName: role,
+	}
+}

--- a/pkg/test/resourcebuilder/openshift_machine_v1beta1_template.go
+++ b/pkg/test/resourcebuilder/openshift_machine_v1beta1_template.go
@@ -18,6 +18,7 @@ package resourcebuilder
 
 import (
 	machinev1 "github.com/openshift/api/machine/v1"
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 )
 
 // OpenShiftMachineV1Beta1Template creates a new OpenShift machine template builder.
@@ -25,8 +26,9 @@ func OpenShiftMachineV1Beta1Template() OpenShiftMachineV1Beta1TemplateBuilder {
 	return OpenShiftMachineV1Beta1TemplateBuilder{
 		failureDomainsBuilder: AWSFailureDomains(),
 		labels: map[string]string{
-			machineRoleLabelName: "master",
-			machineTypeLabelName: "master",
+			machineRoleLabelName:                 "master",
+			machineTypeLabelName:                 "master",
+			machinev1beta1.MachineClusterIDLabel: "cpms-cluster-test-id",
 		},
 	}
 }


### PR DESCRIPTION
This PR introduces testing for the MachineProvider CreateMachine, DeleteMachine and GetMachineInfos methods.

These tests define the core behaviour of the MachineProvider implementation including rules about how the Machines should be named and how to handle various Machine states that the MachineProvider may observe within the cluster