### PR TITLE
Ensure master role and type label are present on OpenShift Machine Templates

### DIFF
--- a/pkg/webhooks/controlplanemachineset/webhooks.go
+++ b/pkg/webhooks/controlplanemachineset/webhooks.go
@@ -26,6 +26,20 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
+const (
+	// openshiftMachineRoleLabel is the OpenShift Machine API machine role label.
+	// This must be present on all OpenShift Machine API Machine templates.
+	openshiftMachineRoleLabel = "machine.openshift.io/cluster-api-machine-role"
+
+	// openshiftMachineRoleLabel is the OpenShift Machine API machine type label.
+	// This must be present on all OpenShift Machine API Machine templates.
+	openshiftMachineTypeLabel = "machine.openshift.io/cluster-api-machine-type"
+
+	// masterMachineRole is the master role/type that is required to be set on
+	// all OpenShift Machine API Machine templates.
+	masterMachineRole = "master"
+)
+
 // ControlPlaneMachineSetWebhook acts as a webhook validator for the
 // machinev1beta1.ControlPlaneMachineSet resource.
 type ControlPlaneMachineSetWebhook struct{}

--- a/pkg/webhooks/controlplanemachineset/webhooks_test.go
+++ b/pkg/webhooks/controlplanemachineset/webhooks_test.go
@@ -109,13 +109,15 @@ var _ = Describe("Webhooks", func() {
 		PIt("with mismatched selector and machine labels", func() {
 			cpms := builder.WithSelector(metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"role":                               "master",
+					openshiftMachineRoleLabel:            masterMachineRole,
+					openshiftMachineTypeLabel:            masterMachineRole,
 					machinev1beta1.MachineClusterIDLabel: "cluster-id",
 				},
 			}).WithMachineTemplateBuilder(
 				machineTemplate.WithLabels(map[string]string{
-					"role":                               "worker",
-					machinev1beta1.MachineClusterIDLabel: "cluster-id",
+					openshiftMachineRoleLabel:            masterMachineRole,
+					openshiftMachineTypeLabel:            masterMachineRole,
+					machinev1beta1.MachineClusterIDLabel: "different-id",
 				}),
 			).Build()
 
@@ -125,11 +127,45 @@ var _ = Describe("Webhooks", func() {
 		PIt("with no cluster ID label is set", func() {
 			cpms := builder.WithSelector(metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"role": "master",
+					openshiftMachineRoleLabel: masterMachineRole,
+					openshiftMachineTypeLabel: masterMachineRole,
 				},
 			}).WithMachineTemplateBuilder(
 				machineTemplate.WithLabels(map[string]string{
-					"role": "master",
+					openshiftMachineRoleLabel: masterMachineRole,
+					openshiftMachineTypeLabel: masterMachineRole,
+				}),
+			).Build()
+
+			Expect(k8sClient.Create(ctx, cpms)).To(MatchError(ContainSubstring("TODO")))
+		})
+
+		PIt("with no master role label on the template", func() {
+			cpms := builder.WithSelector(metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					openshiftMachineTypeLabel:            masterMachineRole,
+					machinev1beta1.MachineClusterIDLabel: "cluster-id",
+				},
+			}).WithMachineTemplateBuilder(
+				machineTemplate.WithLabels(map[string]string{
+					openshiftMachineTypeLabel:            masterMachineRole,
+					machinev1beta1.MachineClusterIDLabel: "cluster-id",
+				}),
+			).Build()
+
+			Expect(k8sClient.Create(ctx, cpms)).To(MatchError(ContainSubstring("TODO")))
+		})
+
+		PIt("with no master type label on the template", func() {
+			cpms := builder.WithSelector(metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					openshiftMachineRoleLabel:            masterMachineRole,
+					machinev1beta1.MachineClusterIDLabel: "cluster-id",
+				},
+			}).WithMachineTemplateBuilder(
+				machineTemplate.WithLabels(map[string]string{
+					openshiftMachineRoleLabel:            masterMachineRole,
+					machinev1beta1.MachineClusterIDLabel: "cluster-id",
 				}),
 			).Build()
 


### PR DESCRIPTION
Various components within OpenShift expect the machine role label to be present to identify which Machines are Control Plane Machines.
We should enforce consistency here as, if we don't have those labels, other components may not operate correctly.