### PR TITLE
[OCPCLOUD-1565] Ensure invalid cluster state prevents further reconciliation

### DIFF
--- a/pkg/controllers/controlplanemachineset/consts.go
+++ b/pkg/controllers/controlplanemachineset/consts.go
@@ -77,6 +77,12 @@ const (
 	// with the other controller.
 	reasonMachinesAlreadyOwned = "MachinesAlreadyOwned"
 
+	// reasonNoReadyMachines denotes that the ControlPlaneMachineSet has
+	// not found any Control Plane Machines that are ready. This normally means that the
+	// cluster is not functioning properly, likely due to some misconfiguration of the
+	// Control Plane Machines.
+	reasonNoReadyMachines = "NoReadyMachines"
+
 	// reasonUnmanagedNodes denotes that the ControlPlaneMachineSet has identified some
 	// Control Plane Node that is not currently managed by a Control Plane Machine.
 	// In this scenario, to prevent potential for degrading the cluster into an unsupported

--- a/pkg/controllers/controlplanemachineset/controller.go
+++ b/pkg/controllers/controlplanemachineset/controller.go
@@ -167,6 +167,22 @@ func (r *ControlPlaneMachineSetReconciler) reconcile(ctx context.Context, logger
 		return ctrl.Result{}, fmt.Errorf("error fetching machine info: %w", err)
 	}
 
+	indexedMachineInfos, err := machineInfosByIndex(cpms, machineInfos)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("could not sort machine info by index: %w", err)
+	}
+
+	result, err := r.reconcileMachines(ctx, logger, cpms, machineProvider, indexedMachineInfos)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("error reconciling machines: %w", err)
+	}
+
+	return result, nil
+}
+
+// reconcileMachines uses the gathered machine info to set the status of the ControlPlaneMachineSet and then,
+// uses the machine provider to take appropriate actions to perform any requied roll outs.
+func (r *ControlPlaneMachineSetReconciler) reconcileMachines(ctx context.Context, logger logr.Logger, cpms *machinev1.ControlPlaneMachineSet, machineProvider machineproviders.MachineProvider, machineInfos map[int32][]machineproviders.MachineInfo) (ctrl.Result, error) {
 	if err := reconcileStatusWithMachineInfo(logger, cpms, machineInfos); err != nil {
 		return ctrl.Result{}, fmt.Errorf("error reconciling machine info with status: %w", err)
 	}
@@ -202,11 +218,34 @@ func (r *ControlPlaneMachineSetReconciler) ensureFinalizer(ctx context.Context, 
 
 // ensureOwnerReferences determines if any of the Machines within the machineInfos require a new controller owner
 // reference to be added, and then uses PartialObjectMetadata to ensure that the owner reference is added.
-func (r *ControlPlaneMachineSetReconciler) ensureOwnerReferences(ctx context.Context, logger logr.Logger, cpms *machinev1.ControlPlaneMachineSet, machineInfos []machineproviders.MachineInfo) error {
+func (r *ControlPlaneMachineSetReconciler) ensureOwnerReferences(ctx context.Context, logger logr.Logger, cpms *machinev1.ControlPlaneMachineSet, machineInfos map[int32][]machineproviders.MachineInfo) error {
 	// TODO: Iterate over the MachineInfos, for each Machine, check the owner references for an owner reference matching
 	// that of the current CPMS (it should be the controller so should be easy to find).
 	// If required, look up the GVK using the rest mapper from the GVR, then uses metav1.PartialObjectMetadata to Patch
 	// the owner references. This should mean we can update the metadata of any type given we know the GVR and existing
 	// ObjectMeta.
 	return nil
+}
+
+// machineInfosByIndex groups MachineInfo entries by index inside a map of index to MachineInfo.
+// This allows the update strategies to process each index in turn.
+// It is expected to add an entry for each expected index (0-(replicas-1)) so that later logic of updates can process
+// indexes that do not have any associated Machines.
+func machineInfosByIndex(cpms *machinev1.ControlPlaneMachineSet, machineInfos []machineproviders.MachineInfo) (map[int32][]machineproviders.MachineInfo, error) {
+	out := make(map[int32][]machineproviders.MachineInfo)
+
+	if cpms.Spec.Replicas == nil {
+		return nil, errReplicasRequired
+	}
+
+	// Make sure that every expected index is accounted for.
+	for i := int32(0); i < *cpms.Spec.Replicas; i++ {
+		out[i] = []machineproviders.MachineInfo{}
+	}
+
+	for _, machineInfo := range machineInfos {
+		out[machineInfo.Index] = append(out[machineInfo.Index], machineInfo)
+	}
+
+	return out, nil
 }

--- a/pkg/controllers/controlplanemachineset/status.go
+++ b/pkg/controllers/controlplanemachineset/status.go
@@ -71,6 +71,6 @@ func (r *ControlPlaneMachineSetReconciler) updateControlPlaneMachineSetStatus(ct
 // - UnavailableReplicas is the number of Machines required to satisfy the requirement of at least 1 Ready Replica per
 //   index. Eg. if one index has no ready replicas, this is 1, if an index has 2 ready replicas, this does not count as
 //   2 available replicas.
-func reconcileStatusWithMachineInfo(logger logr.Logger, cpms *machinev1.ControlPlaneMachineSet, machineInfos []machineproviders.MachineInfo) error {
+func reconcileStatusWithMachineInfo(logger logr.Logger, cpms *machinev1.ControlPlaneMachineSet, machineInfosByIndex map[int32][]machineproviders.MachineInfo) error {
 	return nil
 }

--- a/pkg/controllers/controlplanemachineset/status.go
+++ b/pkg/controllers/controlplanemachineset/status.go
@@ -62,10 +62,8 @@ func (r *ControlPlaneMachineSetReconciler) updateControlPlaneMachineSetStatus(ct
 // ControlPlaneMachineSet to match the data gathered.
 // In particular, it will update the ObservedGeneration, Replicas, ReadyReplicas, UnreadyReplicas and UpdatedReplicas
 // fields based on the information gathered, and then set any relevant conditions if applicable.
-// Eg. If there are any unowned Control Plane Nodes, or failed ControlPlaneMachines, it should add conditions to
-// to denote the state of the Machines.
 // It observes the following rules for setting the status:
-// - Replicas is the number of Machines present (a missing index or unmanaged node does not count towards this).
+// - Replicas is the number of Machines present
 // - ReadyReplicas is the number of the above Replicas which are reporting as Ready
 // - UpdatedReplicas is the number of Ready Replicas that do not need an update (this should be at most 1 per index).
 // - UnavailableReplicas is the number of Machines required to satisfy the requirement of at least 1 Ready Replica per

--- a/pkg/controllers/controlplanemachineset/status_test.go
+++ b/pkg/controllers/controlplanemachineset/status_test.go
@@ -148,7 +148,7 @@ var _ = Describe("Status", func() {
 	Context("reconcileStatusWithMachineInfo", func() {
 		type reconcileStatusTableInput struct {
 			cpms           *machinev1.ControlPlaneMachineSet
-			machineInfos   []machineproviders.MachineInfo
+			machineInfos   map[int32][]machineproviders.MachineInfo
 			expectedError  error
 			expectedStatus machinev1.ControlPlaneMachineSetStatus
 			expectedLogs   []test.LogEntry
@@ -200,10 +200,10 @@ var _ = Describe("Status", func() {
 		},
 			PEntry("with up to date Machines", &reconcileStatusTableInput{
 				cpms: resourcebuilder.ControlPlaneMachineSet().WithGeneration(1).Build(),
-				machineInfos: []machineproviders.MachineInfo{
-					healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build(),
-					healthyMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").Build(),
-					healthyMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("node-2").Build(),
+				machineInfos: map[int32][]machineproviders.MachineInfo{
+					0: {healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build()},
+					1: {healthyMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").Build()},
+					2: {healthyMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("node-2").Build()},
 				},
 				expectedError: nil,
 				expectedStatus: machinev1.ControlPlaneMachineSetStatus{
@@ -249,10 +249,10 @@ var _ = Describe("Status", func() {
 			}),
 			PEntry("when Machines need updates", &reconcileStatusTableInput{
 				cpms: resourcebuilder.ControlPlaneMachineSet().WithGeneration(2).Build(),
-				machineInfos: []machineproviders.MachineInfo{
-					healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build(),
-					healthyMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").WithNeedsUpdate(true).Build(),
-					healthyMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("node-2").WithNeedsUpdate(true).Build(),
+				machineInfos: map[int32][]machineproviders.MachineInfo{
+					0: {healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build()},
+					1: {healthyMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").WithNeedsUpdate(true).Build()},
+					2: {healthyMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("node-2").WithNeedsUpdate(true).Build()},
 				},
 				expectedError: nil,
 				expectedStatus: machinev1.ControlPlaneMachineSetStatus{
@@ -299,12 +299,16 @@ var _ = Describe("Status", func() {
 			}),
 			PEntry("with pending replacement replicas", &reconcileStatusTableInput{
 				cpms: resourcebuilder.ControlPlaneMachineSet().WithGeneration(3).Build(),
-				machineInfos: []machineproviders.MachineInfo{
-					healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build(),
-					healthyMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").WithNeedsUpdate(true).Build(),
-					healthyMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("node-2").WithNeedsUpdate(true).Build(),
-					pendingMachineBuilder.WithIndex(1).WithMachineName("machine-replacement-1").Build(),
-					pendingMachineBuilder.WithIndex(2).WithMachineName("machine-replacement-2").Build(),
+				machineInfos: map[int32][]machineproviders.MachineInfo{
+					0: {healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build()},
+					1: {
+						healthyMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").WithNeedsUpdate(true).Build(),
+						pendingMachineBuilder.WithIndex(1).WithMachineName("machine-replacement-1").Build(),
+					},
+					2: {
+						healthyMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("node-2").WithNeedsUpdate(true).Build(),
+						pendingMachineBuilder.WithIndex(2).WithMachineName("machine-replacement-2").Build(),
+					},
 				},
 				expectedError: nil,
 				expectedStatus: machinev1.ControlPlaneMachineSetStatus{
@@ -351,12 +355,16 @@ var _ = Describe("Status", func() {
 			}),
 			PEntry("with ready replacement replicas", &reconcileStatusTableInput{
 				cpms: resourcebuilder.ControlPlaneMachineSet().WithGeneration(4).Build(),
-				machineInfos: []machineproviders.MachineInfo{
-					healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build(),
-					healthyMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").WithNeedsUpdate(true).Build(),
-					healthyMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("node-2").WithNeedsUpdate(true).Build(),
-					healthyMachineBuilder.WithIndex(1).WithMachineName("machine-replacement-1").WithNodeName("node-replacement-1").Build(),
-					healthyMachineBuilder.WithIndex(2).WithMachineName("machine-replacement-2").WithNodeName("node-replacement-2").Build(),
+				machineInfos: map[int32][]machineproviders.MachineInfo{
+					0: {healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build()},
+					1: {
+						healthyMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").WithNeedsUpdate(true).Build(),
+						healthyMachineBuilder.WithIndex(1).WithMachineName("machine-replacement-1").WithNodeName("node-replacement-1").Build(),
+					},
+					2: {
+						healthyMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("node-2").WithNeedsUpdate(true).Build(),
+						healthyMachineBuilder.WithIndex(2).WithMachineName("machine-replacement-2").WithNodeName("node-replacement-2").Build(),
+					},
 				},
 				expectedError: nil,
 				expectedStatus: machinev1.ControlPlaneMachineSetStatus{
@@ -403,10 +411,10 @@ var _ = Describe("Status", func() {
 			}),
 			PEntry("with no managed Nodes", &reconcileStatusTableInput{
 				cpms: resourcebuilder.ControlPlaneMachineSet().WithGeneration(5).Build(),
-				machineInfos: []machineproviders.MachineInfo{
-					missingMachineBuilder.WithIndex(0).WithNodeName("node-0").Build(),
-					missingMachineBuilder.WithIndex(1).WithNodeName("node-1").Build(),
-					missingMachineBuilder.WithIndex(2).WithNodeName("node-2").Build(),
+				machineInfos: map[int32][]machineproviders.MachineInfo{
+					0: {missingMachineBuilder.WithIndex(0).WithNodeName("node-0").Build()},
+					1: {missingMachineBuilder.WithIndex(1).WithNodeName("node-1").Build()},
+					2: {missingMachineBuilder.WithIndex(2).WithNodeName("node-2").Build()},
 				},
 				expectedError: errors.New("found unmanaged control plane nodes, the following node(s) do not have associated machines: node-0, node-1, node-2"),
 				expectedStatus: machinev1.ControlPlaneMachineSetStatus{
@@ -450,10 +458,10 @@ var _ = Describe("Status", func() {
 			}),
 			PEntry("with an unmanaged Node", &reconcileStatusTableInput{
 				cpms: resourcebuilder.ControlPlaneMachineSet().WithGeneration(6).Build(),
-				machineInfos: []machineproviders.MachineInfo{
-					healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build(),
-					healthyMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").Build(),
-					missingMachineBuilder.WithIndex(2).WithNodeName("node-2").Build(),
+				machineInfos: map[int32][]machineproviders.MachineInfo{
+					0: {healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build()},
+					1: {healthyMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").Build()},
+					2: {missingMachineBuilder.WithIndex(2).WithNodeName("node-2").Build()},
 				},
 				expectedError: errors.New("found unmanaged control plane nodes, the following node(s) do not have associated machines: node-2"),
 				expectedStatus: machinev1.ControlPlaneMachineSetStatus{
@@ -497,10 +505,10 @@ var _ = Describe("Status", func() {
 			}),
 			PEntry("with an unhealthy Machine", &reconcileStatusTableInput{
 				cpms: resourcebuilder.ControlPlaneMachineSet().WithGeneration(7).Build(),
-				machineInfos: []machineproviders.MachineInfo{
-					healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build(),
-					healthyMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").Build(),
-					missingNodeBuilder.WithIndex(2).WithMachineName("machine-2").Build(),
+				machineInfos: map[int32][]machineproviders.MachineInfo{
+					0: {healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build()},
+					1: {healthyMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").Build()},
+					2: {missingNodeBuilder.WithIndex(2).WithMachineName("machine-2").Build()},
 				},
 				expectedError: nil,
 				expectedStatus: machinev1.ControlPlaneMachineSetStatus{
@@ -548,12 +556,16 @@ var _ = Describe("Status", func() {
 			}),
 			PEntry("with an unhealthy index (failure domain)", &reconcileStatusTableInput{
 				cpms: resourcebuilder.ControlPlaneMachineSet().WithGeneration(8).Build(),
-				machineInfos: []machineproviders.MachineInfo{
-					healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build(),
-					healthyMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").WithNeedsUpdate(true).Build(),
-					missingNodeBuilder.WithIndex(2).WithMachineName("machine-2").WithNeedsUpdate(true).Build(),
-					healthyMachineBuilder.WithIndex(1).WithMachineName("machine-replacement-1").WithNodeName("node-replacement-1").Build(),
-					missingNodeBuilder.WithIndex(2).WithMachineName("machine-replacement-2").Build(),
+				machineInfos: map[int32][]machineproviders.MachineInfo{
+					0: {healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build()},
+					1: {
+						healthyMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").WithNeedsUpdate(true).Build(),
+						healthyMachineBuilder.WithIndex(1).WithMachineName("machine-replacement-1").WithNodeName("node-replacement-1").Build(),
+					},
+					2: {
+						missingNodeBuilder.WithIndex(2).WithMachineName("machine-2").WithNeedsUpdate(true).Build(),
+						missingNodeBuilder.WithIndex(2).WithMachineName("machine-replacement-2").Build(),
+					},
 				},
 				expectedError: nil,
 				expectedStatus: machinev1.ControlPlaneMachineSetStatus{
@@ -599,12 +611,12 @@ var _ = Describe("Status", func() {
 					},
 				},
 			}),
-			PEntry("with a missing index", &reconcileStatusTableInput{
+			PEntry("with an empty index", &reconcileStatusTableInput{
 				cpms: resourcebuilder.ControlPlaneMachineSet().WithGeneration(9).Build(),
-				machineInfos: []machineproviders.MachineInfo{
-					healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build(),
-					healthyMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").Build(),
-					resourcebuilder.MachineInfo().WithIndex(2).Build(),
+				machineInfos: map[int32][]machineproviders.MachineInfo{
+					0: {healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build()},
+					1: {healthyMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").Build()},
+					2: {},
 				},
 				expectedError: nil,
 				expectedStatus: machinev1.ControlPlaneMachineSetStatus{

--- a/pkg/test/resourcebuilder/node.go
+++ b/pkg/test/resourcebuilder/node.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcebuilder
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	masterNodeRoleLabel = "node-role.kubernetes.io/master"
+	workerNodeRoleLabel = "node-role.kubernetes.io/worker"
+)
+
+// Node creates a new node builder.
+func Node() NodeBuilder {
+	return NodeBuilder{}
+}
+
+// NodeBuilder is used to build out a node object.
+type NodeBuilder struct {
+	generateName string
+	name         string
+	labels       map[string]string
+}
+
+// Build builds a new node based on the configuration provided.
+func (m NodeBuilder) Build() *corev1.Node {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: m.generateName,
+			Name:         m.name,
+			Labels:       m.labels,
+		},
+	}
+
+	return node
+}
+
+// AsWorker sets the worker role on the node labels for the node builder.
+func (m NodeBuilder) AsWorker() NodeBuilder {
+	return m.WithLabel(workerNodeRoleLabel, "")
+}
+
+// AsMaster sets the master role on the node labels for the node builder.
+func (m NodeBuilder) AsMaster() NodeBuilder {
+	return m.WithLabel(masterNodeRoleLabel, "")
+}
+
+// WithGenerateName sets the generateName for the node builder.
+func (m NodeBuilder) WithGenerateName(generateName string) NodeBuilder {
+	m.generateName = generateName
+	return m
+}
+
+// WithLabel sets the labels for the node builder.
+func (m NodeBuilder) WithLabel(key, value string) NodeBuilder {
+	if m.labels == nil {
+		m.labels = make(map[string]string)
+	}
+
+	m.labels[key] = value
+
+	return m
+}
+
+// WithLabels sets the labels for the node builder.
+func (m NodeBuilder) WithLabels(labels map[string]string) NodeBuilder {
+	m.labels = labels
+	return m
+}
+
+// WithName sets the name for the node builder.
+func (m NodeBuilder) WithName(name string) NodeBuilder {
+	m.name = name
+	return m
+}


### PR DESCRIPTION
The first few commits in this PR are mainly refactor (and I recommend reviewing commit wise).

The main point of this PR is that there are a couple of scenarios (no ready machines, unmanaged control plane nodes) that should cause the operator to go degraded, we need to make sure this is accounted for.

This PR adds the skeleton for this and then adds tests to ensure the appropriate conditions are set given the scenarios 