### PR TITLE
Bug 2098508: Resolve panics and fix webhooks and logs and watches

### DIFF
--- a/cmd/control-plane-machine-set-operator/main.go
+++ b/cmd/control-plane-machine-set-operator/main.go
@@ -27,9 +27,10 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/klogr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	cpmscontroller "github.com/openshift/cluster-control-plane-machine-set-operator/pkg/controllers/controlplanemachineset"
 	cpmswebhook "github.com/openshift/cluster-control-plane-machine-set-operator/pkg/webhooks/controlplanemachineset"
@@ -62,13 +63,10 @@ func main() { //nolint:funlen
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 
-	opts := zap.Options{
-		Development: true,
-	}
-	opts.BindFlags(flag.CommandLine)
+	klog.InitFlags(flag.CommandLine)
 	flag.Parse()
 
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+	ctrl.SetLogger(klogr.New())
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,

--- a/go.mod
+++ b/go.mod
@@ -220,6 +220,6 @@ require (
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/openshift/library-go v0.0.0-20220419144511-5b7d3d77b85e
 	golang.org/x/net v0.0.0-20220403103023-749bd193bc2b // indirect
-	k8s.io/klog/v2 v2.60.1 // indirect
+	k8s.io/klog/v2 v2.60.1
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect
 )

--- a/manifests/0000_31_control-plane-machine-set-operator_01_rbac.yaml
+++ b/manifests/0000_31_control-plane-machine-set-operator_01_rbac.yaml
@@ -57,6 +57,7 @@ rules:
       - get
       - update
       - list
+      - watch
 
   - apiGroups:
       - ""

--- a/manifests/0000_31_control-plane-machine-set-operator_03_deployment.yaml
+++ b/manifests/0000_31_control-plane-machine-set-operator_03_deployment.yaml
@@ -27,6 +27,8 @@ spec:
         image: quay.io/origin/origin-control-plane-machine-set-operator
         command:
         - "/manager"
+        args:
+        - "-v=2"
         env:
         - name: RELEASE_VERSION
           value: "0.0.1-snapshot"

--- a/manifests/0000_31_control-plane-machine-set-operator_03_deployment.yaml
+++ b/manifests/0000_31_control-plane-machine-set-operator_03_deployment.yaml
@@ -35,6 +35,9 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
+        ports:
+        - name: https
+          containerPort: 9443
         resources:
           requests:
             cpu: 10m
@@ -53,4 +56,4 @@ spec:
       - name: control-plane-machine-set-operator-tls
         secret:
           defaultMode: 420
-          secretName: machine-api-operator-tls
+          secretName: control-plane-machine-set-operator-tls

--- a/manifests/0000_31_control-plane-machine-set-operator_05_service.yaml
+++ b/manifests/0000_31_control-plane-machine-set-operator_05_service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: control-plane-machine-set-operator
+  namespace: openshift-machine-api
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    service.alpha.openshift.io/serving-cert-secret-name: control-plane-machine-set-operator-tls
+  labels:
+    k8s-app: control-plane-machine-set-operator
+spec:
+  type: ClusterIP
+  ports:
+  - name: https
+    port: 9443
+    targetPort: https
+  selector:
+    k8s-app: control-plane-machine-set-operator
+  sessionAffinity: None

--- a/manifests/0000_31_control-plane-machine-set-operator_06_webhook.yaml
+++ b/manifests/0000_31_control-plane-machine-set-operator_06_webhook.yaml
@@ -1,0 +1,30 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: controlplanemachineset.machine.openshift.io
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    service.beta.openshift.io/inject-cabundle: "true"
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: control-plane-machine-set-operator
+      namespace: openshift-machine-api
+      path: /validate-machine-openshift-io-v1-controlplanemachineset
+      port: 9443
+  failurePolicy: Fail
+  name: controlplanemachineset.machine.openshift.io
+  rules:
+  - apiGroups:
+    - machine.openshift.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - controlplanemachinesets
+  sideEffects: None

--- a/pkg/controllers/controlplanemachineset/cluster_operator.go
+++ b/pkg/controllers/controlplanemachineset/cluster_operator.go
@@ -133,10 +133,10 @@ func (r *ControlPlaneMachineSetReconciler) patchClusterOperatorConditions(ctx co
 
 	logger.V(4).Info(
 		"Syncing cluster operator status",
-		"available", string(v1helpers.FindStatusCondition(conds, configv1.OperatorAvailable).Status),
-		"progressing", string(v1helpers.FindStatusCondition(conds, configv1.OperatorProgressing).Status),
-		"degraded", string(v1helpers.FindStatusCondition(conds, configv1.OperatorDegraded).Status),
-		"upgradable", string(v1helpers.FindStatusCondition(conds, configv1.OperatorUpgradeable).Status),
+		"available", getStatusForConditionType(co.Status.Conditions, configv1.OperatorAvailable),
+		"progressing", getStatusForConditionType(co.Status.Conditions, configv1.OperatorProgressing),
+		"degraded", getStatusForConditionType(co.Status.Conditions, configv1.OperatorDegraded),
+		"upgradable", getStatusForConditionType(co.Status.Conditions, configv1.OperatorUpgradeable),
 	)
 
 	return nil
@@ -151,4 +151,14 @@ func isStatusConditionPresentAndEqual(conditions []configv1.ClusterOperatorStatu
 	}
 
 	return false
+}
+
+// getStatusForConditionType returns as a string the status of the condition of the given type if present.
+// If no condition of that type exists, it returns unknown for the status.
+func getStatusForConditionType(conds []configv1.ClusterOperatorStatusCondition, conditionType configv1.ClusterStatusConditionType) string {
+	if status := v1helpers.FindStatusCondition(conds, conditionType); status != nil {
+		return string(status.Status)
+	}
+
+	return string(configv1.ConditionUnknown)
 }

--- a/pkg/controllers/controlplanemachineset/controller.go
+++ b/pkg/controllers/controlplanemachineset/controller.go
@@ -37,6 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
@@ -81,6 +82,12 @@ func (r *ControlPlaneMachineSetReconciler) SetupWithManager(mgr ctrl.Manager) er
 			handler.EnqueueRequestsFromMapFunc(clusterOperatorToControlPlaneMachineSet(r.Namespace)),
 			builder.WithPredicates(filterClusterOperator(r.OperatorName)),
 		).
+		// Override the default log constructor as it makes the logs very chatty.
+		WithLogConstructor(func(req *reconcile.Request) logr.Logger {
+			return mgr.GetLogger().WithValues(
+				"controller", "controlplanemachineset",
+			)
+		}).
 		Complete(r); err != nil {
 		return fmt.Errorf("could not set up controller for control plane machine set: %w", err)
 	}

--- a/pkg/controllers/controlplanemachineset/controller_test.go
+++ b/pkg/controllers/controlplanemachineset/controller_test.go
@@ -65,6 +65,7 @@ var _ = Describe("With a running controller", func() {
 		Expect(err).ToNot(HaveOccurred(), "Manager should be able to be created")
 
 		reconciler := &ControlPlaneMachineSetReconciler{
+			Client:       mgr.GetClient(),
 			Namespace:    namespaceName,
 			OperatorName: operatorName,
 		}

--- a/vendor/k8s.io/klog/v2/klogr/README.md
+++ b/vendor/k8s.io/klog/v2/klogr/README.md
@@ -1,0 +1,19 @@
+# Minimal Go logging using klog
+
+This package implements the [logr interface](https://github.com/go-logr/logr)
+in terms of Kubernetes' [klog](https://github.com/kubernetes/klog).  This
+provides a relatively minimalist API to logging in Go, backed by a well-proven
+implementation.
+
+Because klogr was implemented before klog itself added supported for
+structured logging, the default in klogr is to serialize key/value
+pairs with JSON and log the result as text messages via klog. This
+does not work well when klog itself forwards output to a structured
+logger.
+
+Therefore the recommended approach is to let klogr pass all log
+messages through to klog and deal with structured logging there. Just
+beware that the output of klog without a structured logger is meant to
+be human-readable, in contrast to the JSON-based traditional format.
+
+This is a BETA grade implementation.

--- a/vendor/k8s.io/klog/v2/klogr/klogr.go
+++ b/vendor/k8s.io/klog/v2/klogr/klogr.go
@@ -1,0 +1,183 @@
+// Package klogr implements github.com/go-logr/logr.Logger in terms of
+// k8s.io/klog.
+package klogr
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/go-logr/logr"
+
+	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/internal/serialize"
+)
+
+// Option is a functional option that reconfigures the logger created with New.
+type Option func(*klogger)
+
+// Format defines how log output is produced.
+type Format string
+
+const (
+	// FormatSerialize tells klogr to turn key/value pairs into text itself
+	// before invoking klog.
+	FormatSerialize Format = "Serialize"
+
+	// FormatKlog tells klogr to pass all text messages and key/value pairs
+	// directly to klog. Klog itself then serializes in a human-readable
+	// format and optionally passes on to a structure logging backend.
+	FormatKlog Format = "Klog"
+)
+
+// WithFormat selects the output format.
+func WithFormat(format Format) Option {
+	return func(l *klogger) {
+		l.format = format
+	}
+}
+
+// New returns a logr.Logger which serializes output itself
+// and writes it via klog.
+func New() logr.Logger {
+	return NewWithOptions(WithFormat(FormatSerialize))
+}
+
+// NewWithOptions returns a logr.Logger which serializes as determined
+// by the WithFormat option and writes via klog. The default is
+// FormatKlog.
+func NewWithOptions(options ...Option) logr.Logger {
+	l := klogger{
+		level:  0,
+		prefix: "",
+		values: nil,
+		format: FormatKlog,
+	}
+	for _, option := range options {
+		option(&l)
+	}
+	return logr.New(&l)
+}
+
+type klogger struct {
+	level     int
+	callDepth int
+	prefix    string
+	values    []interface{}
+	format    Format
+}
+
+func (l *klogger) Init(info logr.RuntimeInfo) {
+	l.callDepth += info.CallDepth
+}
+
+func flatten(kvList ...interface{}) string {
+	keys := make([]string, 0, len(kvList))
+	vals := make(map[string]interface{}, len(kvList))
+	for i := 0; i < len(kvList); i += 2 {
+		k, ok := kvList[i].(string)
+		if !ok {
+			panic(fmt.Sprintf("key is not a string: %s", pretty(kvList[i])))
+		}
+		var v interface{}
+		if i+1 < len(kvList) {
+			v = kvList[i+1]
+		}
+		keys = append(keys, k)
+		vals[k] = v
+	}
+	sort.Strings(keys)
+	buf := bytes.Buffer{}
+	for i, k := range keys {
+		v := vals[k]
+		if i > 0 {
+			buf.WriteRune(' ')
+		}
+		buf.WriteString(pretty(k))
+		buf.WriteString("=")
+		buf.WriteString(pretty(v))
+	}
+	return buf.String()
+}
+
+func pretty(value interface{}) string {
+	if err, ok := value.(error); ok {
+		if _, ok := value.(json.Marshaler); !ok {
+			value = err.Error()
+		}
+	}
+	buffer := &bytes.Buffer{}
+	encoder := json.NewEncoder(buffer)
+	encoder.SetEscapeHTML(false)
+	encoder.Encode(value)
+	return strings.TrimSpace(string(buffer.Bytes()))
+}
+
+func (l klogger) Info(level int, msg string, kvList ...interface{}) {
+	switch l.format {
+	case FormatSerialize:
+		msgStr := flatten("msg", msg)
+		trimmed := serialize.TrimDuplicates(l.values, kvList)
+		fixedStr := flatten(trimmed[0]...)
+		userStr := flatten(trimmed[1]...)
+		klog.V(klog.Level(level)).InfoDepth(l.callDepth+1, l.prefix, " ", msgStr, " ", fixedStr, " ", userStr)
+	case FormatKlog:
+		trimmed := serialize.TrimDuplicates(l.values, kvList)
+		if l.prefix != "" {
+			msg = l.prefix + ": " + msg
+		}
+		klog.V(klog.Level(level)).InfoSDepth(l.callDepth+1, msg, append(trimmed[0], trimmed[1]...)...)
+	}
+}
+
+func (l klogger) Enabled(level int) bool {
+	return klog.V(klog.Level(level)).Enabled()
+}
+
+func (l klogger) Error(err error, msg string, kvList ...interface{}) {
+	msgStr := flatten("msg", msg)
+	var loggableErr interface{}
+	if err != nil {
+		loggableErr = serialize.ErrorToString(err)
+	}
+	switch l.format {
+	case FormatSerialize:
+		errStr := flatten("error", loggableErr)
+		trimmed := serialize.TrimDuplicates(l.values, kvList)
+		fixedStr := flatten(trimmed[0]...)
+		userStr := flatten(trimmed[1]...)
+		klog.ErrorDepth(l.callDepth+1, l.prefix, " ", msgStr, " ", errStr, " ", fixedStr, " ", userStr)
+	case FormatKlog:
+		trimmed := serialize.TrimDuplicates(l.values, kvList)
+		if l.prefix != "" {
+			msg = l.prefix + ": " + msg
+		}
+		klog.ErrorSDepth(l.callDepth+1, err, msg, append(trimmed[0], trimmed[1]...)...)
+	}
+}
+
+// WithName returns a new logr.Logger with the specified name appended.  klogr
+// uses '/' characters to separate name elements.  Callers should not pass '/'
+// in the provided name string, but this library does not actually enforce that.
+func (l klogger) WithName(name string) logr.LogSink {
+	if len(l.prefix) > 0 {
+		l.prefix = l.prefix + "/"
+	}
+	l.prefix += name
+	return &l
+}
+
+func (l klogger) WithValues(kvList ...interface{}) logr.LogSink {
+	l.values = serialize.WithValues(l.values, kvList)
+	return &l
+}
+
+func (l klogger) WithCallDepth(depth int) logr.LogSink {
+	l.callDepth += depth
+	return &l
+}
+
+var _ logr.LogSink = &klogger{}
+var _ logr.CallDepthLogSink = &klogger{}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1182,6 +1182,7 @@ k8s.io/klog/v2/internal/buffer
 k8s.io/klog/v2/internal/clock
 k8s.io/klog/v2/internal/serialize
 k8s.io/klog/v2/internal/severity
+k8s.io/klog/v2/klogr
 # k8s.io/kube-openapi v0.0.0-20220328201542-3ee0da9b0b42
 ## explicit; go 1.16
 k8s.io/kube-openapi/pkg/builder3/util


### PR DESCRIPTION
I spent a little time on friday investigating whythe controller was panicking and then attempted to pre verify the webhooks.
It turned out that the panic was due to conditions not existing so I've fixed that in commit 1. Then the webhooks weren't working because we didn't have a ValidatingWebhookConfiguration, commit 2.

On top of this, I noticed the logging was particularly chatty and not in the normal klog format, so I've switched the logging over and used a custom log builder func so that we don't add lots of additional unnecessary context from controller-runtime (eg it adds information about the GVK, we know what that will be already).

Finally, we were missing the watch permission for the clusteroperator resource, so the watches were failing. 

This PR should now make the operator behaviour verifiable, in particular in preparation for the webhooks to be validated.