### PR TITLE
Refactor table tests to use cpmsBuilder, stick to camelCase log key convention

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -53,10 +53,10 @@ consistent and follow the following guidelines:
     messages
 * Loggers are scoped to a particular action and should not be embedded in an object, pass them as a variable
   * This allows you to add context which can be added to future log lines
-  * Eg. When logs refer to an update strategy, we expect all logs to contain a key `UpdateStrategy` and the value set to
+  * Eg. When logs refer to an update strategy, we expect all logs to contain a key `updateStrategy` and the value set to
     the update strategy type. This can be achieved by creating a child logger when the update strategy is determined
     ```golang
-    logger = logger.WithValues("UpdateStrategy", cpms.Spec.Strategy.Type)
+    logger = logger.WithValues("updateStrategy", cpms.Spec.Strategy.Type)
     ```
 * Logger keys and values should be lowerCamelCase (as per [Kubernetes Guidelines](https://github.com/kubernetes/community/blob/HEAD/contributors/devel/sig-instrumentation/migration-to-structured-logging.md#name-arguments))
 

--- a/pkg/controllers/controlplanemachineset/cluster_operator_test.go
+++ b/pkg/controllers/controlplanemachineset/cluster_operator_test.go
@@ -217,7 +217,7 @@ var _ = Describe("Cluster Operator Status", func() {
 
 	Context("updateClusterOperatorStatus", func() {
 		type updateClusterOperatorStatusTableInput struct {
-			cpmsBuilder        resourcebuilder.ControlPlaneMachineSetBuilder
+			cpmsBuilder        resourcebuilder.ControlPlaneMachineSetInterface
 			expectedConditions []configv1.ClusterOperatorStatusCondition
 			expectedError      error
 			expectedLogs       []test.LogEntry

--- a/pkg/controllers/controlplanemachineset/cluster_operator_test.go
+++ b/pkg/controllers/controlplanemachineset/cluster_operator_test.go
@@ -217,16 +217,18 @@ var _ = Describe("Cluster Operator Status", func() {
 
 	Context("updateClusterOperatorStatus", func() {
 		type updateClusterOperatorStatusTableInput struct {
-			cpms               *machinev1.ControlPlaneMachineSet
+			cpmsBuilder        resourcebuilder.ControlPlaneMachineSetBuilder
 			expectedConditions []configv1.ClusterOperatorStatusCondition
 			expectedError      error
 			expectedLogs       []test.LogEntry
 		}
 
 		DescribeTable("should update the cluster operator status based on the ControlPlaneMachineSet conditions", func(in updateClusterOperatorStatusTableInput) {
-			originalCPMS := in.cpms.DeepCopy()
+			// originalCPMS := in.cpms.DeepCopy()
+			cpms := in.cpmsBuilder.Build()
+			originalCPMS := cpms.DeepCopy()
 
-			err := reconciler.updateClusterOperatorStatus(ctx, logger.Logger(), in.cpms)
+			err := reconciler.updateClusterOperatorStatus(ctx, logger.Logger(), cpms)
 			if in.expectedError != nil {
 				Expect(err).To(MatchError(in.expectedError))
 				return
@@ -236,10 +238,10 @@ var _ = Describe("Cluster Operator Status", func() {
 
 			Eventually(komega.Object(co)).Should(HaveField("Status.Conditions", test.MatchClusterOperatorStatusConditions(in.expectedConditions)))
 			Expect(logger.Entries()).To(ConsistOf(in.expectedLogs))
-			Expect(in.cpms).To(Equal(originalCPMS), "The update functions should not modify the ControlPlaneMachineSet in any way")
+			Expect(cpms).To(Equal(originalCPMS), "The update functions should not modify the ControlPlaneMachineSet in any way")
 		},
 			Entry("with an available control plane machine set", updateClusterOperatorStatusTableInput{
-				cpms: cpmsBuilder.WithConditions([]metav1.Condition{statusConditionAvailable, statusConditionNotProgressing, statusConditionNotDegraded}).Build(),
+				cpmsBuilder: cpmsBuilder.WithConditions([]metav1.Condition{statusConditionAvailable, statusConditionNotProgressing, statusConditionNotDegraded}),
 				expectedConditions: []configv1.ClusterOperatorStatusCondition{
 					{
 						Type:    configv1.OperatorAvailable,
@@ -278,7 +280,7 @@ var _ = Describe("Cluster Operator Status", func() {
 				},
 			}),
 			Entry("with a degraded control plane machine set", updateClusterOperatorStatusTableInput{
-				cpms: cpmsBuilder.WithConditions([]metav1.Condition{statusConditionNotAvailable, statusConditionNotProgressing, statusConditionDegraded}).Build(),
+				cpmsBuilder: cpmsBuilder.WithConditions([]metav1.Condition{statusConditionNotAvailable, statusConditionNotProgressing, statusConditionDegraded}),
 				expectedConditions: []configv1.ClusterOperatorStatusCondition{
 					{
 						Type:    configv1.OperatorAvailable,
@@ -318,7 +320,7 @@ var _ = Describe("Cluster Operator Status", func() {
 				},
 			}),
 			Entry("with a progressing control plane machine set", updateClusterOperatorStatusTableInput{
-				cpms: cpmsBuilder.WithConditions([]metav1.Condition{statusConditionNotAvailable, statusConditionProgressing, statusConditionNotDegraded}).Build(),
+				cpmsBuilder: cpmsBuilder.WithConditions([]metav1.Condition{statusConditionNotAvailable, statusConditionProgressing, statusConditionNotDegraded}),
 				expectedConditions: []configv1.ClusterOperatorStatusCondition{
 					{
 						Type:    configv1.OperatorAvailable,

--- a/pkg/controllers/controlplanemachineset/cluster_operator_test.go
+++ b/pkg/controllers/controlplanemachineset/cluster_operator_test.go
@@ -224,7 +224,6 @@ var _ = Describe("Cluster Operator Status", func() {
 		}
 
 		DescribeTable("should update the cluster operator status based on the ControlPlaneMachineSet conditions", func(in updateClusterOperatorStatusTableInput) {
-			// originalCPMS := in.cpms.DeepCopy()
 			cpms := in.cpmsBuilder.Build()
 			originalCPMS := cpms.DeepCopy()
 

--- a/pkg/controllers/controlplanemachineset/status_test.go
+++ b/pkg/controllers/controlplanemachineset/status_test.go
@@ -145,7 +145,7 @@ var _ = Describe("Status", func() {
 
 	Context("reconcileStatusWithMachineInfo", func() {
 		type reconcileStatusTableInput struct {
-			cpmsBuilder    resourcebuilder.ControlPlaneMachineSetBuilder
+			cpmsBuilder    resourcebuilder.ControlPlaneMachineSetInterface
 			machineInfos   map[int32][]machineproviders.MachineInfo
 			expectedError  error
 			expectedStatus machinev1.ControlPlaneMachineSetStatus

--- a/pkg/controllers/controlplanemachineset/status_test.go
+++ b/pkg/controllers/controlplanemachineset/status_test.go
@@ -145,7 +145,7 @@ var _ = Describe("Status", func() {
 
 	Context("reconcileStatusWithMachineInfo", func() {
 		type reconcileStatusTableInput struct {
-			cpms           *machinev1.ControlPlaneMachineSet
+			cpmsBuilder    resourcebuilder.ControlPlaneMachineSetBuilder
 			machineInfos   map[int32][]machineproviders.MachineInfo
 			expectedError  error
 			expectedStatus machinev1.ControlPlaneMachineSetStatus
@@ -174,7 +174,7 @@ var _ = Describe("Status", func() {
 
 		DescribeTable("correctly sets the status based on the machine info", func(in *reconcileStatusTableInput) {
 			logger := test.NewTestLogger()
-			cpms := in.cpms.DeepCopy()
+			cpms := in.cpmsBuilder.Build()
 
 			err := reconcileStatusWithMachineInfo(logger.Logger(), cpms, in.machineInfos)
 			if in.expectedError != nil {
@@ -192,7 +192,7 @@ var _ = Describe("Status", func() {
 			Expect(cpms.Status.UnavailableReplicas).To(Equal(in.expectedStatus.UnavailableReplicas))
 		},
 			PEntry("with up to date Machines", &reconcileStatusTableInput{
-				cpms: resourcebuilder.ControlPlaneMachineSet().WithGeneration(1).Build(),
+				cpmsBuilder: resourcebuilder.ControlPlaneMachineSet().WithGeneration(1),
 				machineInfos: map[int32][]machineproviders.MachineInfo{
 					0: {healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build()},
 					1: {healthyMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").Build()},
@@ -241,7 +241,7 @@ var _ = Describe("Status", func() {
 				},
 			}),
 			PEntry("when Machines need updates", &reconcileStatusTableInput{
-				cpms: resourcebuilder.ControlPlaneMachineSet().WithGeneration(2).Build(),
+				cpmsBuilder: resourcebuilder.ControlPlaneMachineSet().WithGeneration(2),
 				machineInfos: map[int32][]machineproviders.MachineInfo{
 					0: {healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build()},
 					1: {healthyMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").WithNeedsUpdate(true).Build()},
@@ -291,7 +291,7 @@ var _ = Describe("Status", func() {
 				},
 			}),
 			PEntry("with pending replacement replicas", &reconcileStatusTableInput{
-				cpms: resourcebuilder.ControlPlaneMachineSet().WithGeneration(3).Build(),
+				cpmsBuilder: resourcebuilder.ControlPlaneMachineSet().WithGeneration(3),
 				machineInfos: map[int32][]machineproviders.MachineInfo{
 					0: {healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build()},
 					1: {
@@ -347,7 +347,7 @@ var _ = Describe("Status", func() {
 				},
 			}),
 			PEntry("with ready replacement replicas", &reconcileStatusTableInput{
-				cpms: resourcebuilder.ControlPlaneMachineSet().WithGeneration(4).Build(),
+				cpmsBuilder: resourcebuilder.ControlPlaneMachineSet().WithGeneration(4),
 				machineInfos: map[int32][]machineproviders.MachineInfo{
 					0: {healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build()},
 					1: {
@@ -403,7 +403,7 @@ var _ = Describe("Status", func() {
 				},
 			}),
 			PEntry("with no MachineInfos", &reconcileStatusTableInput{
-				cpms: resourcebuilder.ControlPlaneMachineSet().WithGeneration(5).Build(),
+				cpmsBuilder: resourcebuilder.ControlPlaneMachineSet().WithGeneration(5),
 				machineInfos: map[int32][]machineproviders.MachineInfo{
 					0: {},
 					1: {},
@@ -454,7 +454,7 @@ var _ = Describe("Status", func() {
 				},
 			}),
 			PEntry("with an unhealthy Machine", &reconcileStatusTableInput{
-				cpms: resourcebuilder.ControlPlaneMachineSet().WithGeneration(7).Build(),
+				cpmsBuilder: resourcebuilder.ControlPlaneMachineSet().WithGeneration(7),
 				machineInfos: map[int32][]machineproviders.MachineInfo{
 					0: {healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build()},
 					1: {healthyMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").Build()},
@@ -505,7 +505,7 @@ var _ = Describe("Status", func() {
 				},
 			}),
 			PEntry("with an unhealthy index (failure domain)", &reconcileStatusTableInput{
-				cpms: resourcebuilder.ControlPlaneMachineSet().WithGeneration(8).Build(),
+				cpmsBuilder: resourcebuilder.ControlPlaneMachineSet().WithGeneration(8),
 				machineInfos: map[int32][]machineproviders.MachineInfo{
 					0: {healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build()},
 					1: {
@@ -562,7 +562,7 @@ var _ = Describe("Status", func() {
 				},
 			}),
 			PEntry("with an empty index", &reconcileStatusTableInput{
-				cpms: resourcebuilder.ControlPlaneMachineSet().WithGeneration(9).Build(),
+				cpmsBuilder: resourcebuilder.ControlPlaneMachineSet().WithGeneration(9),
 				machineInfos: map[int32][]machineproviders.MachineInfo{
 					0: {healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build()},
 					1: {healthyMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").Build()},

--- a/pkg/controllers/controlplanemachineset/updates_test.go
+++ b/pkg/controllers/controlplanemachineset/updates_test.go
@@ -92,7 +92,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 		})
 
 		type rollingUpdateTableInput struct {
-			cpmsBuilder    resourcebuilder.ControlPlaneMachineSetBuilder
+			cpmsBuilder    resourcebuilder.ControlPlaneMachineSetInterface
 			machineInfos   map[int32][]machineproviders.MachineInfo
 			setupMock      func()
 			expectedError  error
@@ -522,7 +522,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 		})
 
 		type onDeleteUpdateTableInput struct {
-			cpmsBuilder    resourcebuilder.ControlPlaneMachineSetBuilder
+			cpmsBuilder    resourcebuilder.ControlPlaneMachineSetInterface
 			machineInfos   map[int32][]machineproviders.MachineInfo
 			setupMock      func()
 			expectedError  error

--- a/pkg/controllers/controlplanemachineset/updates_test.go
+++ b/pkg/controllers/controlplanemachineset/updates_test.go
@@ -92,7 +92,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 		})
 
 		type rollingUpdateTableInput struct {
-			cpms           *machinev1.ControlPlaneMachineSet
+			cpmsBuilder    resourcebuilder.ControlPlaneMachineSetBuilder
 			machineInfos   map[int32][]machineproviders.MachineInfo
 			setupMock      func()
 			expectedError  error
@@ -104,9 +104,10 @@ var _ = Describe("reconcileMachineUpdates", func() {
 			// We setup the mock machine provider on each test with the expected assertions.
 			in.setupMock()
 
-			originalCPMS := in.cpms.DeepCopy()
+			cpms := cpmsBuilder.Build()
+			originalCPMS := cpms.DeepCopy()
 
-			result, err := reconciler.reconcileMachineUpdates(ctx, logger.Logger(), in.cpms, mockMachineProvider, in.machineInfos)
+			result, err := reconciler.reconcileMachineUpdates(ctx, logger.Logger(), cpms, mockMachineProvider, in.machineInfos)
 			if in.expectedError != nil {
 				Expect(err).To(MatchError(in.expectedError))
 			} else {
@@ -114,10 +115,10 @@ var _ = Describe("reconcileMachineUpdates", func() {
 			}
 			Expect(result).To(Equal(in.expectedResult))
 			Expect(logger.Entries()).To(ConsistOf(in.expectedLogs))
-			Expect(in.cpms).To(Equal(originalCPMS), "The update functions should not modify the ControlPlaneMachineSet in any way")
+			Expect(cpms).To(Equal(originalCPMS), "The update functions should not modify the ControlPlaneMachineSet in any way")
 		},
 			PEntry("with no updates required", rollingUpdateTableInput{
-				cpms: cpmsBuilder.WithReplicas(3).Build(),
+				cpmsBuilder: cpmsBuilder.WithReplicas(3),
 				machineInfos: map[int32][]machineproviders.MachineInfo{
 					0: {healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build()},
 					1: {healthyMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").Build()},
@@ -138,7 +139,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 				},
 			}),
 			PEntry("with updates required in a single index", rollingUpdateTableInput{
-				cpms: cpmsBuilder.WithReplicas(3).Build(),
+				cpmsBuilder: cpmsBuilder.WithReplicas(3),
 				machineInfos: map[int32][]machineproviders.MachineInfo{
 					0: {healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build()},
 					1: {healthyMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").WithNeedsUpdate(true).Build()},
@@ -162,7 +163,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 				},
 			}),
 			PEntry("with updates required in a single index, and an error occurs", rollingUpdateTableInput{
-				cpms:          cpmsBuilder.WithReplicas(3).Build(),
+				cpmsBuilder:   cpmsBuilder.WithReplicas(3),
 				expectedError: fmt.Errorf("error creating new Machine for index %d: %w", 1, transientError),
 				machineInfos: map[int32][]machineproviders.MachineInfo{
 					0: {healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build()},
@@ -187,7 +188,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 				},
 			}),
 			PEntry("with updates required in a single index, but the replacement machine is pending", rollingUpdateTableInput{
-				cpms: cpmsBuilder.WithReplicas(3).Build(),
+				cpmsBuilder: cpmsBuilder.WithReplicas(3),
 				machineInfos: map[int32][]machineproviders.MachineInfo{
 					0: {healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build()},
 					1: {
@@ -215,7 +216,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 				},
 			}),
 			PEntry("with updates required in a single index, and the replacement machine is ready", rollingUpdateTableInput{
-				cpms: cpmsBuilder.WithReplicas(3).Build(),
+				cpmsBuilder: cpmsBuilder.WithReplicas(3),
 				machineInfos: map[int32][]machineproviders.MachineInfo{
 					0: {healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build()},
 					1: {
@@ -245,7 +246,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 				},
 			}),
 			PEntry("with updates required in a single index, and the replacement machine is ready, and an error occurs", rollingUpdateTableInput{
-				cpms:          cpmsBuilder.WithReplicas(3).Build(),
+				cpmsBuilder:   cpmsBuilder.WithReplicas(3),
 				expectedError: fmt.Errorf("error deleting Machine %s/%s: %w", namespaceName, "machine-1", transientError),
 				machineInfos: map[int32][]machineproviders.MachineInfo{
 					0: {healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build()},
@@ -276,7 +277,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 				},
 			}),
 			PEntry("with updates required in a single index, and the replacement machine is ready, and the old machine is already deleted", rollingUpdateTableInput{
-				cpms: cpmsBuilder.WithReplicas(3).Build(),
+				cpmsBuilder: cpmsBuilder.WithReplicas(3),
 				machineInfos: map[int32][]machineproviders.MachineInfo{
 					0: {healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build()},
 					1: {
@@ -303,7 +304,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 				},
 			}),
 			PEntry("with updates are required in multiple indexes", rollingUpdateTableInput{
-				cpms: cpmsBuilder.WithReplicas(3).Build(),
+				cpmsBuilder: cpmsBuilder.WithReplicas(3),
 				machineInfos: map[int32][]machineproviders.MachineInfo{
 					0: {healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").WithNeedsUpdate(true).Build()},
 					1: {healthyMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").WithNeedsUpdate(true).Build()},
@@ -328,7 +329,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 				},
 			}),
 			PEntry("with updates are required in multiple indexes, but the replacement machine is pending", rollingUpdateTableInput{
-				cpms: cpmsBuilder.WithReplicas(3).Build(),
+				cpmsBuilder: cpmsBuilder.WithReplicas(3),
 				machineInfos: map[int32][]machineproviders.MachineInfo{
 					0: {
 						healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").WithNeedsUpdate(true).Build(),
@@ -357,7 +358,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 				},
 			}),
 			PEntry("with updates are required in multiple indexes, and the replacement machine is ready", rollingUpdateTableInput{
-				cpms: cpmsBuilder.WithReplicas(3).Build(),
+				cpmsBuilder: cpmsBuilder.WithReplicas(3),
 				machineInfos: map[int32][]machineproviders.MachineInfo{
 					0: {
 						healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").WithNeedsUpdate(true).Build(),
@@ -389,7 +390,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 				},
 			}),
 			PEntry("with updates required in multiple indexes, and the replacement machine is ready, and the old machine is already deleted", rollingUpdateTableInput{
-				cpms: cpmsBuilder.WithReplicas(3).Build(),
+				cpmsBuilder: cpmsBuilder.WithReplicas(3),
 				machineInfos: map[int32][]machineproviders.MachineInfo{
 					0: {
 						healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").WithNeedsUpdate(true).WithMachineDeletionTimestamp(metav1.Now()).Build(),
@@ -416,7 +417,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 				},
 			}),
 			PEntry("with an empty index", rollingUpdateTableInput{
-				cpms: cpmsBuilder.WithReplicas(3).Build(),
+				cpmsBuilder: cpmsBuilder.WithReplicas(3),
 				machineInfos: map[int32][]machineproviders.MachineInfo{
 					0: {healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build()},
 					1: {healthyMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").Build()},
@@ -440,7 +441,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 				},
 			}),
 			PEntry("with a pending machine in an index", rollingUpdateTableInput{
-				cpms: cpmsBuilder.WithReplicas(3).Build(),
+				cpmsBuilder: cpmsBuilder.WithReplicas(3),
 				machineInfos: map[int32][]machineproviders.MachineInfo{
 					0: {healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build()},
 					1: {healthyMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").Build()},
@@ -464,7 +465,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 				},
 			}),
 			PEntry("with a missing index, and other indexes needing updates", rollingUpdateTableInput{
-				cpms: cpmsBuilder.WithReplicas(3).Build(),
+				cpmsBuilder: cpmsBuilder.WithReplicas(3),
 				machineInfos: map[int32][]machineproviders.MachineInfo{
 					0: {healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build()},
 					1: {healthyMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").WithNeedsUpdate(true).Build()},
@@ -489,7 +490,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 				},
 			}),
 			PEntry("with a pending machine in an index, and other indexes needing updates", rollingUpdateTableInput{
-				cpms: cpmsBuilder.WithReplicas(3).Build(),
+				cpmsBuilder: cpmsBuilder.WithReplicas(3),
 				machineInfos: map[int32][]machineproviders.MachineInfo{
 					0: {healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build()},
 					1: {healthyMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").WithNeedsUpdate(true).Build()},
@@ -521,7 +522,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 		})
 
 		type onDeleteUpdateTableInput struct {
-			cpms           *machinev1.ControlPlaneMachineSet
+			cpmsBuilder    resourcebuilder.ControlPlaneMachineSetBuilder
 			machineInfos   map[int32][]machineproviders.MachineInfo
 			setupMock      func()
 			expectedError  error
@@ -533,9 +534,10 @@ var _ = Describe("reconcileMachineUpdates", func() {
 			// We setup the mock machine provider on each test with the expected assertions.
 			in.setupMock()
 
-			originalCPMS := in.cpms.DeepCopy()
+			cpms := cpmsBuilder.Build()
+			originalCPMS := cpms.DeepCopy()
 
-			result, err := reconciler.reconcileMachineUpdates(ctx, logger.Logger(), in.cpms, mockMachineProvider, in.machineInfos)
+			result, err := reconciler.reconcileMachineUpdates(ctx, logger.Logger(), cpms, mockMachineProvider, in.machineInfos)
 			if in.expectedError != nil {
 				Expect(err).To(MatchError(in.expectedError))
 			} else {
@@ -544,10 +546,10 @@ var _ = Describe("reconcileMachineUpdates", func() {
 
 			Expect(result).To(Equal(in.expectedResult))
 			Expect(logger.Entries()).To(ConsistOf(in.expectedLogs))
-			Expect(in.cpms).To(Equal(originalCPMS), "The update functions should not modify the ControlPlaneMachineSet in any way")
+			Expect(cpms).To(Equal(originalCPMS), "The update functions should not modify the ControlPlaneMachineSet in any way")
 		},
 			PEntry("with no updates required", onDeleteUpdateTableInput{
-				cpms: cpmsBuilder.WithReplicas(3).Build(),
+				cpmsBuilder: cpmsBuilder.WithReplicas(3),
 				machineInfos: map[int32][]machineproviders.MachineInfo{
 					0: {healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build()},
 					1: {healthyMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").Build()},
@@ -568,7 +570,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 				},
 			}),
 			PEntry("with updates required in a single index, and the machine is not yet deleted", onDeleteUpdateTableInput{
-				cpms: cpmsBuilder.WithReplicas(3).Build(),
+				cpmsBuilder: cpmsBuilder.WithReplicas(3),
 				machineInfos: map[int32][]machineproviders.MachineInfo{
 					0: {healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build()},
 					1: {healthyMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").WithNeedsUpdate(true).Build()},
@@ -592,7 +594,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 				},
 			}),
 			PEntry("with updates required in a single index, and the machine has been deleted", onDeleteUpdateTableInput{
-				cpms: cpmsBuilder.WithReplicas(3).Build(),
+				cpmsBuilder: cpmsBuilder.WithReplicas(3),
 				machineInfos: map[int32][]machineproviders.MachineInfo{
 					0: {healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build()},
 					1: {healthyMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").WithNeedsUpdate(true).WithMachineDeletionTimestamp(metav1.Now()).Build()},
@@ -616,7 +618,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 				},
 			}),
 			PEntry("with updates required in a single index, and the machine has been deleted, and an error occurrs", onDeleteUpdateTableInput{
-				cpms: cpmsBuilder.WithReplicas(3).Build(), expectedError: fmt.Errorf("error creating new Machine for index %d: %w", 1, transientError),
+				cpmsBuilder: cpmsBuilder.WithReplicas(3), expectedError: fmt.Errorf("error creating new Machine for index %d: %w", 1, transientError),
 				machineInfos: map[int32][]machineproviders.MachineInfo{
 					0: {healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build()},
 					1: {healthyMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").WithNeedsUpdate(true).WithMachineDeletionTimestamp(metav1.Now()).Build()},
@@ -640,7 +642,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 				},
 			}),
 			PEntry("with updates required in a single index, and replacement machine is pending", onDeleteUpdateTableInput{
-				cpms: cpmsBuilder.WithReplicas(3).Build(),
+				cpmsBuilder: cpmsBuilder.WithReplicas(3),
 				machineInfos: map[int32][]machineproviders.MachineInfo{
 					0: {healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build()},
 					1: {
@@ -668,7 +670,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 				},
 			}),
 			PEntry("with updates required in a single index, and replacement machine is ready", onDeleteUpdateTableInput{
-				cpms: cpmsBuilder.WithReplicas(3).Build(),
+				cpmsBuilder: cpmsBuilder.WithReplicas(3),
 				machineInfos: map[int32][]machineproviders.MachineInfo{
 					0: {healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build()},
 					1: {
@@ -695,7 +697,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 				},
 			}),
 			PEntry("with updates required in multiple indexes, and the machines are not yet deleted", onDeleteUpdateTableInput{
-				cpms: cpmsBuilder.WithReplicas(3).Build(),
+				cpmsBuilder: cpmsBuilder.WithReplicas(3),
 				machineInfos: map[int32][]machineproviders.MachineInfo{
 					0: {healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").WithNeedsUpdate(true).Build()},
 					1: {healthyMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").WithNeedsUpdate(true).Build()},
@@ -729,7 +731,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 				},
 			}),
 			PEntry("with updates required in a multiple indexes, and machine has been deleted, and an error occurrs", onDeleteUpdateTableInput{
-				cpms: cpmsBuilder.WithReplicas(3).Build(), expectedError: fmt.Errorf("error creating new Machine for index %d: %w", 1, transientError),
+				cpmsBuilder: cpmsBuilder.WithReplicas(3), expectedError: fmt.Errorf("error creating new Machine for index %d: %w", 1, transientError),
 				machineInfos: map[int32][]machineproviders.MachineInfo{
 					0: {healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").WithNeedsUpdate(true).Build()},
 					1: {healthyMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").WithNeedsUpdate(true).WithMachineDeletionTimestamp(metav1.Now()).Build()},
@@ -763,7 +765,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 				},
 			}),
 			PEntry("with updates required in multiple indexes, and a machine has been deleted", onDeleteUpdateTableInput{
-				cpms: cpmsBuilder.WithReplicas(3).Build(),
+				cpmsBuilder: cpmsBuilder.WithReplicas(3),
 				machineInfos: map[int32][]machineproviders.MachineInfo{
 					0: {healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").WithNeedsUpdate(true).Build()},
 					1: {healthyMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").WithNeedsUpdate(true).WithMachineDeletionTimestamp(metav1.Now()).Build()},
@@ -797,7 +799,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 				},
 			}),
 			PEntry("with updates required in multiple indexes, and multiple machines have been deleted", onDeleteUpdateTableInput{
-				cpms: cpmsBuilder.WithReplicas(3).Build(),
+				cpmsBuilder: cpmsBuilder.WithReplicas(3),
 				machineInfos: map[int32][]machineproviders.MachineInfo{
 					0: {healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").WithNeedsUpdate(true).WithMachineDeletionTimestamp(metav1.Now()).Build()},
 					1: {healthyMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").WithNeedsUpdate(true).WithMachineDeletionTimestamp(metav1.Now()).Build()},
@@ -832,7 +834,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 				},
 			}),
 			PEntry("with updates required in multiple indexes, and a single machine has been deleted, and the replacement machine is pending", onDeleteUpdateTableInput{
-				cpms: cpmsBuilder.WithReplicas(3).Build(),
+				cpmsBuilder: cpmsBuilder.WithReplicas(3),
 				machineInfos: map[int32][]machineproviders.MachineInfo{
 					0: {healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").WithNeedsUpdate(true).Build()},
 					1: {
@@ -870,7 +872,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 				},
 			}),
 			PEntry("with updates required in multiple indexes, and multiple machines have been deleted, and the replacement machines are pending", onDeleteUpdateTableInput{
-				cpms: cpmsBuilder.WithReplicas(3).Build(),
+				cpmsBuilder: cpmsBuilder.WithReplicas(3),
 				machineInfos: map[int32][]machineproviders.MachineInfo{
 					0: {
 						healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").WithNeedsUpdate(true).WithMachineDeletionTimestamp(metav1.Now()).Build(),
@@ -912,7 +914,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 				},
 			}),
 			PEntry("with updates required in multiple indexes, and a single machine has been deleted, and the replacement machine is ready", onDeleteUpdateTableInput{
-				cpms: cpmsBuilder.WithReplicas(3).Build(),
+				cpmsBuilder: cpmsBuilder.WithReplicas(3),
 				machineInfos: map[int32][]machineproviders.MachineInfo{
 					0: {healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").WithNeedsUpdate(true).Build()},
 					1: {
@@ -949,7 +951,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 				},
 			}),
 			PEntry("with updates required in multiple indexes, and multiple machines have been deleted, and a replacement machine is ready, and a replacement machine is pending", onDeleteUpdateTableInput{
-				cpms: cpmsBuilder.WithReplicas(3).Build(),
+				cpmsBuilder: cpmsBuilder.WithReplicas(3),
 				machineInfos: map[int32][]machineproviders.MachineInfo{
 					0: {
 						healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").WithNeedsUpdate(true).WithMachineDeletionTimestamp(metav1.Now()).Build(),
@@ -990,7 +992,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 				},
 			}),
 			PEntry("with updates required in multiple indexes, and multiple machines have been deleted, and all replacement machines are ready", onDeleteUpdateTableInput{
-				cpms: cpmsBuilder.WithReplicas(3).Build(),
+				cpmsBuilder: cpmsBuilder.WithReplicas(3),
 				machineInfos: map[int32][]machineproviders.MachineInfo{
 					0: {
 						healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").WithNeedsUpdate(true).WithMachineDeletionTimestamp(metav1.Now()).Build(),
@@ -1030,7 +1032,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 				},
 			}),
 			PEntry("with an empty index", onDeleteUpdateTableInput{
-				cpms: cpmsBuilder.WithReplicas(3).Build(),
+				cpmsBuilder: cpmsBuilder.WithReplicas(3),
 				machineInfos: map[int32][]machineproviders.MachineInfo{
 					0: {healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build()},
 					1: {healthyMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").Build()},
@@ -1054,7 +1056,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 				},
 			}),
 			PEntry("with a pending machine in an index", onDeleteUpdateTableInput{
-				cpms: cpmsBuilder.WithReplicas(3).Build(),
+				cpmsBuilder: cpmsBuilder.WithReplicas(3),
 				machineInfos: map[int32][]machineproviders.MachineInfo{
 					0: {healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build()},
 					1: {healthyMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").Build()},
@@ -1078,7 +1080,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 				},
 			}),
 			PEntry("with a missing index, and other indexes need updating", onDeleteUpdateTableInput{
-				cpms: cpmsBuilder.WithReplicas(3).Build(),
+				cpmsBuilder: cpmsBuilder.WithReplicas(3),
 				machineInfos: map[int32][]machineproviders.MachineInfo{
 					0: {healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build()},
 					1: {healthyMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").WithNeedsUpdate(true).Build()},
@@ -1112,7 +1114,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 				},
 			}),
 			PEntry("with a pending machine in an index, and other indexes need updating", onDeleteUpdateTableInput{
-				cpms: cpmsBuilder.WithReplicas(3).Build(),
+				cpmsBuilder: cpmsBuilder.WithReplicas(3),
 				machineInfos: map[int32][]machineproviders.MachineInfo{
 					0: {healthyMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build()},
 					1: {healthyMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").WithNeedsUpdate(true).Build()},

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/mapping_test.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/mapping_test.go
@@ -123,7 +123,7 @@ var _ = Describe("Failure Domain Mapping", func() {
 
 	Context("mappingMachineIndexesToFailureDomains", func() {
 		type mappingMachineIndexesTableInput struct {
-			cpmsBuilder     resourcebuilder.ControlPlaneMachineSetBuilder
+			cpmsBuilder     resourcebuilder.ControlPlaneMachineSetInterface
 			failureDomains  machinev1.FailureDomains
 			machines        []*machinev1beta1.Machine
 			expectedError   error
@@ -567,7 +567,7 @@ var _ = Describe("Failure Domain Mapping", func() {
 
 	Context("createBaseFailureDomainMapping", func() {
 		type createBaseMappingTableInput struct {
-			cpmsBuilder     resourcebuilder.ControlPlaneMachineSetBuilder
+			cpmsBuilder     resourcebuilder.ControlPlaneMachineSetInterface
 			failureDomains  machinev1.FailureDomains
 			expectedMapping map[int32]failuredomain.FailureDomain
 			expectedError   error
@@ -733,7 +733,7 @@ var _ = Describe("Failure Domain Mapping", func() {
 
 	Context("createMachineMapping", func() {
 		type machineMappingTableInput struct {
-			cpmsBuilder     resourcebuilder.ControlPlaneMachineSetBuilder
+			cpmsBuilder     resourcebuilder.ControlPlaneMachineSetInterface
 			machines        []*machinev1beta1.Machine
 			expectedError   error
 			expectedMapping map[int32]failuredomain.FailureDomain

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/mapping_test.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/mapping_test.go
@@ -123,7 +123,7 @@ var _ = Describe("Failure Domain Mapping", func() {
 
 	Context("mappingMachineIndexesToFailureDomains", func() {
 		type mappingMachineIndexesTableInput struct {
-			cpms            *machinev1.ControlPlaneMachineSet
+			cpmsBuilder     resourcebuilder.ControlPlaneMachineSetBuilder
 			failureDomains  machinev1.FailureDomains
 			machines        []*machinev1beta1.Machine
 			expectedError   error
@@ -137,17 +137,18 @@ var _ = Describe("Failure Domain Mapping", func() {
 
 			logger := test.NewTestLogger()
 
+			cpms := cpmsBuilder.Build()
 			// Make sure all resources use the right namespace.
-			in.cpms.SetNamespace(namespaceName)
+			cpms.SetNamespace(namespaceName)
 
 			for _, machine := range in.machines {
 				machine.SetNamespace(namespaceName)
 				Expect(k8sClient.Create(ctx, machine)).To(Succeed())
 			}
 
-			originalCPMS := in.cpms.DeepCopy()
+			originalCPMS := cpms.DeepCopy()
 
-			mapping, err := mapMachineIndexesToFailureDomains(ctx, logger.Logger(), k8sClient, in.cpms, failureDomains)
+			mapping, err := mapMachineIndexesToFailureDomains(ctx, logger.Logger(), k8sClient, cpms, failureDomains)
 			if in.expectedError != nil {
 				Expect(err).To(MatchError(in.expectedError))
 			} else {
@@ -156,10 +157,10 @@ var _ = Describe("Failure Domain Mapping", func() {
 
 			Expect(mapping).To(Equal(in.expectedMapping))
 			Expect(logger.Entries()).To(ConsistOf(in.expectedLogs))
-			Expect(in.cpms).To(Equal(originalCPMS), "The update functions should not modify the ControlPlaneMachineSet in any way")
+			Expect(cpms).To(Equal(originalCPMS), "The update functions should not modify the ControlPlaneMachineSet in any way")
 		},
 			PEntry("with no failure domains defined, returns an empty mapping", mappingMachineIndexesTableInput{
-				cpms:           cpmsBuilder.Build(),
+				cpmsBuilder:    cpmsBuilder,
 				failureDomains: machinev1.FailureDomains{},
 				machines: []*machinev1beta1.Machine{
 					machineBuilder.WithName("machine-0").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build(),
@@ -176,7 +177,7 @@ var _ = Describe("Failure Domain Mapping", func() {
 				},
 			}),
 			PEntry("with three failure domains matching three machines in order (a,b,c)", mappingMachineIndexesTableInput{
-				cpms: cpmsBuilder.Build(),
+				cpmsBuilder: cpmsBuilder,
 				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
 					usEast1aFailureDomainBuilder,
 					usEast1bFailureDomainBuilder,
@@ -207,7 +208,7 @@ var _ = Describe("Failure Domain Mapping", func() {
 				},
 			}),
 			PEntry("with three failure domains matching three machines in a order (b,c,a)", mappingMachineIndexesTableInput{
-				cpms: cpmsBuilder.Build(),
+				cpmsBuilder: cpmsBuilder,
 				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
 					usEast1aFailureDomainBuilder,
 					usEast1bFailureDomainBuilder,
@@ -238,7 +239,7 @@ var _ = Describe("Failure Domain Mapping", func() {
 				},
 			}),
 			PEntry("with three failure domains matching three machines in a order (b,a,c)", mappingMachineIndexesTableInput{
-				cpms: cpmsBuilder.Build(),
+				cpmsBuilder: cpmsBuilder,
 				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
 					usEast1aFailureDomainBuilder,
 					usEast1bFailureDomainBuilder,
@@ -269,7 +270,7 @@ var _ = Describe("Failure Domain Mapping", func() {
 				},
 			}),
 			PEntry("with three failure domains matching five machines in order (a,b,c,a,b)", mappingMachineIndexesTableInput{
-				cpms: cpmsBuilder.WithReplicas(5).Build(),
+				cpmsBuilder: cpmsBuilder.WithReplicas(5),
 				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
 					usEast1aFailureDomainBuilder,
 					usEast1bFailureDomainBuilder,
@@ -306,7 +307,7 @@ var _ = Describe("Failure Domain Mapping", func() {
 				},
 			}),
 			PEntry("with three failure domains matching five machines in order (b,c,a,c,b)", mappingMachineIndexesTableInput{
-				cpms: cpmsBuilder.WithReplicas(5).Build(),
+				cpmsBuilder: cpmsBuilder.WithReplicas(5),
 				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
 					usEast1aFailureDomainBuilder,
 					usEast1bFailureDomainBuilder,
@@ -343,7 +344,7 @@ var _ = Describe("Failure Domain Mapping", func() {
 				},
 			}),
 			PEntry("with three failure domains matching five machines in order (b,a,c,c,a)", mappingMachineIndexesTableInput{
-				cpms: cpmsBuilder.WithReplicas(5).Build(),
+				cpmsBuilder: cpmsBuilder.WithReplicas(5),
 				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
 					usEast1aFailureDomainBuilder,
 					usEast1bFailureDomainBuilder,
@@ -380,7 +381,7 @@ var _ = Describe("Failure Domain Mapping", func() {
 				},
 			}),
 			PEntry("with a machine in an unrecognised failure domain (failure domains ordered a,b)", mappingMachineIndexesTableInput{
-				cpms: cpmsBuilder.Build(),
+				cpmsBuilder: cpmsBuilder,
 				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
 					usEast1aFailureDomainBuilder,
 					usEast1bFailureDomainBuilder,
@@ -410,7 +411,7 @@ var _ = Describe("Failure Domain Mapping", func() {
 				},
 			}),
 			PEntry("with a machine in an unrecognised failure domain (failure domains ordered b,a)", mappingMachineIndexesTableInput{
-				cpms: cpmsBuilder.Build(),
+				cpmsBuilder: cpmsBuilder,
 				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
 					usEast1bFailureDomainBuilder,
 					usEast1aFailureDomainBuilder,
@@ -440,7 +441,7 @@ var _ = Describe("Failure Domain Mapping", func() {
 				},
 			}),
 			PEntry("with multiple machines in unrecognised failure domains ", mappingMachineIndexesTableInput{
-				cpms: cpmsBuilder.Build(),
+				cpmsBuilder: cpmsBuilder,
 				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
 					usEast1aFailureDomainBuilder,
 				).BuildFailureDomains(),
@@ -469,7 +470,7 @@ var _ = Describe("Failure Domain Mapping", func() {
 				},
 			}),
 			PEntry("with multiple machines in the same failure domain", mappingMachineIndexesTableInput{
-				cpms: cpmsBuilder.Build(),
+				cpmsBuilder: cpmsBuilder,
 				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
 					usEast1aFailureDomainBuilder,
 					usEast1bFailureDomainBuilder,
@@ -500,7 +501,7 @@ var _ = Describe("Failure Domain Mapping", func() {
 				},
 			}),
 			PEntry("with a machine name does not indicate its index (a,b,c)", mappingMachineIndexesTableInput{
-				cpms: cpmsBuilder.Build(),
+				cpmsBuilder: cpmsBuilder,
 				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
 					usEast1aFailureDomainBuilder,
 					usEast1bFailureDomainBuilder,
@@ -531,7 +532,7 @@ var _ = Describe("Failure Domain Mapping", func() {
 				},
 			}),
 			PEntry("with a machine name does not indicate its index (b,c,a)", mappingMachineIndexesTableInput{
-				cpms: cpmsBuilder.Build(),
+				cpmsBuilder: cpmsBuilder,
 				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
 					usEast1aFailureDomainBuilder,
 					usEast1bFailureDomainBuilder,
@@ -566,7 +567,7 @@ var _ = Describe("Failure Domain Mapping", func() {
 
 	Context("createBaseFailureDomainMapping", func() {
 		type createBaseMappingTableInput struct {
-			cpms            *machinev1.ControlPlaneMachineSet
+			cpmsBuilder     resourcebuilder.ControlPlaneMachineSetBuilder
 			failureDomains  machinev1.FailureDomains
 			expectedMapping map[int32]failuredomain.FailureDomain
 			expectedError   error
@@ -576,7 +577,8 @@ var _ = Describe("Failure Domain Mapping", func() {
 			failureDomains, err := failuredomain.NewFailureDomains(in.failureDomains)
 			Expect(err).ToNot(HaveOccurred())
 
-			mapping, err := createBaseFailureDomainMapping(in.cpms, failureDomains)
+			cpms := cpmsBuilder.Build()
+			mapping, err := createBaseFailureDomainMapping(cpms, failureDomains)
 			if in.expectedError != nil {
 				Expect(err).To(MatchError(in.expectedError))
 			} else {
@@ -586,7 +588,7 @@ var _ = Describe("Failure Domain Mapping", func() {
 			Expect(mapping).To(Equal(in.expectedMapping))
 		},
 			PEntry("with no replicas set", createBaseMappingTableInput{
-				cpms: &machinev1.ControlPlaneMachineSet{},
+				cpmsBuilder: cpmsBuilder.WithReplicas(0),
 				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
 					usEast1aFailureDomainBuilder,
 					usEast1bFailureDomainBuilder,
@@ -595,7 +597,7 @@ var _ = Describe("Failure Domain Mapping", func() {
 				expectedError: errReplicasRequired,
 			}),
 			PEntry("with three replicas and three failure domains (order a,b,c)", createBaseMappingTableInput{
-				cpms: cpmsBuilder.WithReplicas(3).Build(),
+				cpmsBuilder: cpmsBuilder.WithReplicas(3),
 				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
 					usEast1aFailureDomainBuilder,
 					usEast1bFailureDomainBuilder,
@@ -608,7 +610,7 @@ var _ = Describe("Failure Domain Mapping", func() {
 				},
 			}),
 			PEntry("with three replicas and three failure domains (order b,c,a)", createBaseMappingTableInput{
-				cpms: cpmsBuilder.WithReplicas(3).Build(),
+				cpmsBuilder: cpmsBuilder.WithReplicas(3),
 				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
 					usEast1bFailureDomainBuilder,
 					usEast1cFailureDomainBuilder,
@@ -621,7 +623,7 @@ var _ = Describe("Failure Domain Mapping", func() {
 				},
 			}),
 			PEntry("with three replicas and three failure domains (order b,a,c)", createBaseMappingTableInput{
-				cpms: cpmsBuilder.WithReplicas(3).Build(),
+				cpmsBuilder: cpmsBuilder.WithReplicas(3),
 				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
 					usEast1bFailureDomainBuilder,
 					usEast1aFailureDomainBuilder,
@@ -634,7 +636,7 @@ var _ = Describe("Failure Domain Mapping", func() {
 				},
 			}),
 			PEntry("with three replicas and one failure domains", createBaseMappingTableInput{
-				cpms: cpmsBuilder.WithReplicas(3).Build(),
+				cpmsBuilder: cpmsBuilder.WithReplicas(3),
 				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
 					usEast1aFailureDomainBuilder,
 				).BuildFailureDomains(),
@@ -645,7 +647,7 @@ var _ = Describe("Failure Domain Mapping", func() {
 				},
 			}),
 			PEntry("with three replicas and two failure domains (order a,b)", createBaseMappingTableInput{
-				cpms: cpmsBuilder.WithReplicas(3).Build(),
+				cpmsBuilder: cpmsBuilder.WithReplicas(3),
 				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
 					usEast1aFailureDomainBuilder,
 					usEast1bFailureDomainBuilder,
@@ -657,7 +659,7 @@ var _ = Describe("Failure Domain Mapping", func() {
 				},
 			}),
 			PEntry("with three replicas and two failure domains (order b,a)", createBaseMappingTableInput{
-				cpms: cpmsBuilder.WithReplicas(3).Build(),
+				cpmsBuilder: cpmsBuilder.WithReplicas(3),
 				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
 					usEast1bFailureDomainBuilder,
 					usEast1aFailureDomainBuilder,
@@ -669,7 +671,7 @@ var _ = Describe("Failure Domain Mapping", func() {
 				},
 			}),
 			PEntry("with five replicas and three failure domains (order a,b,c)", createBaseMappingTableInput{
-				cpms: cpmsBuilder.WithReplicas(3).Build(),
+				cpmsBuilder: cpmsBuilder.WithReplicas(3),
 				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
 					usEast1aFailureDomainBuilder,
 					usEast1bFailureDomainBuilder,
@@ -684,7 +686,7 @@ var _ = Describe("Failure Domain Mapping", func() {
 				},
 			}),
 			PEntry("with five replicas and three failure domains (order b,c,a)", createBaseMappingTableInput{
-				cpms: cpmsBuilder.WithReplicas(3).Build(),
+				cpmsBuilder: cpmsBuilder.WithReplicas(3),
 				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
 					usEast1bFailureDomainBuilder,
 					usEast1cFailureDomainBuilder,
@@ -699,7 +701,7 @@ var _ = Describe("Failure Domain Mapping", func() {
 				},
 			}),
 			PEntry("with five replicas and two failure domains (order a,b)", createBaseMappingTableInput{
-				cpms: cpmsBuilder.WithReplicas(3).Build(),
+				cpmsBuilder: cpmsBuilder.WithReplicas(3),
 				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
 					usEast1aFailureDomainBuilder,
 					usEast1bFailureDomainBuilder,
@@ -713,7 +715,7 @@ var _ = Describe("Failure Domain Mapping", func() {
 				},
 			}),
 			PEntry("with five replicas and two failure domains (order b,a)", createBaseMappingTableInput{
-				cpms: cpmsBuilder.WithReplicas(3).Build(),
+				cpmsBuilder: cpmsBuilder.WithReplicas(3),
 				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
 					usEast1bFailureDomainBuilder,
 					usEast1aFailureDomainBuilder,
@@ -731,7 +733,7 @@ var _ = Describe("Failure Domain Mapping", func() {
 
 	Context("createMachineMapping", func() {
 		type machineMappingTableInput struct {
-			cpms            *machinev1.ControlPlaneMachineSet
+			cpmsBuilder     resourcebuilder.ControlPlaneMachineSetBuilder
 			machines        []*machinev1beta1.Machine
 			expectedError   error
 			expectedMapping map[int32]failuredomain.FailureDomain
@@ -741,17 +743,18 @@ var _ = Describe("Failure Domain Mapping", func() {
 		DescribeTable("maps Machines based on their failure domain", func(in machineMappingTableInput) {
 			logger := test.NewTestLogger()
 
+			cpms := cpmsBuilder.Build()
 			// Make sure all resources use the right namespace.
-			in.cpms.SetNamespace(namespaceName)
+			cpms.SetNamespace(namespaceName)
 
 			for _, machine := range in.machines {
 				machine.SetNamespace(namespaceName)
 				Expect(k8sClient.Create(ctx, machine)).To(Succeed())
 			}
 
-			originalCPMS := in.cpms.DeepCopy()
+			originalCPMS := cpms.DeepCopy()
 
-			mapping, err := createMachineMapping(ctx, logger.Logger(), k8sClient, in.cpms)
+			mapping, err := createMachineMapping(ctx, logger.Logger(), k8sClient, cpms)
 			if in.expectedError != nil {
 				Expect(err).To(MatchError(in.expectedError))
 			} else {
@@ -760,10 +763,10 @@ var _ = Describe("Failure Domain Mapping", func() {
 
 			Expect(mapping).To(Equal(in.expectedMapping))
 			Expect(logger.Entries()).To(ConsistOf(in.expectedLogs))
-			Expect(in.cpms).To(Equal(originalCPMS), "The update functions should not modify the ControlPlaneMachineSet in any way")
+			Expect(cpms).To(Equal(originalCPMS), "The update functions should not modify the ControlPlaneMachineSet in any way")
 		},
 			PEntry("with machines in three failure domains (order a,b,c)", machineMappingTableInput{
-				cpms: cpmsBuilder.Build(),
+				cpmsBuilder: cpmsBuilder,
 				machines: []*machinev1beta1.Machine{
 					machineBuilder.WithName("machine-0").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build(),
 					machineBuilder.WithName("machine-1").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build(),
@@ -777,7 +780,7 @@ var _ = Describe("Failure Domain Mapping", func() {
 				expectedLogs: []test.LogEntry{},
 			}),
 			PEntry("with machines in three failure domains (order b,c,a)", machineMappingTableInput{
-				cpms: cpmsBuilder.Build(),
+				cpmsBuilder: cpmsBuilder,
 				machines: []*machinev1beta1.Machine{
 					machineBuilder.WithName("machine-0").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build(),
 					machineBuilder.WithName("machine-1").WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build(),
@@ -791,7 +794,7 @@ var _ = Describe("Failure Domain Mapping", func() {
 				expectedLogs: []test.LogEntry{},
 			}),
 			PEntry("with machines in not matched by the selector, they are ignored", machineMappingTableInput{
-				cpms: cpmsBuilder.Build(),
+				cpmsBuilder: cpmsBuilder,
 				machines: []*machinev1beta1.Machine{
 					machineBuilder.WithName("machine-0").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build(),
 					resourcebuilder.Machine().WithName("machine-1").WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build(),
@@ -803,7 +806,7 @@ var _ = Describe("Failure Domain Mapping", func() {
 				expectedLogs: []test.LogEntry{},
 			}),
 			PEntry("with machines with non-index names", machineMappingTableInput{
-				cpms: cpmsBuilder.Build(),
+				cpmsBuilder: cpmsBuilder,
 				machines: []*machinev1beta1.Machine{
 					machineBuilder.WithName("machine-a").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build(),
 					machineBuilder.WithName("machine-1").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build(),
@@ -830,7 +833,7 @@ var _ = Describe("Failure Domain Mapping", func() {
 				},
 			}),
 			PEntry("with multiple machines in a failure domains", machineMappingTableInput{
-				cpms: cpmsBuilder.Build(),
+				cpmsBuilder: cpmsBuilder,
 				machines: []*machinev1beta1.Machine{
 					machineBuilder.WithName("machine-0").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build(),
 					machineBuilder.WithName("machine-1").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build(),
@@ -844,7 +847,7 @@ var _ = Describe("Failure Domain Mapping", func() {
 				expectedLogs: []test.LogEntry{},
 			}),
 			PEntry("with multiple machines in the same index in the same failure domain", machineMappingTableInput{
-				cpms: cpmsBuilder.Build(),
+				cpmsBuilder: cpmsBuilder,
 				machines: []*machinev1beta1.Machine{
 					machineBuilder.WithName("machine-0").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build(),
 					machineBuilder.WithName("machine-replacement-0").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build(),
@@ -857,7 +860,7 @@ var _ = Describe("Failure Domain Mapping", func() {
 				expectedLogs: []test.LogEntry{},
 			}),
 			PEntry("with multiple machines in the same index in different failure domains", machineMappingTableInput{
-				cpms: cpmsBuilder.Build(),
+				cpmsBuilder: cpmsBuilder,
 				machines: []*machinev1beta1.Machine{
 					machineBuilder.WithName("machine-0").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build(),
 					machineBuilder.WithName("machine-replacement-0").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build(),

--- a/pkg/test/resourcebuilder/consts.go
+++ b/pkg/test/resourcebuilder/consts.go
@@ -17,7 +17,7 @@ limitations under the License.
 package resourcebuilder
 
 const (
-	// openshiftMachineAPINamespaceName is the name of the OpenShift
+	// OpenshiftMachineAPINamespaceName is the name of the OpenShift
 	// Machine API namespace.
-	openshiftMachineAPINamespaceName = "openshift-machine-api"
+	OpenshiftMachineAPINamespaceName = "openshift-machine-api"
 )

--- a/pkg/test/resourcebuilder/control_plane_machine_set.go
+++ b/pkg/test/resourcebuilder/control_plane_machine_set.go
@@ -23,17 +23,32 @@ import (
 )
 
 const (
-	// controlPlaneMachineSetName is the only valid name allowed.
+	// ControlPlaneMachineSetName is the only valid name allowed.
 	// A ControlPlaneMachineSet is a singleton within the cluster, this matches other singletons such as Infrastructure.
-	controlPlaneMachineSetName = "cluster"
+	ControlPlaneMachineSetName = "cluster"
 )
+
+// ControlPlaneMachineSetInterface is the interface to controlplanemachineset builder.
+type ControlPlaneMachineSetInterface interface {
+	Build() *machinev1.ControlPlaneMachineSet
+}
+
+// ControlPlaneMachineSetFuncs defines a set of functions for manipulating controlplanemachinesets.
+type ControlPlaneMachineSetFuncs struct {
+	BuildFunc func() *machinev1.ControlPlaneMachineSet
+}
+
+// Build builds a new controlplanemachineset based on the configuration provided.
+func (c *ControlPlaneMachineSetFuncs) Build() *machinev1.ControlPlaneMachineSet {
+	return c.BuildFunc()
+}
 
 // ControlPlaneMachineSet creates a new controlplanemachineset builder.
 func ControlPlaneMachineSet() ControlPlaneMachineSetBuilder {
 	return ControlPlaneMachineSetBuilder{
 		machineTemplateBuilder: OpenShiftMachineV1Beta1Template(),
-		name:                   controlPlaneMachineSetName,
-		namespace:              openshiftMachineAPINamespaceName,
+		name:                   ControlPlaneMachineSetName,
+		namespace:              OpenshiftMachineAPINamespaceName,
 		replicas:               3,
 		selector: metav1.LabelSelector{
 			MatchLabels: map[string]string{


### PR DESCRIPTION
- **refactor table tests to use cpmsBuilder**
   using the cpms pointer was causing issues with not retaining the passed
in values.
- **use lowercase keys for logging**