### PR TITLE
Implement finalizer addition

### DIFF
--- a/pkg/controllers/controlplanemachineset/controller_test.go
+++ b/pkg/controllers/controlplanemachineset/controller_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/openshift/cluster-control-plane-machine-set-operator/pkg/test"
 	"github.com/openshift/cluster-control-plane-machine-set-operator/pkg/test/resourcebuilder"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -113,7 +114,7 @@ var _ = Describe("With a running controller", func() {
 			Expect(k8sClient.Create(ctx, cpms)).Should(Succeed())
 		})
 
-		PIt("should add the controlplanemachineset.machine.openshift.io finalizer", func() {
+		It("should add the controlplanemachineset.machine.openshift.io finalizer", func() {
 			Eventually(komega.Object(cpms)).Should(HaveField("ObjectMeta.Finalizers", ContainElement(controlPlaneMachineSetFinalizer)))
 		})
 	})
@@ -144,7 +145,7 @@ var _ = Describe("With a running controller", func() {
 				Expect(cpms.ObjectMeta.Finalizers).To(BeEmpty())
 			})
 
-			PIt("should re-add the controlplanemachineset.machine.openshift.io finalizer", func() {
+			It("should re-add the controlplanemachineset.machine.openshift.io finalizer", func() {
 				Eventually(komega.Object(cpms)).Should(HaveField("ObjectMeta.Finalizers", ContainElement(controlPlaneMachineSetFinalizer)))
 			})
 		})
@@ -236,11 +237,11 @@ var _ = Describe("ensureFinalizer", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		PIt("returns that it updated the finalizer", func() {
+		It("returns that it updated the finalizer", func() {
 			Expect(updatedFinalizer).To(BeTrue())
 		})
 
-		PIt("sets an appropriate log line", func() {
+		It("sets an appropriate log line", func() {
 			Expect(logger.Entries()).To(ConsistOf(
 				test.LogEntry{
 					Level:   2,
@@ -249,7 +250,7 @@ var _ = Describe("ensureFinalizer", func() {
 			))
 		})
 
-		PIt("ensures the finalizer is set on the API", func() {
+		It("ensures the finalizer is set on the API", func() {
 			Eventually(komega.Object(cpms)).Should(HaveField("ObjectMeta.Finalizers", ContainElement(controlPlaneMachineSetFinalizer)))
 		})
 
@@ -281,7 +282,7 @@ var _ = Describe("ensureFinalizer", func() {
 			Expect(updatedFinalizer).To(BeFalse())
 		})
 
-		PIt("sets an appropriate log line", func() {
+		It("sets an appropriate log line", func() {
 			Expect(logger.Entries()).To(ConsistOf(
 				test.LogEntry{
 					Level:   4,
@@ -311,15 +312,15 @@ var _ = Describe("ensureFinalizer", func() {
 			updatedFinalizer, err = reconciler.ensureFinalizer(ctx, logger.Logger(), originalCPMS)
 		})
 
-		PIt("should return a conflict error", func() {
-			Expect(err).To(MatchError(ContainSubstring("TODO")))
+		It("should return a conflict error", func() {
+			Expect(apierrors.ReasonForError(err)).To(Equal(metav1.StatusReasonConflict))
 		})
 
 		It("returns that it did not update the finalizer", func() {
 			Expect(updatedFinalizer).To(BeFalse())
 		})
 
-		PIt("does not log", func() {
+		It("does not log", func() {
 			Expect(logger.Entries()).To(BeEmpty())
 		})
 

--- a/pkg/controllers/controlplanemachineset/status.go
+++ b/pkg/controllers/controlplanemachineset/status.go
@@ -69,6 +69,9 @@ func (r *ControlPlaneMachineSetReconciler) updateControlPlaneMachineSetStatus(ct
 // - UnavailableReplicas is the number of Machines required to satisfy the requirement of at least 1 Ready Replica per
 //   index. Eg. if one index has no ready replicas, this is 1, if an index has 2 ready replicas, this does not count as
 //   2 available replicas.
+// nolint: unparam
 func reconcileStatusWithMachineInfo(logger logr.Logger, cpms *machinev1.ControlPlaneMachineSet, machineInfosByIndex map[int32][]machineproviders.MachineInfo) error {
+	// TODO: remove nolint after implementing this function
+	cpms.Status.ObservedGeneration = cpms.Generation
 	return nil
 }

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/providerconfig.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/providerconfig.go
@@ -41,6 +41,9 @@ var (
 	// errUnknownProviderConfigType is an error used when provider type
 	// cannot be deduced from providerSpec object kind.
 	errUnknownProviderConfigType = errors.New("unknown provider config type")
+
+	// errUnsupportedProviderConfigType is an error used when provider spec is nil.
+	errNilProviderSpec = errors.New("provider spec is nil")
 )
 
 // ProviderConfig is an interface that allows external code to interact
@@ -210,6 +213,11 @@ func getPlatformTypeFromProviderSpec(providerSpec machinev1beta1.ProviderSpec) (
 	}
 
 	providerKind := providerSpecKind{}
+
+	if providerSpec.Value == nil {
+		return "", errNilProviderSpec
+	}
+
 	if err := json.Unmarshal(providerSpec.Value.Raw, &providerKind); err != nil {
 		return "", fmt.Errorf("could not unmarshal provider spec: %w", err)
 	}

--- a/pkg/test/resourcebuilder/openshift_machine_v1beta1_template.go
+++ b/pkg/test/resourcebuilder/openshift_machine_v1beta1_template.go
@@ -29,6 +29,7 @@ func OpenShiftMachineV1Beta1Template() OpenShiftMachineV1Beta1TemplateBuilder {
 			machineTypeLabelName:                 "master",
 			machinev1beta1.MachineClusterIDLabel: "cpms-cluster-test-id",
 		},
+		providerSpecBuilder: AWSProviderSpec(),
 	}
 }
 


### PR DESCRIPTION
This PR implements finalizer addition for CPMS and fixes nil dereference with nil provider spec.

I don't quite understand why handling stale CPMS is required, but hope it's implemented correctly. 