### PR TITLE
Add ownerrefs to machines owned by CPMS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-
 # Binaries for programs and plugins
 *.exe
 *.exe~
@@ -19,3 +18,5 @@ testbin/*
 *.swp
 *.swo
 *~
+
+.vscode/

--- a/pkg/controllers/controlplanemachineset/controller.go
+++ b/pkg/controllers/controlplanemachineset/controller.go
@@ -18,6 +18,7 @@ package controlplanemachineset
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/go-logr/logr"
@@ -26,15 +27,16 @@ import (
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 	"github.com/openshift/cluster-control-plane-machine-set-operator/pkg/machineproviders"
 	"github.com/openshift/cluster-control-plane-machine-set-operator/pkg/machineproviders/providers"
-
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	errorutils "k8s.io/apimachinery/pkg/util/errors"
-
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -240,11 +242,57 @@ func (r *ControlPlaneMachineSetReconciler) ensureFinalizer(ctx context.Context, 
 // ensureOwnerReferences determines if any of the Machines within the machineInfos require a new controller owner
 // reference to be added, and then uses PartialObjectMetadata to ensure that the owner reference is added.
 func (r *ControlPlaneMachineSetReconciler) ensureOwnerReferences(ctx context.Context, logger logr.Logger, cpms *machinev1.ControlPlaneMachineSet, machineInfos map[int32][]machineproviders.MachineInfo) error {
-	// TODO: Iterate over the MachineInfos, for each Machine, check the owner references for an owner reference matching
-	// that of the current CPMS (it should be the controller so should be easy to find).
-	// If required, look up the GVK using the rest mapper from the GVR, then uses metav1.PartialObjectMetadata to Patch
-	// the owner references. This should mean we can update the metadata of any type given we know the GVR and existing
-	// ObjectMeta.
+	for _, machineInfo := range machineInfos {
+		for _, mInfo := range machineInfo {
+			if mInfo.MachineRef == nil {
+				continue
+			}
+
+			mObjectMeta := mInfo.MachineRef.ObjectMeta
+			mLogger := logger.WithValues("machineNamespace", mObjectMeta.GetNamespace(), "machineName", mObjectMeta.GetName())
+
+			machineGvk, err := r.RESTMapper.KindFor(mInfo.MachineRef.GroupVersionResource)
+			if err != nil {
+				return fmt.Errorf("error getting GVK for machine: %w", err)
+			}
+
+			machine := &metav1.PartialObjectMetadata{}
+			machine.SetGroupVersionKind(machineGvk)
+			machine.ObjectMeta = mObjectMeta
+
+			if isOwnedByCurrentCPMS(cpms, machine) {
+				mLogger.V(4).Info("Owner reference already present on machine")
+				continue
+			}
+
+			patchBase := client.MergeFrom(machine.DeepCopy())
+
+			err = controllerutil.SetControllerReference(cpms, machine, r.Scheme)
+			if err != nil {
+				mLogger.Error(err, "Cannot add owner reference to machine")
+				var alreadyOwnedErr *controllerutil.AlreadyOwnedError
+				if errors.As(err, &alreadyOwnedErr) {
+					meta.SetStatusCondition(&cpms.Status.Conditions, metav1.Condition{
+						Type:               conditionDegraded,
+						Status:             metav1.ConditionTrue,
+						Reason:             reasonMachinesAlreadyOwned,
+						ObservedGeneration: 2,
+						Message:            "Observed already owned machine(s) in target machines",
+					})
+
+					// don't return an error here and continue iterating through the machines
+					continue
+				}
+				return fmt.Errorf("error setting owner reference: %w", err)
+			}
+
+			if err := r.Client.Patch(ctx, machine, patchBase); err != nil {
+				return fmt.Errorf("error patching the macine: %w", err)
+			}
+
+			mLogger.V(2).Info("Added owner reference to machine")
+		}
+	}
 	return nil
 }
 
@@ -282,5 +330,27 @@ func machineInfosByIndex(cpms *machinev1.ControlPlaneMachineSet, machineInfos []
 // isControlPlaneMachineSetDegraded determines whether or not the ControlPlaneMachineSet
 // has a true, degraded condition.
 func isControlPlaneMachineSetDegraded(cpms *machinev1.ControlPlaneMachineSet) bool {
+	return false
+}
+
+func isOwnedByCurrentCPMS(cpms *machinev1.ControlPlaneMachineSet, machineObjectMeta *metav1.PartialObjectMetadata) bool {
+	if machineObjectMeta.OwnerReferences == nil {
+		return false
+	}
+
+	if controlledBy := metav1.GetControllerOf(machineObjectMeta); controlledBy != nil {
+		currentCpmsGV, err := schema.ParseGroupVersion(cpms.APIVersion)
+		if err != nil {
+			return false
+		}
+
+		machineOwnerGV, err := schema.ParseGroupVersion(controlledBy.APIVersion)
+		if err != nil {
+			return false
+		}
+
+		return currentCpmsGV.Group == machineOwnerGV.Group && cpms.Kind == controlledBy.Kind && cpms.Name == controlledBy.Name
+	}
+
 	return false
 }

--- a/pkg/controllers/controlplanemachineset/controller_test.go
+++ b/pkg/controllers/controlplanemachineset/controller_test.go
@@ -589,6 +589,7 @@ var _ = Describe("ensureOwnerRefrences", func() {
 					By("Adding an owner reference for an alternative controller owner")
 					Expect(machineInfos[0][0].MachineRef).ToNot(BeNil())
 					machineInfos[i][i].MachineRef.ObjectMeta.OwnerReferences = []metav1.OwnerReference{badOwnerReference}
+
 					continue
 				}
 

--- a/pkg/controllers/controlplanemachineset/controller_test.go
+++ b/pkg/controllers/controlplanemachineset/controller_test.go
@@ -19,7 +19,6 @@ package controlplanemachineset
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -34,6 +33,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 )
@@ -357,6 +357,11 @@ var _ = Describe("ensureOwnerRefrences", func() {
 		By("Creating a ControlPlaneMachineSet")
 		cpms = resourcebuilder.ControlPlaneMachineSet().WithNamespace(namespaceName).WithGeneration(2).Build()
 		Expect(k8sClient.Create(ctx, cpms)).Should(Succeed())
+		// Set TypeMeta because Create() call removes it from the object.
+		cpms.TypeMeta = metav1.TypeMeta{
+			Kind:       "ControlPlaneMachineSet",
+			APIVersion: "machine.openshift.io/v1",
+		}
 
 		logger = test.NewTestLogger()
 
@@ -380,7 +385,7 @@ var _ = Describe("ensureOwnerRefrences", func() {
 
 			machines = append(machines, machine)
 
-			machineInfo := resourcebuilder.MachineInfo().WithMachineGVR(machineGVR).WithMachineName(machine.GetName()).Build()
+			machineInfo := resourcebuilder.MachineInfo().WithMachineGVR(machineGVR).WithMachineName(machine.GetName()).WithMachineNamespace(namespaceName).Build()
 			machineInfos[int32(i)] = append(machineInfos[int32(i)], machineInfo)
 		}
 	})
@@ -398,13 +403,13 @@ var _ = Describe("ensureOwnerRefrences", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		PIt("should add the expected owner references", func() {
+		It("should add the expected owner references", func() {
 			for _, machine := range machines {
 				Eventually(komega.Object(machine)).Should(HaveField("ObjectMeta.OwnerReferences", ConsistOf(expectedOwnerReference)))
 			}
 		})
 
-		PIt("should log that it has updated the owner references", func() {
+		It("should log that it has updated the owner references", func() {
 			expectedEntries := []test.LogEntry{}
 
 			for _, machine := range machines {
@@ -422,26 +427,31 @@ var _ = Describe("ensureOwnerRefrences", func() {
 	Context("when the machines already have an existing owner references", func() {
 		BeforeEach(func() {
 			By("Setting up the appropriate MachineInfos")
-			machineInfos = map[int32][]machineproviders.MachineInfo{}
+
+			Expect(machineInfos).To(HaveLen(3))
+			Expect(machines).To(HaveLen(3))
 
 			for i := range machineInfos {
 				for j := range machineInfos[i] {
 					Expect(machineInfos[i][j].MachineRef).ToNot(BeNil())
 					machineInfos[i][j].MachineRef.ObjectMeta.OwnerReferences = []metav1.OwnerReference{expectedOwnerReference}
 				}
+				patchBase := client.MergeFrom(machines[i].DeepCopy())
+				machines[i].SetOwnerReferences([]metav1.OwnerReference{expectedOwnerReference})
+				Expect(k8sClient.Patch(ctx, machines[i], patchBase)).To(Succeed())
 			}
 
 			err := reconciler.ensureOwnerReferences(ctx, logger.Logger(), cpms, machineInfos)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		PIt("should not update the owner references", func() {
+		It("should not update the owner references", func() {
 			for _, machine := range machines {
 				Eventually(komega.Object(machine)).Should(HaveField("ObjectMeta.OwnerReferences", ConsistOf(expectedOwnerReference)))
 			}
 		})
 
-		PIt("should log that no update was needed", func() {
+		It("should log that no update was needed", func() {
 			expectedEntries := []test.LogEntry{}
 
 			for _, machine := range machines {
@@ -459,11 +469,11 @@ var _ = Describe("ensureOwnerRefrences", func() {
 	Context("when some machines already have an existing owner reference", func() {
 		BeforeEach(func() {
 			By("Adding an owner reference to some of the machine infos")
-			skippedOne := false
 			Expect(machineInfos).To(HaveLen(3))
+			Expect(machines).To(HaveLen(3))
+
 			for i := range machineInfos {
-				if !skippedOne {
-					skippedOne = true
+				if i == 0 {
 					continue
 				}
 
@@ -471,19 +481,23 @@ var _ = Describe("ensureOwnerRefrences", func() {
 					Expect(machineInfos[i][j].MachineRef).ToNot(BeNil())
 					machineInfos[i][j].MachineRef.ObjectMeta.OwnerReferences = []metav1.OwnerReference{expectedOwnerReference}
 				}
+
+				patchBase := client.MergeFrom(machines[i].DeepCopy())
+				machines[i].SetOwnerReferences([]metav1.OwnerReference{expectedOwnerReference})
+				Expect(k8sClient.Patch(ctx, machines[i], patchBase)).To(Succeed())
 			}
 
 			err := reconciler.ensureOwnerReferences(ctx, logger.Logger(), cpms, machineInfos)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		PIt("should update the owner reference where needed", func() {
+		It("should update the owner reference where needed", func() {
 			for _, machine := range machines {
 				Eventually(komega.Object(machine)).Should(HaveField("ObjectMeta.OwnerReferences", ConsistOf(expectedOwnerReference)))
 			}
 		})
 
-		PIt("should log the update that was needed", func() {
+		It("should log the update that was needed", func() {
 			expectedEntries := []test.LogEntry{}
 
 			machineInfos0 := machineInfos[0]
@@ -497,17 +511,15 @@ var _ = Describe("ensureOwnerRefrences", func() {
 				Message:       "Added owner reference to machine",
 			})
 
-			skippedOne := false
-			for _, machineInfo := range machineInfos {
-				if !skippedOne {
-					skippedOne = true
+			for i, machineInfo := range machineInfos {
+				if i == 0 {
 					continue
 				}
 
-				for i := range machineInfo {
-					Expect(machineInfo[i].MachineRef).ToNot(BeNil())
+				for j := range machineInfo {
+					Expect(machineInfo[j].MachineRef).ToNot(BeNil())
 					expectedEntries = append(expectedEntries, test.LogEntry{
-						KeysAndValues: []interface{}{"machineNamespace", machineInfo[i].MachineRef.ObjectMeta.GetNamespace(), "machineName", machineInfo[i].MachineRef.ObjectMeta.GetName()},
+						KeysAndValues: []interface{}{"machineNamespace", machineInfo[j].MachineRef.ObjectMeta.GetNamespace(), "machineName", machineInfo[j].MachineRef.ObjectMeta.GetName()},
 						Level:         4,
 						Message:       "Owner reference already present on machine",
 					})
@@ -531,7 +543,7 @@ var _ = Describe("ensureOwnerRefrences", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		PIt("should add the expected owner references", func() {
+		It("should add the expected owner references", func() {
 			for _, machine := range machines {
 				if machine.GetName() == skipMachine {
 					continue
@@ -541,7 +553,7 @@ var _ = Describe("ensureOwnerRefrences", func() {
 			}
 		})
 
-		PIt("should log that it has updated the owner references", func() {
+		It("should log that it has updated the owner references", func() {
 			expectedEntries := []test.LogEntry{}
 
 			for _, machine := range machines {
@@ -565,45 +577,53 @@ var _ = Describe("ensureOwnerRefrences", func() {
 
 		BeforeEach(func() {
 			By("Adding an owner reference to some of the machine infos")
-			Expect(machineInfos).To(HaveLen(3))
 
-			skippedOne := false
+			Expect(machineInfos).To(HaveLen(3))
+			Expect(machines).To(HaveLen(3))
+
+			badOwnerReference := expectedOwnerReference
+			badOwnerReference.Name = "different-owner"
+
 			for i := range machineInfos {
-				if !skippedOne {
-					skippedOne = true
+				if i == 0 {
+					By("Adding an owner reference for an alternative controller owner")
+					Expect(machineInfos[0][0].MachineRef).ToNot(BeNil())
+					machineInfos[i][i].MachineRef.ObjectMeta.OwnerReferences = []metav1.OwnerReference{badOwnerReference}
 					continue
 				}
+
 				for j := range machineInfos[i] {
 					Expect(machineInfos[i][j].MachineRef).ToNot(BeNil())
 					machineInfos[i][j].MachineRef.ObjectMeta.OwnerReferences = []metav1.OwnerReference{expectedOwnerReference}
 				}
+
+				patchBase := client.MergeFrom(machines[i].DeepCopy())
+				machines[i].SetOwnerReferences([]metav1.OwnerReference{expectedOwnerReference})
+				Expect(k8sClient.Patch(ctx, machines[i], patchBase)).To(Succeed())
 			}
 
-			By("Adding an owner reference for an alternative controller owner")
-			badOwnerReference := expectedOwnerReference
-			badOwnerReference.Name = "different-owner"
-
-			Expect(machineInfos[0][0].MachineRef).ToNot(BeNil())
-			machineInfos[0][0].MachineRef.ObjectMeta.OwnerReferences = []metav1.OwnerReference{badOwnerReference}
-
 			By("Formulating the expected error")
-			machine := resourcebuilder.Machine().WithNamespace(namespaceName).Build()
+			machine := &metav1.PartialObjectMetadata{
+				TypeMeta: metav1.TypeMeta{Kind: "Machine",
+					APIVersion: "machine.openshift.io/v1beta1",
+				},
+				ObjectMeta: machineInfos[0][0].MachineRef.ObjectMeta,
+			}
 			machine.ObjectMeta.OwnerReferences = []metav1.OwnerReference{badOwnerReference}
 
-			setControllerErr := controllerutil.SetControllerReference(cpms, machine, testScheme)
-			Expect(setControllerErr).To(HaveOccurred())
-			expectedError = fmt.Errorf("error setting owner reference: %w", setControllerErr)
+			expectedError = controllerutil.SetControllerReference(cpms, machine, testScheme)
+			Expect(expectedError).To(HaveOccurred())
 
 			err = reconciler.ensureOwnerReferences(ctx, logger.Logger(), cpms, machineInfos)
 		})
 
-		PIt("should not return an error", func() {
+		It("should not return an error", func() {
 			// Do not return an error as this would cause the controller to requeue.
 			// The degraded conditions check will ensure we do not take any further action.
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		PIt("should add an error log", func() {
+		It("should add an error log", func() {
 			expectedEntries := []test.LogEntry{}
 
 			machineInfo0 := machineInfos[0]
@@ -617,11 +637,14 @@ var _ = Describe("ensureOwnerRefrences", func() {
 				Message:       "Cannot add owner reference to machine",
 			})
 
-			for _, machineInfo := range machineInfos {
-				for i := range machineInfo {
-					Expect(machineInfo[i].MachineRef).ToNot(BeNil())
+			for i, machineInfo := range machineInfos {
+				if i == 0 {
+					continue
+				}
+				for j := range machineInfo {
+					Expect(machineInfo[j].MachineRef).ToNot(BeNil())
 					expectedEntries = append(expectedEntries, test.LogEntry{
-						KeysAndValues: []interface{}{"machineNamespace", machineInfo[i].MachineRef.ObjectMeta.GetNamespace(), "machineName", machineInfo[i].MachineRef.ObjectMeta.GetName()},
+						KeysAndValues: []interface{}{"machineNamespace", machineInfo[j].MachineRef.ObjectMeta.GetNamespace(), "machineName", machineInfo[j].MachineRef.ObjectMeta.GetName()},
 						Level:         4,
 						Message:       "Owner reference already present on machine",
 					})
@@ -631,7 +654,7 @@ var _ = Describe("ensureOwnerRefrences", func() {
 			Expect(logger.Entries()).To(ConsistOf(expectedEntries))
 		})
 
-		PIt("should set the degraded condition on the ControlPlaneMachineSet", func() {
+		It("should set the degraded condition on the ControlPlaneMachineSet", func() {
 			Expect(cpms.Status.Conditions).To(ContainElement(test.MatchCondition(
 				metav1.Condition{
 					Type:               conditionDegraded,


### PR DESCRIPTION
Add ownerrefs to machines owned by CPMS. From function TODO: 
```
TODO: Iterate over the MachineInfos, for each Machine, check the owner references for an owner reference matching
that of the current CPMS (it should be the controller so should be easy to find).
If required, look up the GVK using the rest mapper from the GVR, then uses metav1.PartialObjectMetadata to Patch
the owner references. This should mean we can update the metadata of any type given we know the GVR and existing
ObjectMeta.
```