### PR TITLE
[OCPCLOUD-1486] ControlPlaneMachineSet deletion logic

### DIFF
--- a/pkg/machineproviders/providers/machineproviders.go
+++ b/pkg/machineproviders/providers/machineproviders.go
@@ -23,9 +23,11 @@ import (
 
 	"github.com/go-logr/logr"
 	machinev1 "github.com/openshift/api/machine/v1"
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 	"github.com/openshift/cluster-control-plane-machine-set-operator/pkg/machineproviders"
 	openshiftmachinev1beta1 "github.com/openshift/cluster-control-plane-machine-set-operator/pkg/machineproviders/providers/openshift/machine/v1beta1"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -48,5 +50,20 @@ func NewMachineProvider(ctx context.Context, logger logr.Logger, cl client.Clien
 		return provider, nil
 	default:
 		return nil, fmt.Errorf("%w: %s", errUnexpectedMachineType, cpms.Spec.Template.MachineType)
+	}
+}
+
+// GetMachineTypeMeta returns proper TypeMeta from ControlPlaneMachineSetMachineType.
+func GetMachineTypeMeta(cpmsMachineType machinev1.ControlPlaneMachineSetMachineType) (metav1.TypeMeta, error) {
+	switch cpmsMachineType {
+	case machinev1.OpenShiftMachineV1Beta1MachineType:
+		gv := machinev1beta1.GroupVersion
+
+		return metav1.TypeMeta{
+			Kind:       gv.WithKind("Machine").Kind,
+			APIVersion: gv.String(),
+		}, nil
+	default:
+		return metav1.TypeMeta{}, fmt.Errorf("%w: %s", errUnexpectedMachineType, cpmsMachineType)
 	}
 }

--- a/pkg/test/resourcebuilder/consts.go
+++ b/pkg/test/resourcebuilder/consts.go
@@ -20,4 +20,6 @@ const (
 	// OpenshiftMachineAPINamespaceName is the name of the OpenShift
 	// Machine API namespace.
 	OpenshiftMachineAPINamespaceName = "openshift-machine-api"
+
+	testClusterIDValue = "cpms-cluster-test-id"
 )

--- a/pkg/test/resourcebuilder/control_plane_machine_set.go
+++ b/pkg/test/resourcebuilder/control_plane_machine_set.go
@@ -54,7 +54,7 @@ func ControlPlaneMachineSet() ControlPlaneMachineSetBuilder {
 			MatchLabels: map[string]string{
 				machineRoleLabelName:                 "master",
 				machineTypeLabelName:                 "master",
-				machinev1beta1.MachineClusterIDLabel: "cpms-cluster-test-id",
+				machinev1beta1.MachineClusterIDLabel: testClusterIDValue,
 			},
 		},
 		strategyType: machinev1.RollingUpdate,

--- a/pkg/test/resourcebuilder/machine.go
+++ b/pkg/test/resourcebuilder/machine.go
@@ -66,6 +66,8 @@ func (m MachineBuilder) Build() *machinev1beta1.Machine {
 		machine.Spec.ProviderSpec.Value = m.providerSpecBuilder.BuildRawExtension()
 	}
 
+	m.WithLabel(machinev1beta1.MachineClusterIDLabel, testClusterIDValue)
+
 	return machine
 }
 

--- a/pkg/test/resourcebuilder/openshift_machine_v1beta1_template.go
+++ b/pkg/test/resourcebuilder/openshift_machine_v1beta1_template.go
@@ -27,7 +27,7 @@ func OpenShiftMachineV1Beta1Template() OpenShiftMachineV1Beta1TemplateBuilder {
 		labels: map[string]string{
 			machineRoleLabelName:                 "master",
 			machineTypeLabelName:                 "master",
-			machinev1beta1.MachineClusterIDLabel: "cpms-cluster-test-id",
+			machinev1beta1.MachineClusterIDLabel: testClusterIDValue,
 		},
 		providerSpecBuilder: AWSProviderSpec(),
 	}


### PR DESCRIPTION
During ControlPlaneMachineSet deletion procedure
reconciler removes owner reference from the machines which it owns.

This pr introduces such logic, related tests and helper functions.