### PR TITLE
Allow the operator to update a ControlPlaneMachineSet status subresource

### DIFF
--- a/manifests/0000_31_control-plane-machine-set-operator_01_rbac.yaml
+++ b/manifests/0000_31_control-plane-machine-set-operator_01_rbac.yaml
@@ -32,6 +32,7 @@ rules:
       - machine.openshift.io
     resources:
       - controlplanemachinesets
+      - controlplanemachinesets/status
     verbs:
       - get
       - list


### PR DESCRIPTION
Without this permission, we cannot update the status of the ControlPlaneMachineSet resources and the operator runs into errors like:
```
E0720 08:32:16.649730       1 controller.go:326]  "msg"="Reconciler error" "error"="error updating control plane machine set status: failed to sync status for control plane machine set object: controlplanemachinesets.machine.openshift.io \"cluster\" is forbidden: User \"system:serviceaccount:openshift-machine-api:control-plane-machine-set-operator\" cannot update resource \"controlplanemachinesets/status\" in API group \"machine.openshift.io\" in the namespace \"openshift-machine-api\"" "controller"="controlplanemachineset" "reconcileID"="062d5457-ffe3-4749-b56e-9110a9b9c10e"
```