### PR TITLE
Add missing "spec" in error path

### DIFF
--- a/pkg/webhooks/controlplanemachineset/webhooks.go
+++ b/pkg/webhooks/controlplanemachineset/webhooks.go
@@ -256,7 +256,7 @@ func validateOpenShiftMachineV1BetaTemplateOnCreate(parentPath *field.Path, temp
 	errs := []error{}
 
 	if template.FailureDomains.Platform == "" {
-		errs = append(errs, checkOpenShiftProviderSpecFailureDomainMatchesMachines(parentPath.Child("providerSpec"), template, machines)...)
+		errs = append(errs, checkOpenShiftProviderSpecFailureDomainMatchesMachines(parentPath.Child("spec", "providerSpec"), template, machines)...)
 	} else {
 		errs = append(errs, checkOpenShiftFailureDomainsMatchMachines(parentPath.Child("failureDomains"), template.FailureDomains, machines)...)
 	}

--- a/pkg/webhooks/controlplanemachineset/webhooks_test.go
+++ b/pkg/webhooks/controlplanemachineset/webhooks_test.go
@@ -248,7 +248,7 @@ var _ = Describe("Webhooks", func() {
 				templateBuilder := resourcebuilder.OpenShiftMachineV1Beta1Template().WithProviderSpecBuilder(tempateProviderSpec)
 				cpms := builder.WithMachineTemplateBuilder(templateBuilder).Build()
 
-				Expect(apierrors.ReasonForError(k8sClient.Create(ctx, cpms))).To(BeEquivalentTo("spec.template.machines_v1beta1_machine_openshift_io.providerSpec: Invalid value: AWSFailureDomain{AvailabilityZone:different-zone-1, Subnet:{Type:Filters, Value:&[{Name:tag:Name Values:[aws-subnet-12345678]}]}}: Failure domain extracted from machine template providerSpec does not match failure domain of all control plane machines"))
+				Expect(apierrors.ReasonForError(k8sClient.Create(ctx, cpms))).To(BeEquivalentTo("spec.template.machines_v1beta1_machine_openshift_io.spec.providerSpec: Invalid value: AWSFailureDomain{AvailabilityZone:different-zone-1, Subnet:{Type:Filters, Value:&[{Name:tag:Name Values:[aws-subnet-12345678]}]}}: Failure domain extracted from machine template providerSpec does not match failure domain of all control plane machines"))
 			})
 
 			It("with invalid failure domain information", func() {


### PR DESCRIPTION
"template" field in error path was erroneously removed instead of changing it into "spec".
This PR adds the "spec" field to the error path.