### PR TITLE
Test CPMS degraded when failing to create new Machines

### DIFF
--- a/pkg/controllers/controlplanemachineset/consts.go
+++ b/pkg/controllers/controlplanemachineset/consts.go
@@ -65,6 +65,12 @@ const (
 	// and is not currently encountering any issues in operation.
 	reasonAsExpected = "AsExpected"
 
+	// reasonFailedReplacement denotes that the ControlPlaneMachineSet has identified that
+	// a replacement machines is in an error state. In this case, operations must not
+	// continue and manual intervention is required to identify and rectify the cause
+	// of the issue.
+	reasonFailedReplacement = "FailedReplacement"
+
 	// reasonInvalidStrategy denotes that the ControlPlaneMachineSet has identified an
 	// invalid value for the spec.strategy.type field.
 	// This must be resolved by the user before operation of the ControlPlaneMachineSet

--- a/pkg/controllers/controlplanemachineset/controller.go
+++ b/pkg/controllers/controlplanemachineset/controller.go
@@ -404,13 +404,14 @@ func (r *ControlPlaneMachineSetReconciler) ensureOwnerReferences(ctx context.Con
 }
 
 // validateClusterState uses the machineInfos to validate that:
-// - All Nodes in the cluster claiming to be control plane nodes have a valid machine
+// - All Nodes in the cluster claiming to be control plane nodes have a valid machine.
 // - At least 1 of the control plane machines is in the ready state (if there are no ready Machines then the cluster
-//   is likely misconfigured)
+//   is likely misconfigured).
 // - We have the correct number of indexes:
-//   + Right number of indexes, valid
-//   + Too few indexes, valid. We will later scale up without user intervention when we perform reconcileMachineUpdates
-//   + Too many indexes, invalid. We set the operator to degraded and ask the user for manual intervention
+//   + Right number of indexes, valid.
+//   + Too few indexes, valid. We will later scale up without user intervention when we perform reconcileMachineUpdates.
+//   + Too many indexes, invalid. We set the operator to degraded and ask the user for manual intervention.
+// - No replacement machines (one that doesn't need update but has an equivalent in the index that needs update) have an error.
 func (r *ControlPlaneMachineSetReconciler) validateClusterState(ctx context.Context, logger logr.Logger, cpms *machinev1.ControlPlaneMachineSet, machineInfos map[int32][]machineproviders.MachineInfo) error {
 	return nil
 }


### PR DESCRIPTION
If we know that we aren't going to progress with a rollout, we should degrade the operator.
So, if we can see that a newly created replacement machine errors straight away, for example because the new instance type was invalid, then we should report that and go degraded.

If an existing Machine goes failed, this wouldn't result in degraded as a MachineHealthCheck should cause the Machine to be deleted, and then in that case, we would replace the Machine. Also, if we do go degraded when any Machine is failed, we will not be able to create a replacement Machine if the Failed Machine becomes deleted.