### PR TITLE
Add image-references

### DIFF
--- a/manifests/0000_31_control-plane-machine-set-operator_03_deployment.yaml
+++ b/manifests/0000_31_control-plane-machine-set-operator_03_deployment.yaml
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: control-plane-machine-set-operator
       containers:
       - name: control-plane-machine-set-operator
-        image: quay.io/origin/origin-control-plane-machine-set-operator
+        image: quay.io/openshift/origin-cluster-control-plane-machine-set-operator
         command:
         - "/manager"
         args:

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -1,0 +1,8 @@
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+spec:
+  tags:
+  - name: cluster-control-plane-machine-set-operator
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-cluster-control-plane-machine-set-operator


### PR DESCRIPTION
To allow CPMS operator to be installed by CVO we need to create an
image-references file.

For more information:
https://github.com/openshift/enhancements/blob/master/dev-guide/cluster-version-operator/dev/operators.md#how-do-i-ensure-the-right-images-get-used-by-my-manifests