### PR TITLE
Bug 2115638: Ensure that the failure domain mapping is respected in getMachineInfo

### DIFF
--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/mapping.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/mapping.go
@@ -71,7 +71,7 @@ func mapMachineIndexesToFailureDomains(ctx context.Context, logger logr.Logger, 
 
 	logger.V(4).Info(
 		"Mapped provided failure domains",
-		"mapping", out,
+		"mapping", fmt.Sprintf("%v", out),
 	)
 
 	return out, nil

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/mapping_test.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/mapping_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1beta1
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -230,11 +232,11 @@ var _ = Describe("Failure Domain Mapping", func() {
 					{
 						Level: 4,
 						KeysAndValues: []interface{}{
-							"mapping", map[int32]failuredomain.FailureDomain{
+							"mapping", fmt.Sprintf("%v", map[int32]failuredomain.FailureDomain{
 								0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
 								1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
 								2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
-							},
+							}),
 						},
 						Message: "Mapped provided failure domains",
 					},
@@ -261,11 +263,11 @@ var _ = Describe("Failure Domain Mapping", func() {
 					{
 						Level: 4,
 						KeysAndValues: []interface{}{
-							"mapping", map[int32]failuredomain.FailureDomain{
+							"mapping", fmt.Sprintf("%v", map[int32]failuredomain.FailureDomain{
 								0: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
 								1: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
 								2: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
-							},
+							}),
 						},
 						Message: "Mapped provided failure domains",
 					},
@@ -292,11 +294,11 @@ var _ = Describe("Failure Domain Mapping", func() {
 					{
 						Level: 4,
 						KeysAndValues: []interface{}{
-							"mapping", map[int32]failuredomain.FailureDomain{
+							"mapping", fmt.Sprintf("%v", map[int32]failuredomain.FailureDomain{
 								0: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
 								1: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
 								2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
-							},
+							}),
 						},
 						Message: "Mapped provided failure domains",
 					},
@@ -327,13 +329,13 @@ var _ = Describe("Failure Domain Mapping", func() {
 					{
 						Level: 4,
 						KeysAndValues: []interface{}{
-							"mapping", map[int32]failuredomain.FailureDomain{
+							"mapping", fmt.Sprintf("%v", map[int32]failuredomain.FailureDomain{
 								0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
 								1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
 								2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
 								3: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
 								4: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
-							},
+							}),
 						},
 						Message: "Mapped provided failure domains",
 					},
@@ -364,13 +366,13 @@ var _ = Describe("Failure Domain Mapping", func() {
 					{
 						Level: 4,
 						KeysAndValues: []interface{}{
-							"mapping", map[int32]failuredomain.FailureDomain{
+							"mapping", fmt.Sprintf("%v", map[int32]failuredomain.FailureDomain{
 								0: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
 								1: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
 								2: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
 								3: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
 								4: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
-							},
+							}),
 						},
 						Message: "Mapped provided failure domains",
 					},
@@ -401,13 +403,13 @@ var _ = Describe("Failure Domain Mapping", func() {
 					{
 						Level: 4,
 						KeysAndValues: []interface{}{
-							"mapping", map[int32]failuredomain.FailureDomain{
+							"mapping", fmt.Sprintf("%v", map[int32]failuredomain.FailureDomain{
 								0: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
 								1: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
 								2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
 								3: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
 								4: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
-							},
+							}),
 						},
 						Message: "Mapped provided failure domains",
 					},
@@ -441,11 +443,11 @@ var _ = Describe("Failure Domain Mapping", func() {
 					{
 						Level: 4,
 						KeysAndValues: []interface{}{
-							"mapping", map[int32]failuredomain.FailureDomain{
+							"mapping", fmt.Sprintf("%v", map[int32]failuredomain.FailureDomain{
 								0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
 								1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
 								2: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
-							},
+							}),
 						},
 						Message: "Mapped provided failure domains",
 					},
@@ -479,11 +481,11 @@ var _ = Describe("Failure Domain Mapping", func() {
 					{
 						Level: 4,
 						KeysAndValues: []interface{}{
-							"mapping", map[int32]failuredomain.FailureDomain{
+							"mapping", fmt.Sprintf("%v", map[int32]failuredomain.FailureDomain{
 								0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
 								1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
 								2: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
-							},
+							}),
 						},
 						Message: "Mapped provided failure domains",
 					},
@@ -524,11 +526,11 @@ var _ = Describe("Failure Domain Mapping", func() {
 					{
 						Level: 4,
 						KeysAndValues: []interface{}{
-							"mapping", map[int32]failuredomain.FailureDomain{
+							"mapping", fmt.Sprintf("%v", map[int32]failuredomain.FailureDomain{
 								0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
 								1: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
 								2: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
-							},
+							}),
 						},
 						Message: "Mapped provided failure domains",
 					},
@@ -564,11 +566,11 @@ var _ = Describe("Failure Domain Mapping", func() {
 					{
 						Level: 4,
 						KeysAndValues: []interface{}{
-							"mapping", map[int32]failuredomain.FailureDomain{
+							"mapping", fmt.Sprintf("%v", map[int32]failuredomain.FailureDomain{
 								0: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
 								1: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
 								2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
-							},
+							}),
 						},
 						Message: "Mapped provided failure domains",
 					},
@@ -602,11 +604,11 @@ var _ = Describe("Failure Domain Mapping", func() {
 					{
 						Level: 4,
 						KeysAndValues: []interface{}{
-							"mapping", map[int32]failuredomain.FailureDomain{
+							"mapping", fmt.Sprintf("%v", map[int32]failuredomain.FailureDomain{
 								0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
 								1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
 								2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
-							},
+							}),
 						},
 						Message: "Mapped provided failure domains",
 					},
@@ -640,11 +642,11 @@ var _ = Describe("Failure Domain Mapping", func() {
 					{
 						Level: 4,
 						KeysAndValues: []interface{}{
-							"mapping", map[int32]failuredomain.FailureDomain{
+							"mapping", fmt.Sprintf("%v", map[int32]failuredomain.FailureDomain{
 								0: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
 								1: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
 								2: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
-							},
+							}),
 						},
 						Message: "Mapped provided failure domains",
 					},
@@ -684,13 +686,13 @@ var _ = Describe("Failure Domain Mapping", func() {
 					{
 						Level: 4,
 						KeysAndValues: []interface{}{
-							"mapping", map[int32]failuredomain.FailureDomain{
+							"mapping", fmt.Sprintf("%v", map[int32]failuredomain.FailureDomain{
 								0: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
 								1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
 								2: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
 								3: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
 								4: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
-							},
+							}),
 						},
 						Message: "Mapped provided failure domains",
 					},


### PR DESCRIPTION
This fixes two things, firstly that we weren't respecting the failure domain mapping from reconcile mappings when a Machine had a different failure domain. This means the rebalancing won't work. We were comparing the failure domain from the machine to failure domain from the machine, where it should have been the failure domain from the mapping.

Secondly, for some reason logging the mapping directly resulted in a map of integers to nil values, the only way I could work out to fix this was to flatten it to a string.

This PR would best be reviewed commit wise