### PR TITLE
Add manifests in the resulting docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,6 @@ RUN make build
 
 FROM registry.ci.openshift.org/ocp/4.11:base
 COPY --from=builder /go/src/github.com/openshift/cluster-control-plane-machine-set-operator/bin/manager .
+COPY --from=builder /go/src/github.com/openshift/cluster-control-plane-machine-set-operator/manifests manifests
 
 LABEL io.openshift.release.operator true

--- a/pkg/controllers/controlplanemachineset/controller.go
+++ b/pkg/controllers/controlplanemachineset/controller.go
@@ -71,6 +71,9 @@ type ControlPlaneMachineSetReconciler struct {
 	// OperatorName is the name of the ClusterOperator with which the controller should report
 	// its status.
 	OperatorName string
+
+	// ReleaseVersion is the version of current cluster operator release.
+	ReleaseVersion string
 }
 
 // SetupWithManager sets up the controller with the Manager.


### PR DESCRIPTION
Currently we don't copy manifests in the image and therefore CVO can't deploy it.