### PR TITLE
Add .ci-operator.yaml file

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,4 @@
+build_root_image:
+  name: release
+  namespace: openshift
+  tag: rhel-8-release-golang-1.18-openshift-4.11


### PR DESCRIPTION
This will allow us to manage build root image from the repo.
This is a prerequisite for https://github.com/openshift/release/pull/31146