### PR TITLE
Bug 2115358: Fix panic when injecting nil FailureDomain

### DIFF
--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/failuredomain/failuredomain.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/failuredomain/failuredomain.go
@@ -119,6 +119,10 @@ func (f failureDomain) OpenStack() machinev1.OpenStackFailureDomain {
 
 // Equal compares the underlying failure domain.
 func (f failureDomain) Equal(other FailureDomain) bool {
+	if other == nil {
+		return false
+	}
+
 	if f.platformType != other.Type() {
 		return false
 	}

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/failuredomain/failuredomain_test.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/failuredomain/failuredomain_test.go
@@ -360,6 +360,19 @@ var _ = Describe("FailureDomains", func() {
 			})
 		})
 
+		Context("With nil failure domain", func() {
+			BeforeEach(func() {
+				fd1 = failureDomain{
+					platformType: configv1.AWSPlatformType,
+					aws:          resourcebuilder.AWSFailureDomain().WithAvailabilityZone("us-east-1a").Build(),
+				}
+			})
+
+			It("returns false", func() {
+				Expect(fd1.Equal(nil)).To(BeFalse())
+			})
+		})
+
 		Context("With two identical Azure failure domains", func() {
 			BeforeEach(func() {
 				fd1 = failureDomain{

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/providerconfig.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/providerconfig.go
@@ -160,6 +160,10 @@ func (p providerConfig) ExtractFailureDomain() failuredomain.FailureDomain {
 
 // Equal compares two ProviderConfigs to determine whether or not they are equal.
 func (p providerConfig) Equal(other ProviderConfig) (bool, error) {
+	if other == nil {
+		return false, nil
+	}
+
 	if p.platformType != other.Type() {
 		return false, errMismatchedPlatformTypes
 	}

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/providerconfig.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/providerconfig.go
@@ -44,6 +44,9 @@ var (
 
 	// errUnsupportedProviderConfigType is an error used when provider spec is nil.
 	errNilProviderSpec = errors.New("provider spec is nil")
+
+	// errNilFailureDomain is an error used when when nil value is present and failure domain is expected.
+	errNilFailureDomain = errors.New("failure domain is nil")
 )
 
 // ProviderConfig is an interface that allows external code to interact
@@ -121,6 +124,10 @@ type providerConfig struct {
 // The returned ProviderConfig will be a copy of the current ProviderConfig with
 // the new failure domain injected.
 func (p providerConfig) InjectFailureDomain(fd failuredomain.FailureDomain) (ProviderConfig, error) {
+	if fd == nil {
+		return nil, errNilFailureDomain
+	}
+
 	newConfig := p
 
 	switch p.platformType {

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/providerconfig_test.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/providerconfig_test.go
@@ -431,6 +431,13 @@ var _ = Describe("Provider Config", func() {
 
 			Expect(equal).To(Equal(in.expectedEqual), "Equality of provider configs was not as expected")
 		},
+			Entry("with nil provider config", equalTableInput{
+				basePC: &providerConfig{
+					platformType: configv1.AWSPlatformType,
+				},
+				comparePC:     nil,
+				expectedEqual: false,
+			}),
 			Entry("with different platform types", equalTableInput{
 				basePC: &providerConfig{
 					platformType: configv1.AWSPlatformType,

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/providerconfig_test.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/providerconfig_test.go
@@ -128,12 +128,37 @@ var _ = Describe("Provider Config", func() {
 
 			if in.expectedError != nil {
 				Expect(err).To(MatchError(in.expectedError))
+				Expect(pc).To(BeNil())
 			} else {
 				Expect(err).ToNot(HaveOccurred())
+				Expect(pc).To(HaveField(in.matchPath, Equal(in.matchExpectation)))
 			}
 
-			Expect(pc).To(HaveField(in.matchPath, Equal(in.matchExpectation)))
 		},
+			Entry("with nil failure domain", injectFailureDomainTableInput{
+				providerConfig: &providerConfig{
+					platformType: configv1.AWSPlatformType,
+					aws: AWSProviderConfig{
+						providerConfig: *resourcebuilder.AWSProviderSpec().WithAvailabilityZone("us-east-1a").Build(),
+					},
+				},
+				failureDomain: nil,
+				expectedError: errNilFailureDomain,
+			}),
+			Entry("with empty failure domain", injectFailureDomainTableInput{
+				providerConfig: &providerConfig{
+					platformType: configv1.AWSPlatformType,
+					aws: AWSProviderConfig{
+						providerConfig: *resourcebuilder.AWSProviderSpec().WithAvailabilityZone("us-east-1a").Build(),
+					},
+				},
+				failureDomain: failuredomain.NewAWSFailureDomain(
+					machinev1.AWSFailureDomain{},
+				),
+				expectedError:    nil,
+				matchPath:        "AWS().Config().Placement.AvailabilityZone",
+				matchExpectation: "",
+			}),
 			Entry("when keeping an AWS availability zone the same", injectFailureDomainTableInput{
 				providerConfig: &providerConfig{
 					platformType: configv1.AWSPlatformType,


### PR DESCRIPTION
This PR fixes panic when trying to inject nil failure domain and two potential panics when comparing FailureDomains and ProviderConfigs.