### PR TITLE
Bug 2117439: Add webhook validation to prevent scenarios which can create known broken clusters

### DIFF
--- a/pkg/test/resourcebuilder/azure_failure_domains.go
+++ b/pkg/test/resourcebuilder/azure_failure_domains.go
@@ -58,7 +58,7 @@ func (a AzureFailureDomainsBuilder) WithFailureDomainBuilder(fdbuilder AzureFail
 }
 
 // WithFailureDomainBuilders replaces the failure domains builder's builders with the given builders.
-func (a AzureFailureDomainsBuilder) WithFailureDomainBuilders(fdbuilders []AzureFailureDomainBuilder) AzureFailureDomainsBuilder {
+func (a AzureFailureDomainsBuilder) WithFailureDomainBuilders(fdbuilders ...AzureFailureDomainBuilder) AzureFailureDomainsBuilder {
 	a.failureDomainsBuilders = fdbuilders
 	return a
 }

--- a/pkg/test/resourcebuilder/azure_provider_spec.go
+++ b/pkg/test/resourcebuilder/azure_provider_spec.go
@@ -28,15 +28,17 @@ import (
 // AzureProviderSpec creates a new Azure machine config builder.
 func AzureProviderSpec() AzureProviderSpecBuilder {
 	return AzureProviderSpecBuilder{
-		Zone:   "1",
-		VMSize: "Standard_D4s_v3",
+		internalLoadBalancer: "internal-load-balancer-12345678",
+		vmSize:               "Standard_D4s_v3",
+		zone:                 "1",
 	}
 }
 
 // AzureProviderSpecBuilder is used to build a Azure machine config object.
 type AzureProviderSpecBuilder struct {
-	Zone   string
-	VMSize string
+	internalLoadBalancer string
+	vmSize               string
+	zone                 string
 }
 
 // Build builds a new Azure machine config based on the configuration provided.
@@ -55,7 +57,7 @@ func (m AzureProviderSpecBuilder) Build() *machinev1beta1.AzureMachineProviderSp
 		},
 		Location: "test-location",
 		Vnet:     "vnet-12345678",
-		VMSize:   m.VMSize,
+		VMSize:   m.vmSize,
 		Image: machinev1beta1.Image{
 			ResourceID: "/resourceGroups/test-rg/providers/Microsoft.Compute/images/test-image",
 		},
@@ -68,10 +70,11 @@ func (m AzureProviderSpecBuilder) Build() *machinev1beta1.AzureMachineProviderSp
 			OSType: "Linux",
 		},
 		NetworkResourceGroup:  "network-resource-group-12345678",
+		InternalLoadBalancer:  m.internalLoadBalancer,
 		PublicLoadBalancer:    "public-load-balancer-12345678",
 		PublicIP:              false,
 		ResourceGroup:         "resource-group-12345678",
-		Zone:                  &m.Zone,
+		Zone:                  &m.zone,
 		AcceleratedNetworking: true,
 		Subnet:                "subnet-12345678",
 	}
@@ -92,14 +95,20 @@ func (m AzureProviderSpecBuilder) BuildRawExtension() *runtime.RawExtension {
 	}
 }
 
-// WithZone sets the availabilityZone for the Azure machine config builder.
-func (m AzureProviderSpecBuilder) WithZone(az string) AzureProviderSpecBuilder {
-	m.Zone = az
+// WithInternalLoadBalancer sets the internalLoadBalancer for the Azure machine config builder.
+func (m AzureProviderSpecBuilder) WithInternalLoadBalancer(lb string) AzureProviderSpecBuilder {
+	m.internalLoadBalancer = lb
 	return m
 }
 
 // WithVMSize sets the VMSize (Instance type) for the Azure machine config builder.
 func (m AzureProviderSpecBuilder) WithVMSize(vmSize string) AzureProviderSpecBuilder {
-	m.VMSize = vmSize
+	m.vmSize = vmSize
+	return m
+}
+
+// WithZone sets the availabilityZone for the Azure machine config builder.
+func (m AzureProviderSpecBuilder) WithZone(az string) AzureProviderSpecBuilder {
+	m.zone = az
 	return m
 }

--- a/pkg/test/resourcebuilder/gcp_failure_domains.go
+++ b/pkg/test/resourcebuilder/gcp_failure_domains.go
@@ -58,7 +58,7 @@ func (g GCPFailureDomainsBuilder) WithFailureDomainBuilder(fdbuilder GCPFailureD
 }
 
 // WithFailureDomainBuilders replaces the failure domains builder's builders with the given builders.
-func (g GCPFailureDomainsBuilder) WithFailureDomainBuilders(fdbuilders []GCPFailureDomainBuilder) GCPFailureDomainsBuilder {
+func (g GCPFailureDomainsBuilder) WithFailureDomainBuilders(fdbuilders ...GCPFailureDomainBuilder) GCPFailureDomainsBuilder {
 	g.failureDomainsBuilders = fdbuilders
 	return g
 }

--- a/pkg/test/resourcebuilder/openstack_failure_domains.go
+++ b/pkg/test/resourcebuilder/openstack_failure_domains.go
@@ -58,7 +58,7 @@ func (m OpenStackFailureDomainsBuilder) WithFailureDomainBuilder(fdbuilder OpenS
 }
 
 // WithFailureDomainBuilders replaces the OpenStack failure domains builder's builders with the given builders.
-func (m OpenStackFailureDomainsBuilder) WithFailureDomainBuilders(fdbuilders []OpenStackFailureDomainBuilder) OpenStackFailureDomainsBuilder {
+func (m OpenStackFailureDomainsBuilder) WithFailureDomainBuilders(fdbuilders ...OpenStackFailureDomainBuilder) OpenStackFailureDomainsBuilder {
 	m.failureDomainsBuilders = fdbuilders
 	return m
 }

--- a/pkg/webhooks/controlplanemachineset/webhooks.go
+++ b/pkg/webhooks/controlplanemachineset/webhooks.go
@@ -246,6 +246,7 @@ func validateOpenShiftMachineV1BetaTemplate(parentPath *field.Path, template mac
 
 	errs = append(errs, validateTemplateLabels(parentPath.Child("metadata", "labels"), template.ObjectMeta.Labels, selector)...)
 	errs = append(errs, validateOpenShiftFailureDomains(parentPath.Child("failureDomains"), template.FailureDomains)...)
+	errs = append(errs, validateOpenShiftProviderConfig(parentPath, template)...)
 
 	return errs
 }
@@ -332,6 +333,38 @@ func validateOpenShiftAWSFailureDomains(parentPath *field.Path, failureDomains *
 
 	for i, failureDomain := range *failureDomains {
 		errs = append(errs, validateDiscriminatedUnion(parentPath.Index(i).Child("subnet"), failureDomain.Subnet, "Type")...)
+	}
+
+	return errs
+}
+
+// validateOpenShiftProviderConfig checks the provider config on the ControlPlaneMachineSet to ensure that the
+// ControlPlaneMachineSet can safely replace control plane machines.
+func validateOpenShiftProviderConfig(parentPath *field.Path, template machinev1.OpenShiftMachineV1Beta1MachineTemplate) []error {
+	providerSpecPath := parentPath.Child("spec", "providerSpec")
+
+	providerConfig, err := providerconfig.NewProviderConfigFromMachineTemplate(template)
+	if err != nil {
+		return []error{field.Invalid(providerSpecPath, template.Spec.ProviderSpec, fmt.Sprintf("error determining provider configuration: %s", err))}
+	}
+
+	switch providerConfig.Type() {
+	case configv1.AzurePlatformType:
+		return validateOpenShiftAzureProviderConfig(providerSpecPath.Child("value"), providerConfig.Azure())
+	}
+
+	return []error{}
+}
+
+// validateOpenShiftAzureProviderConfig runs Azure specific checks on the provider config on the ControlPlaneMachineSet.
+// This ensure that the ControlPlaneMachineSet can safely replace Azure control plane machines.
+func validateOpenShiftAzureProviderConfig(parentPath *field.Path, providerConfig providerconfig.AzureProviderConfig) []error {
+	errs := []error{}
+
+	config := providerConfig.Config()
+
+	if config.InternalLoadBalancer == "" {
+		errs = append(errs, field.Required(parentPath.Child("internalLoadBalancer"), "internalLoadBalancer is required for control plane machines"))
 	}
 
 	return errs

--- a/pkg/webhooks/controlplanemachineset/webhooks.go
+++ b/pkg/webhooks/controlplanemachineset/webhooks.go
@@ -351,6 +351,8 @@ func validateOpenShiftProviderConfig(parentPath *field.Path, template machinev1.
 	switch providerConfig.Type() {
 	case configv1.AzurePlatformType:
 		return validateOpenShiftAzureProviderConfig(providerSpecPath.Child("value"), providerConfig.Azure())
+	case configv1.GCPPlatformType:
+		return validateOpenShiftGCPProviderConfig(providerSpecPath.Child("value"), providerConfig.GCP())
 	}
 
 	return []error{}
@@ -368,6 +370,14 @@ func validateOpenShiftAzureProviderConfig(parentPath *field.Path, providerConfig
 	}
 
 	return errs
+}
+
+// validateOpenShiftGCPProviderConfig runs GCP specific checks on the provider config on the ControlPlaneMachineSet.
+// This ensure that the ControlPlaneMachineSet can safely replace GCP control plane machines.
+func validateOpenShiftGCPProviderConfig(parentPath *field.Path, _ providerconfig.GCPProviderConfig) []error {
+	// On GCP, we do not currently update the backend pools for the inernal load balancer.
+	// Until this is supported in Machine API Provider GCP, we cannot safely replace control plane machines.
+	return []error{field.Forbidden(parentPath, "automatic replacement of control plane machines on GCP is not currently supported")}
 }
 
 // fetchControlPlaneMachines returns all control plane machines in the cluster.

--- a/pkg/webhooks/controlplanemachineset/webhooks_test.go
+++ b/pkg/webhooks/controlplanemachineset/webhooks_test.go
@@ -47,6 +47,10 @@ var _ = Describe("Webhooks", func() {
 
 	var namespaceName string
 
+	const (
+		dummyValue = "value"
+	)
+
 	BeforeEach(func() {
 		By("Setting up a namespace for the test")
 		ns := resourcebuilder.Namespace().WithGenerateName("control-plane-machine-set-webhook-").Build()
@@ -510,112 +514,295 @@ var _ = Describe("Webhooks", func() {
 				})
 			})
 		})
+
+		Context("on Azure", func() {
+			zone1Builder := resourcebuilder.AzureFailureDomain().WithZone("1")
+			zone2Builder := resourcebuilder.AzureFailureDomain().WithZone("2")
+			zone3Builder := resourcebuilder.AzureFailureDomain().WithZone("3")
+			zone4Builder := resourcebuilder.AzureFailureDomain().WithZone("4")
+
+			BeforeEach(func() {
+				providerSpec := resourcebuilder.AzureProviderSpec()
+				machineTemplate = resourcebuilder.OpenShiftMachineV1Beta1Template().WithProviderSpecBuilder(providerSpec)
+				// Default CPMS builder should be valid, individual tests will override to make it invalid
+				builder = resourcebuilder.ControlPlaneMachineSet().WithNamespace(namespaceName).WithMachineTemplateBuilder(machineTemplate)
+
+				machineBuilder := resourcebuilder.Machine().WithNamespace(namespaceName)
+
+				By("Creating a selection of Machines")
+				for i := 1; i <= 3; i++ {
+					controlPlaneMachineBuilder := machineBuilder.WithGenerateName("control-plane-machine-").AsMaster().WithProviderSpecBuilder(providerSpec.WithZone(fmt.Sprintf("%d", i)))
+
+					controlPlaneMachine := controlPlaneMachineBuilder.Build()
+					Expect(k8sClient.Create(ctx, controlPlaneMachine)).To(Succeed())
+				}
+			})
+
+			It("with a valid failure domains spec", func() {
+				cpms := builder.WithMachineTemplateBuilder(machineTemplate.WithFailureDomainsBuilder(
+					resourcebuilder.AzureFailureDomains().WithFailureDomainBuilders(
+						zone1Builder,
+						zone2Builder,
+						zone3Builder,
+					),
+				)).Build()
+
+				Expect(k8sClient.Create(ctx, cpms)).To(Succeed())
+			})
+
+			It("with a mismatched failure domains spec", func() {
+				cpms := builder.WithMachineTemplateBuilder(machineTemplate.WithFailureDomainsBuilder(
+					resourcebuilder.AzureFailureDomains().WithFailureDomainBuilders(
+						zone1Builder,
+						zone2Builder,
+						zone4Builder,
+					),
+				)).Build()
+
+				Expect(k8sClient.Create(ctx, cpms)).To(MatchError(
+					ContainSubstring("spec.template.machines_v1beta1_machine_openshift_io.failureDomains: Forbidden: control plane machines are using unspecified failure domain(s) [AzureFailureDomain{Zone:3}]"),
+				))
+			})
+
+			It("when reducing the availability", func() {
+				cpms := builder.WithMachineTemplateBuilder(machineTemplate.WithFailureDomainsBuilder(
+					resourcebuilder.AzureFailureDomains().WithFailureDomainBuilders(
+						zone1Builder,
+						zone2Builder,
+					),
+				)).Build()
+
+				Expect(k8sClient.Create(ctx, cpms)).To(MatchError(
+					ContainSubstring("spec.template.machines_v1beta1_machine_openshift_io.failureDomains: Forbidden: control plane machines are using unspecified failure domain(s) [AzureFailureDomain{Zone:3}]"),
+				))
+			})
+
+			It("when increasing the availability", func() {
+				cpms := builder.WithMachineTemplateBuilder(machineTemplate.WithFailureDomainsBuilder(
+					resourcebuilder.AzureFailureDomains().WithFailureDomainBuilders(
+						zone1Builder,
+						zone2Builder,
+						zone3Builder,
+						zone4Builder,
+					),
+				)).Build()
+
+				Expect(k8sClient.Create(ctx, cpms)).To(Succeed())
+			})
+
+			It("with an internal load balancer", func() {
+				cpms := builder.WithMachineTemplateBuilder(machineTemplate.WithFailureDomainsBuilder(
+					resourcebuilder.AzureFailureDomains().WithFailureDomainBuilders(
+						zone1Builder,
+						zone2Builder,
+						zone3Builder,
+					),
+				).WithProviderSpecBuilder(
+					resourcebuilder.AzureProviderSpec().WithInternalLoadBalancer("internal-load-balancer-12345678"),
+				),
+				).Build()
+
+				Expect(k8sClient.Create(ctx, cpms)).To(Succeed())
+			})
+
+			It("without an internal load balancer", func() {
+				cpms := builder.WithMachineTemplateBuilder(machineTemplate.WithFailureDomainsBuilder(
+					resourcebuilder.AzureFailureDomains().WithFailureDomainBuilders(
+						zone1Builder,
+						zone2Builder,
+						zone3Builder,
+					),
+				).WithProviderSpecBuilder(
+					resourcebuilder.AzureProviderSpec().WithInternalLoadBalancer(""), // Set to the empty string to remove it.
+				)).Build()
+
+				Expect(k8sClient.Create(ctx, cpms)).To(MatchError(
+					ContainSubstring("spec.template.machines_v1beta1_machine_openshift_io.spec.providerSpec.value.internalLoadBalancer: Required value: internalLoadBalancer is required for control plane machines"),
+				))
+			})
+		})
 	})
 
 	Context("on update", func() {
 		var cpms *machinev1.ControlPlaneMachineSet
 
-		BeforeEach(func() {
-			providerSpec := resourcebuilder.AWSProviderSpec().WithAvailabilityZone("us-east-1")
-			machineTemplate := resourcebuilder.OpenShiftMachineV1Beta1Template().WithProviderSpecBuilder(providerSpec)
-			// Default CPMS builder should be valid
-			cpms = resourcebuilder.ControlPlaneMachineSet().WithNamespace(namespaceName).WithMachineTemplateBuilder(machineTemplate).Build()
+		Context("on AWS", func() {
+			BeforeEach(func() {
+				providerSpec := resourcebuilder.AWSProviderSpec().WithAvailabilityZone("us-east-1")
+				machineTemplate := resourcebuilder.OpenShiftMachineV1Beta1Template().WithProviderSpecBuilder(providerSpec)
+				// Default CPMS builder should be valid
+				cpms = resourcebuilder.ControlPlaneMachineSet().WithNamespace(namespaceName).WithMachineTemplateBuilder(machineTemplate).Build()
 
-			machineBuilder := resourcebuilder.Machine().WithNamespace(namespaceName)
-			controlPlaneMachineBuilder := machineBuilder.WithGenerateName("control-plane-machine-").AsMaster().WithProviderSpecBuilder(providerSpec)
-			By("Creating a selection of Machines")
-			for i := 0; i < 3; i++ {
-				controlPlaneMachine := controlPlaneMachineBuilder.Build()
-				Expect(k8sClient.Create(ctx, controlPlaneMachine)).To(Succeed())
-			}
-
-			By("Creating a valid ControlPlaneMachineSet")
-			Expect(k8sClient.Create(ctx, cpms)).To(Succeed())
-		})
-
-		It("with an update to the providerSpec", func() {
-			// Change the providerSpec, expect the update to be successful
-			rawProviderSpec := resourcebuilder.AWSProviderSpec().WithAvailabilityZone("us-east-2").BuildRawExtension()
-
-			Expect(komega.Update(cpms, func() {
-				cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec.ProviderSpec.Value = rawProviderSpec
-			})()).Should(Succeed())
-		})
-
-		It("with 4 replicas", func() {
-			// This is an openapi validation but it makes sense to include it here as well
-			Expect(komega.Update(cpms, func() {
-				four := int32(4)
-				cpms.Spec.Replicas = &four
-			})()).Should(MatchError(ContainSubstring("Unsupported value: 4: supported values: \"3\", \"5\"")))
-		})
-
-		It("with 5 replicas", func() {
-			// Five replicas is a valid value but the existing CPMS has three replicas
-			Expect(komega.Update(cpms, func() {
-				five := int32(5)
-				cpms.Spec.Replicas = &five
-			})()).Should(MatchError(ContainSubstring(`spec.replicas: Forbidden: control plane machine set replicas cannot be changed`)), "Replicas should be immutable")
-		})
-
-		It("when modifying the machine labels and the selector still matches", func() {
-			Expect(komega.Update(cpms, func() {
-				cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.ObjectMeta.Labels["new"] = "value"
-			})()).Should(Succeed(), "Machine label updates are allowed provided the selector still matches")
-		})
-
-		It("when modifying the machine labels so that the selector no longer matches", func() {
-			Expect(komega.Update(cpms, func() {
-				cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.ObjectMeta.Labels = map[string]string{
-					"different":                          "labels",
-					machinev1beta1.MachineClusterIDLabel: "cpms-cluster-test-id",
-					openshiftMachineRoleLabel:            "not-matching-label",
-					openshiftMachineTypeLabel:            masterMachineRole,
+				machineBuilder := resourcebuilder.Machine().WithNamespace(namespaceName)
+				controlPlaneMachineBuilder := machineBuilder.WithGenerateName("control-plane-machine-").AsMaster().WithProviderSpecBuilder(providerSpec)
+				By("Creating a selection of Machines")
+				for i := 0; i < 3; i++ {
+					controlPlaneMachine := controlPlaneMachineBuilder.Build()
+					Expect(k8sClient.Create(ctx, controlPlaneMachine)).To(Succeed())
 				}
-			})()).Should(MatchError(ContainSubstring("selector does not match template labels")), "The selector must always match the machine labels")
-		})
 
-		It("when modifying the machine labels to remove the cluster ID label", func() {
-			Expect(komega.Update(cpms, func() {
-				delete(cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.ObjectMeta.Labels, machinev1beta1.MachineClusterIDLabel)
-			})()).Should(MatchError(ContainSubstring("Required value: machine.openshift.io/cluster-api-cluster label is required")), "The labels must always contain a cluster ID label")
-		})
+				By("Creating a valid ControlPlaneMachineSet")
+				Expect(k8sClient.Create(ctx, cpms)).To(Succeed())
+			})
 
-		It("when mutating the selector", func() {
-			Expect(komega.Update(cpms, func() {
-				cpms.Spec.Selector.MatchLabels["new"] = "value"
-			})()).Should(MatchError(ContainSubstring("Forbidden: control plane machine set selector is immutable")), "The selector should be immutable")
-		})
+			It("with an update to the providerSpec", func() {
+				// Change the providerSpec, expect the update to be successful
+				rawProviderSpec := resourcebuilder.AWSProviderSpec().WithAvailabilityZone("us-east-2").BuildRawExtension()
 
-		It("when adding invalid failure domain information", func() {
-			Expect(komega.Update(cpms, func() {
-				cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.FailureDomains.Platform = configv1.AWSPlatformType
-				cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.FailureDomains.Azure = &[]machinev1.AzureFailureDomain{
-					{
-						Zone: "us-central-1",
-					},
-				}
-			})()).To(MatchError(SatisfyAll(
-				ContainSubstring("spec.template.machines_v1beta1_machine_openshift_io.failureDomains.aws: Required value: value required when platform is \"AWS\""),
-				ContainSubstring("spec.template.machines_v1beta1_machine_openshift_io.failureDomains.azure: Forbidden: value not allowed when platform is \"AWS\""),
-			)))
-		})
+				Expect(komega.Update(cpms, func() {
+					cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec.ProviderSpec.Value = rawProviderSpec
+				})()).Should(Succeed())
+			})
 
-		It("when adding invalid subnets in the faliure domains", func() {
-			Expect(komega.Update(cpms, func() {
-				cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.FailureDomains.Platform = configv1.AWSPlatformType
-				cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.FailureDomains.AWS = &[]machinev1.AWSFailureDomain{
-					{
-						Subnet: &machinev1.AWSResourceReference{
-							Type: machinev1.AWSARNReferenceType,
-							ID:   pointer.String("id-123"),
+			It("with 4 replicas", func() {
+				// This is an openapi validation but it makes sense to include it here as well
+				Expect(komega.Update(cpms, func() {
+					four := int32(4)
+					cpms.Spec.Replicas = &four
+				})()).Should(MatchError(ContainSubstring("Unsupported value: 4: supported values: \"3\", \"5\"")))
+			})
+
+			It("with 5 replicas", func() {
+				// Five replicas is a valid value but the existing CPMS has three replicas
+				Expect(komega.Update(cpms, func() {
+					five := int32(5)
+					cpms.Spec.Replicas = &five
+				})()).Should(MatchError(ContainSubstring(`spec.replicas: Forbidden: control plane machine set replicas cannot be changed`)), "Replicas should be immutable")
+			})
+
+			It("when modifying the machine labels and the selector still matches", func() {
+				Expect(komega.Update(cpms, func() {
+					cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.ObjectMeta.Labels["new"] = dummyValue
+				})()).Should(Succeed(), "Machine label updates are allowed provided the selector still matches")
+			})
+
+			It("when modifying the machine labels so that the selector no longer matches", func() {
+				Expect(komega.Update(cpms, func() {
+					cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.ObjectMeta.Labels = map[string]string{
+						"different":                          "labels",
+						machinev1beta1.MachineClusterIDLabel: "cpms-cluster-test-id",
+						openshiftMachineRoleLabel:            "not-matching-label",
+						openshiftMachineTypeLabel:            masterMachineRole,
+					}
+				})()).Should(MatchError(ContainSubstring("selector does not match template labels")), "The selector must always match the machine labels")
+			})
+
+			It("when modifying the machine labels to remove the cluster ID label", func() {
+				Expect(komega.Update(cpms, func() {
+					delete(cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.ObjectMeta.Labels, machinev1beta1.MachineClusterIDLabel)
+				})()).Should(MatchError(ContainSubstring("Required value: machine.openshift.io/cluster-api-cluster label is required")), "The labels must always contain a cluster ID label")
+			})
+
+			It("when mutating the selector", func() {
+				Expect(komega.Update(cpms, func() {
+					cpms.Spec.Selector.MatchLabels["new"] = dummyValue
+				})()).Should(MatchError(ContainSubstring("Forbidden: control plane machine set selector is immutable")), "The selector should be immutable")
+			})
+
+			It("when adding invalid failure domain information", func() {
+				Expect(komega.Update(cpms, func() {
+					cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.FailureDomains.Platform = configv1.AWSPlatformType
+					cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.FailureDomains.Azure = &[]machinev1.AzureFailureDomain{
+						{
+							Zone: "us-central-1",
 						},
-					},
+					}
+				})()).To(MatchError(SatisfyAll(
+					ContainSubstring("spec.template.machines_v1beta1_machine_openshift_io.failureDomains.aws: Required value: value required when platform is \"AWS\""),
+					ContainSubstring("spec.template.machines_v1beta1_machine_openshift_io.failureDomains.azure: Forbidden: value not allowed when platform is \"AWS\""),
+				)))
+			})
+
+			It("when adding invalid subnets in the faliure domains", func() {
+				Expect(komega.Update(cpms, func() {
+					cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.FailureDomains.Platform = configv1.AWSPlatformType
+					cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.FailureDomains.AWS = &[]machinev1.AWSFailureDomain{
+						{
+							Subnet: &machinev1.AWSResourceReference{
+								Type: machinev1.AWSARNReferenceType,
+								ID:   pointer.String("id-123"),
+							},
+						},
+					}
+				})()).To(MatchError(SatisfyAll(
+					ContainSubstring("spec.template.machines_v1beta1_machine_openshift_io.failureDomains.aws[0].subnet.arn: Required value: value required when type is \"ARN\""),
+					ContainSubstring("spec.template.machines_v1beta1_machine_openshift_io.failureDomains.aws[0].subnet.id: Forbidden: value not allowed when type is \"ARN\""),
+				)))
+			})
+		})
+
+		Context("on Azure", func() {
+			BeforeEach(func() {
+				providerSpec := resourcebuilder.AzureProviderSpec()
+				machineTemplate := resourcebuilder.OpenShiftMachineV1Beta1Template().WithProviderSpecBuilder(providerSpec)
+				// Default CPMS builder should be valid
+				cpms = resourcebuilder.ControlPlaneMachineSet().WithNamespace(namespaceName).WithMachineTemplateBuilder(machineTemplate).Build()
+
+				machineBuilder := resourcebuilder.Machine().WithNamespace(namespaceName)
+				controlPlaneMachineBuilder := machineBuilder.WithGenerateName("control-plane-machine-").AsMaster().WithProviderSpecBuilder(providerSpec)
+				By("Creating a selection of Machines")
+				for i := 0; i < 3; i++ {
+					controlPlaneMachine := controlPlaneMachineBuilder.Build()
+					Expect(k8sClient.Create(ctx, controlPlaneMachine)).To(Succeed())
 				}
-			})()).To(MatchError(SatisfyAll(
-				ContainSubstring("spec.template.machines_v1beta1_machine_openshift_io.failureDomains.aws[0].subnet.arn: Required value: value required when type is \"ARN\""),
-				ContainSubstring("spec.template.machines_v1beta1_machine_openshift_io.failureDomains.aws[0].subnet.id: Forbidden: value not allowed when type is \"ARN\""),
-			)))
+
+				By("Creating a valid ControlPlaneMachineSet")
+				Expect(k8sClient.Create(ctx, cpms)).To(Succeed())
+			})
+
+			It("with 4 replicas", func() {
+				// This is an openapi validation but it makes sense to include it here as well
+				Expect(komega.Update(cpms, func() {
+					four := int32(4)
+					cpms.Spec.Replicas = &four
+				})()).Should(MatchError(ContainSubstring("Unsupported value: 4: supported values: \"3\", \"5\"")))
+			})
+
+			It("with 5 replicas", func() {
+				// Five replicas is a valid value but the existing CPMS has three replicas
+				Expect(komega.Update(cpms, func() {
+					five := int32(5)
+					cpms.Spec.Replicas = &five
+				})()).Should(MatchError(ContainSubstring(`spec.replicas: Forbidden: control plane machine set replicas cannot be changed`)), "Replicas should be immutable")
+			})
+
+			It("when modifying the machine labels and the selector still matches", func() {
+				Expect(komega.Update(cpms, func() {
+					cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.ObjectMeta.Labels["new"] = dummyValue
+				})()).Should(Succeed(), "Machine label updates are allowed provided the selector still matches")
+			})
+
+			It("when modifying the machine labels so that the selector no longer matches", func() {
+				Expect(komega.Update(cpms, func() {
+					cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.ObjectMeta.Labels = map[string]string{
+						"different":                          "labels",
+						machinev1beta1.MachineClusterIDLabel: "cpms-cluster-test-id",
+						openshiftMachineRoleLabel:            "not-matching-label",
+						openshiftMachineTypeLabel:            masterMachineRole,
+					}
+				})()).Should(MatchError(ContainSubstring("selector does not match template labels")), "The selector must always match the machine labels")
+			})
+
+			It("when modifying the machine labels to remove the cluster ID label", func() {
+				Expect(komega.Update(cpms, func() {
+					delete(cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.ObjectMeta.Labels, machinev1beta1.MachineClusterIDLabel)
+				})()).Should(MatchError(ContainSubstring("Required value: machine.openshift.io/cluster-api-cluster label is required")), "The labels must always contain a cluster ID label")
+			})
+
+			It("when mutating the selector", func() {
+				Expect(komega.Update(cpms, func() {
+					cpms.Spec.Selector.MatchLabels["new"] = dummyValue
+				})()).Should(MatchError(ContainSubstring("Forbidden: control plane machine set selector is immutable")), "The selector should be immutable")
+			})
+
+			It("when removing the internal load balancer", func() {
+				// Change the providerSpec, expect the update to be successful
+				rawProviderSpec := resourcebuilder.AzureProviderSpec().WithInternalLoadBalancer("").BuildRawExtension()
+
+				Expect(komega.Update(cpms, func() {
+					cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec.ProviderSpec.Value = rawProviderSpec
+				})()).Should(MatchError(ContainSubstring("spec.template.machines_v1beta1_machine_openshift_io.spec.providerSpec.value.internalLoadBalancer: Required value: internalLoadBalancer is required for control plane machines")))
+			})
 		})
 	})
 })


### PR DESCRIPTION
We have identified via this bug, that there are two scenarios in which an automated replacement of Control Plane Machines can lead to a broken cluster. Both related to load balancers.

On Azure, the `internalLoadBalancer` has historically not been set by the installer. This is needed (and supported) by Machine API to ensure that the load balancer used by control plane components and kubelet has backends to fulfil the requests. Without this parameter, the CPMS will happily replace all Machines and the cluster will grind to a halt as KCM will lose communication within the API.

On GCP, we have a similar scenario, except updating the internal load balancer backend pool is not currently supported by Machine API on GCP. Until that issue is resolved, we must prevent users installing a CPMS on GCP.