### PR TITLE
[OCPCLOUD-1647] Implement pre-flight Cluster state validation

### DIFF
--- a/pkg/controllers/controlplanemachineset/consts.go
+++ b/pkg/controllers/controlplanemachineset/consts.go
@@ -16,6 +16,13 @@ limitations under the License.
 
 package controlplanemachineset
 
+const (
+	// masterNodeRoleLabel denotes the master node label for a node.
+	masterNodeRoleLabel = "node-role.kubernetes.io/master"
+	// controlPlaneNodeRoleLabel denotes the control-plane node label for a node.
+	controlPlaneNodeRoleLabel = "node-role.kubernetes.io/control-plane"
+)
+
 // Condition types for use in the ControlPlaneMachineSet status.
 // These types will define the output of the ContorlPlaneMachineSet status
 // as conditions which in turn will influence how the ClusterOperator
@@ -95,6 +102,13 @@ const (
 	// configuration, the ControlPlaneMachineSet will cease all operations.
 	reasonUnmanagedNodes = "UnmanagedNodes"
 
+	// reasonExcessIndexes denotes that the ControlPlaneMachineSet has more indexes
+	// than desired.
+	// This will typically occur when extra indexes have been created outside of the cpms.
+	// In this scenario, to prevent potential for degrading the cluster into an unsupported
+	// configuration, the ControlPlaneMachineSet will cease all operations.
+	reasonExcessIndexes = "ExcessIndexes"
+
 	// END: Degraded reasons.
 
 	// BEGIN: Progressing reasons.
@@ -108,7 +122,7 @@ const (
 	// action towards a rollout because the operator is currently in a degraded state.
 	reasonOperatorDegraded = "OperatorDegraded"
 
-	// reasonExcessReplicas denotes that the ControlPLaneMachineSet has the correct number
+	// reasonExcessReplicas denotes that the ControlPlaneMachineSet has the correct number
 	// of ready and updated replicas, however, has more replicas than expected.
 	// This will typically occur when an old replica has not yet been removed.
 	reasonExcessReplicas = "ExcessReplicas"

--- a/pkg/controllers/controlplanemachineset/controller_test.go
+++ b/pkg/controllers/controlplanemachineset/controller_test.go
@@ -910,7 +910,7 @@ var _ = Describe("validateClusterState", func() {
 			Namespace: namespaceName,
 		}
 
-		cpms := cpmsBuilder.Build()
+		cpms := in.cpmsBuilder.Build()
 
 		err := reconciler.validateClusterState(ctx, logger.Logger(), cpms, in.machineInfos)
 


### PR DESCRIPTION
We need to make sure a number of checks pass before the CPMS controller can perform any operations.
The things to be checked are:

1. **All Nodes in the cluster claiming to be control plane nodes have a valid machine**.
1. **At least 1 of the control plane machines is in the ready state** (if there are no ready Machines then the cluster is likely misconfigured).
1. **The cluster has the correct number of indexes**:
      + Right number of indexes, The cluster state is valid.
      + Too few indexes, The cluster state is valid. We will later scale up without user intervention when we perform reconcileMachineUpdates.
      + Too many indexes, invalid. We set the operator to degraded and ask the user for manual intervention.
1. **No replacement machines** (one that doesn't need update but has an equivalent in the index that needs update) **have an error.**

If any of these conditions is not met, the cpms operator will go degraded and will halt all operations until the issue has been resolved.