### PR TITLE
add more options for running tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,10 @@ lint: ## Run golangci-lint over the codebase.
 	./hack/verify-log-keys.sh
 
 .PHONY: test
-test: generate fmt vet ## Run tests.
+test: generate fmt vet unit ## Run tests.
+
+.PHONY: unit
+unit: ## Run only the tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path --bin-dir $(PROJECT_DIR)/bin)" ./hack/test.sh
 
 .PHONY: verify-%

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Tooling is vendored and executed using `go run` so no additional tooling should 
 * `make build`: Build the operator binary into `bin/manager`
 * `make test`: Run the project tests. Tests are written using ginkgo and the ginkgo tooling is used to execute the
 tests. In CI, this target outputs JUnit and code coverage reports. Depends on `generate`, `fmt` and `vet` tasks.
+* `make unit`: Run only the project tests, without the `generate`, `fmt`, or `vet` tasks. The `GINKGO_EXTRA_ARGS`
+environment variable can be used to pass more options to the ginkgo runner.
 * `make lint`: Runs `golangci-lint` based on the project linter configuration. It is recommend to run this target before
 committing any code changes.
 * `make vendor`: Update the vendor directory when there are changes to the `go.mod` file. Runs tidy, vendor and verify.

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -9,6 +9,7 @@ OPENSHIFT_CI=${OPENSHIFT_CI:-""}
 ARTIFACT_DIR=${ARTIFACT_DIR:-""}
 GINKGO=${GINKGO:-"go run ${REPO_ROOT}/vendor/github.com/onsi/ginkgo/v2/ginkgo"}
 GINKGO_ARGS=${GINKGO_ARGS:-"-r -v --randomize-all --randomize-suites --keep-going --race --trace --timeout=2m"}
+GINKGO_EXTRA_ARGS=${GINKGO_EXTRA_ARGS:-""}
 
 # Ensure that some home var is set and that it's not the root.
 # This is required for the kubebuilder cache.
@@ -22,8 +23,8 @@ if [ "$OPENSHIFT_CI" == "true" ] && [ -n "$ARTIFACT_DIR" ] && [ -d "$ARTIFACT_DI
 fi
 
 # Print the command we are going to run as Make would.
-echo ${GINKGO} ${GINKGO_ARGS} ./...
-${GINKGO} ${GINKGO_ARGS} ./...
+echo ${GINKGO} ${GINKGO_ARGS} ${GINKGO_EXTRA_ARGS} ./...
+${GINKGO} ${GINKGO_ARGS} ${GINKGO_EXTRA_ARGS} ./...
 # Capture the test result to exit on error after coverage.
 TEST_RESULT=$?
 


### PR DESCRIPTION
This change adds a new Makefile target named `test-only` that will run
just the tests with no linting or vendoring activities. It also adds the
`GINKGO_EXTRA_ARGS` environment variable to the `hack/test.sh` script so
that users can inject extra commands to the ginkgo runner.