### PR TITLE
Bug 2115358: Ensure a MachineProvider with no failure domains can create machines

### DIFF
--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/provider_test.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/provider_test.go
@@ -1191,6 +1191,30 @@ var _ = Describe("MachineProvider", func() {
 					Consistently(komega.ObjectList(&machinev1beta1.MachineList{})).Should(HaveField("Items", BeEmpty()))
 				})
 			})
+
+			Context("if the MachineProvider has no failure domains configure", func() {
+				usEast1aBuilder := providerConfigBuilder.WithAvailabilityZone("us-east-1a").WithSubnet(usEast1aSubnetbeta1)
+
+				BeforeEach(func() {
+					template = resourcebuilder.OpenShiftMachineV1Beta1Template().
+						WithProviderSpecBuilder(usEast1aBuilder).
+						WithLabel(machinev1beta1.MachineClusterIDLabel, "cpms-aws-cluster-id").
+						BuildTemplate()
+
+					providerConfig, err := providerconfig.NewProviderConfigFromMachineTemplate(*template.OpenShiftMachineV1Beta1Machine)
+					Expect(err).ToNot(HaveOccurred())
+
+					openshiftProvider, ok := provider.(*openshiftMachineProvider)
+					Expect(ok).To(BeTrue(), "provider should be an openshiftMachineProvider")
+
+					openshiftProvider.providerConfig = providerConfig
+					openshiftProvider.indexToFailureDomain = nil
+				})
+
+				assertCreatesMachine(0, usEast1aBuilder, "cpms-aws-cluster-id", "us-east-1a")
+				assertCreatesMachine(1, usEast1aBuilder, "cpms-aws-cluster-id", "us-east-1a")
+				assertCreatesMachine(2, usEast1aBuilder, "cpms-aws-cluster-id", "us-east-1a")
+			})
 		})
 
 	})


### PR DESCRIPTION
When creating new Machines, the MachineProvider was injecting nil failure domains when running without failure domains configured. This meant that on single zone deployments without the `failureDomains` configured, it could not actually create new machines.
This PR resolves the issue by checking if the failure domains are mapped before continuing with the creation.