### PR TITLE
Fix behavior in cluster state validation and machine info generation

### DIFF
--- a/pkg/controllers/controlplanemachineset/controller.go
+++ b/pkg/controllers/controlplanemachineset/controller.go
@@ -665,11 +665,11 @@ func (r *ControlPlaneMachineSetReconciler) checkNoErrorForReplacements(logger lo
 	var erroredReplacementMachineNames []string
 
 	for _, machines := range sortedIndexedMs {
-		machinesUpdated := updatedMachines(machines)
+		machinesPending := pendingMachines(machines)
 		machinesOutdated := needReplacementMachines(machines)
 
-		if hasAny(machinesOutdated) && hasAny(machinesUpdated) {
-			for _, m := range machinesUpdated {
+		if hasAny(machinesOutdated) && hasAny(machinesPending) {
+			for _, m := range machinesPending {
 				if m.ErrorMessage != "" {
 					erroredReplacementMachineNames = append(erroredReplacementMachineNames, m.MachineRef.ObjectMeta.Name)
 				}

--- a/pkg/controllers/controlplanemachineset/controller_test.go
+++ b/pkg/controllers/controlplanemachineset/controller_test.go
@@ -1104,7 +1104,7 @@ var _ = Describe("validateClusterState", func() {
 			machineInfos: map[int32][]machineproviders.MachineInfo{
 				0: {
 					updatedMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("master-0").WithNeedsUpdate(true).Build(),
-					updatedMachineBuilder.WithIndex(0).WithMachineName("machine-replacement-0").WithErrorMessage("Could not create new instance").Build(),
+					updatedMachineBuilder.WithIndex(0).WithMachineName("machine-replacement-0").WithErrorMessage("Could not create new instance").WithReady(false).Build(),
 				},
 				1: {updatedMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("master-1").WithNeedsUpdate(true).Build()},
 				2: {updatedMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("master-2").WithNeedsUpdate(true).Build()},
@@ -1140,11 +1140,11 @@ var _ = Describe("validateClusterState", func() {
 			machineInfos: map[int32][]machineproviders.MachineInfo{
 				0: {
 					updatedMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("master-0").WithNeedsUpdate(true).Build(),
-					updatedMachineBuilder.WithIndex(0).WithMachineName("machine-replacement-0").WithErrorMessage("Could not create new instance").Build(),
+					updatedMachineBuilder.WithIndex(0).WithMachineName("machine-replacement-0").WithErrorMessage("Could not create new instance").WithReady(false).Build(),
 				},
 				1: {
 					updatedMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("master-1").WithNeedsUpdate(true).Build(),
-					updatedMachineBuilder.WithIndex(1).WithMachineName("machine-replacement-1").WithErrorMessage("Could not create new instance").Build(),
+					updatedMachineBuilder.WithIndex(1).WithMachineName("machine-replacement-1").WithErrorMessage("Could not create new instance").WithReady(false).Build(),
 				},
 				2: {updatedMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("master-2").WithNeedsUpdate(true).Build()},
 			},

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/provider.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/provider.go
@@ -236,15 +236,15 @@ func (m *openshiftMachineProvider) generateMachineInfo(logger logr.Logger, machi
 		// Make sure to compare using the desired failure domain from the mapping.
 		mappedFailureDomain, ok := m.indexToFailureDomain[machineIndex]
 		if !ok {
-			return machineproviders.MachineInfo{}, fmt.Errorf("%w: unknown index %d", errCouldNotFindFailureDomain, machineIndex)
-		}
+			logger.Error(fmt.Errorf("%w: unknown index %d", errCouldNotFindFailureDomain, machineIndex), "Unknown Index")
+		} else {
+			injectedProviderConfig, err := m.providerConfig.InjectFailureDomain(mappedFailureDomain)
+			if err != nil {
+				return machineproviders.MachineInfo{}, fmt.Errorf("error injecting failure domain into provider config: %w", err)
+			}
 
-		injectedProviderConfig, err := m.providerConfig.InjectFailureDomain(mappedFailureDomain)
-		if err != nil {
-			return machineproviders.MachineInfo{}, fmt.Errorf("error injecting failure domain into provider config: %w", err)
+			templateProviderConfig = injectedProviderConfig
 		}
-
-		templateProviderConfig = injectedProviderConfig
 	}
 
 	configsEqual, err := templateProviderConfig.Equal(providerConfig)


### PR DESCRIPTION
This PR fixes some behavior of the Control Plane Machine Set controller around cluster state validation and machine info generation.

- [fix: failed replacement machine test](https://github.com/openshift/cluster-control-plane-machine-set-operator/commit/ef4193080701adafe6cc7e94e48869ef38dd9c24) 
    WithError() doesn't automatically set the MachineInfo status to UnReady.
    Which is the condition we check on to determine if the replacement is
    misbehaving and to later determine if it has errored.
    Thus we also need to set WithReady(false).
    This closely mimic the real behaviour of the MachineInfo's content
    observed in a real cpms cluster.

- [fix: cluster state validation's: checkNoErrorForReplacements](https://github.com/openshift/cluster-control-plane-machine-set-operator/commit/1ab4bb261fdaaa0d82568f5135c68d0dd68fb825) 
    prior to this fix the check was relying on finding replacement machines
    via the updatedMachines() method.
    This method though lists MachineInfos with machines that have an up-to-date Spec and are Ready.
    But in this case we want to find machine that have an up-to-date Spec
    and are not-Ready. We need to use pendingMachines() instead.

- [fix: MachineInfo generation, don't error on unknown index](https://github.com/openshift/cluster-control-plane-machine-set-operator/commit/8b1fb18d718f774faf7dda4311c2dc37224a8884) 
    we don't want to error when an index is unknown, but rather we should
    not inject the failure domain into the provider config and carry.
    This will allow us to catch the unknown index later on in the reconcile
    (at cluster state validation stage), where we'll instead degrade the
    operator.