### PR TITLE
Control Plane Machine Set manifest generator tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ help: ## Display this help.
 
 .PHONY: generate-cpms
 generate-cpms: # generate the control plane machine set (cpms) K8s object manifest.
-	go run ./cmd/cpmsctl generate --kubeconfig=$$KUBECONFIG
+	@go run ./cmd/cpmsctl generate
 
 ##@ Development
 

--- a/pkg/cmd/generate/generator.go
+++ b/pkg/cmd/generate/generator.go
@@ -74,8 +74,9 @@ func NewGenerateCmd() *cobra.Command {
 	generateCmd.PersistentFlags().StringVar(&generateOpts.To, "to", "",
 		"User-defined destination file for the generated manifest, when omitted the result is emitted to stdout")
 
-	generateCmd.PersistentFlags().StringVar(&generateOpts.Kubeconfig, "kubeconfig", "",
-		"User-defined kubeconfig path for the cluster, when omitted it falls back to inClusterConfig, then to default config")
+	generateCmd.PersistentFlags().StringVar(&generateOpts.Kubeconfig, "kubeconfig", os.Getenv("KUBECONFIG"),
+		"User-defined kubeconfig path for the cluster, when omitted it uses the KUBECONFIG environment variable,"+
+			" if that's empty it uses the inClusterConfig, if that can't be found it uses the default config")
 
 	return generateCmd
 }


### PR DESCRIPTION
Tweaks the cpms generation flow:
- [silence make cpms-generator, so it can be piped to other commands](https://github.com/openshift/cluster-control-plane-machine-set-operator/commit/87b4bd5e057b36c97712c77493e07748521fe5d8)
- [use the KUBECONFIG env var if no --kubeconfig is passed](https://github.com/openshift/cluster-control-plane-machine-set-operator/commit/27a7946a35649081d2f5c0ce616f42857b87f748)