### PR TITLE
OCPBUGS-996: Add logic to handle extra updated machines in a single index + minor fixes

### DIFF
--- a/pkg/controllers/controlplanemachineset/consts.go
+++ b/pkg/controllers/controlplanemachineset/consts.go
@@ -127,6 +127,11 @@ const (
 	// This will typically occur when an old replica has not yet been removed.
 	reasonExcessReplicas = "ExcessReplicas"
 
+	// reasonExcessUpdatedReplicas denotes that the ControlPlaneMachineSet has a more than expected number
+	// of ready and up-to-date replicas.
+	// This will typically occur when extra replica(s) for an index have been created.
+	reasonExcessUpdatedReplicas = "ExcessUpdatedReplicas"
+
 	// reasonNeedsUpdateReplicas denotes that the ControlPlaneMachineSet has identified
 	// replicas under its management that are currently in need of an update.
 	reasonNeedsUpdateReplicas = "NeedsUpdateReplicas"

--- a/pkg/controllers/controlplanemachineset/controller.go
+++ b/pkg/controllers/controlplanemachineset/controller.go
@@ -73,6 +73,9 @@ var (
 
 	// errFoundExcessiveIndexes is used to inform users that an excessive number of indexes has been found.
 	errFoundExcessiveIndexes = errors.New("found an excessive number of indexes for the control plane machine set")
+
+	// errFoundExcessiveUpdatedReplicas is used to inform users that an excessive number of updated machines has been found for a single index.
+	errFoundExcessiveUpdatedReplicas = errors.New("found an excessive number of updated machines for a single index")
 )
 
 // ControlPlaneMachineSetReconciler reconciles a ControlPlaneMachineSet object.
@@ -454,6 +457,11 @@ func (r *ControlPlaneMachineSetReconciler) validateClusterState(ctx context.Cont
 		return nil
 	}
 
+	// Check that the number of Updated (Ready and with Up-to-date spec) Machines in an index is valid.
+	if ok := r.checkValidNumerOfUpdatedMachinesPerIndex(logger, cpms, sortedIndexedMs); !ok {
+		return nil
+	}
+
 	// Check that no replacement machines (one that doesn't need update but has an equivalent in the index that needs update)
 	// have an error.
 	if ok := r.checkNoErrorForReplacements(logger, cpms, sortedIndexedMs); !ok {
@@ -655,6 +663,59 @@ func (r *ControlPlaneMachineSetReconciler) checkCorrectNumberOfIndexes(logger lo
 		})
 
 		return false
+	}
+
+	return true
+}
+
+// checkValidNumerOfUpdatedMachinesPerIndex checks that the number of updated machines in an index is valid.
+func (r *ControlPlaneMachineSetReconciler) checkValidNumerOfUpdatedMachinesPerIndex(logger logr.Logger, cpms *machinev1.ControlPlaneMachineSet, sortedIndexedMs [][]machineproviders.MachineInfo) bool {
+	for _, index := range sortedIndexedMs {
+		updatedMachinesCount := len(updatedMachines(index))
+
+		switch {
+		case updatedMachinesCount <= 1:
+			// Valid numer of Updated Machines. The cluster state is valid.
+		case updatedMachinesCount > 1:
+			switch cpms.Spec.Strategy.Type {
+			case machinev1.RollingUpdate:
+				// Even though there is an excess number of Updated Machines,
+				// with the RollingUpdate update strategy we consider this a valid state for the cluster.
+				// We carry on and let the RollingUpdate reconciliation handle the excess in Updated Machines.
+			case machinev1.Recreate:
+				// Even though there is an excess number of Updated Machines,
+				// with the Recreate update strategy we consider this a valid state for the cluster.
+				// We carry on and let the Recreate reconciliation handle the excess in Updated Machines.
+			case machinev1.OnDelete:
+				// Too many Updated Machines. With OnDelete update strategy,
+				// if there are an excess number of Updated Machines
+				// we set the operator to degraded and ask the user for manual intervention,
+				// to remove the excess replicas.
+				excessiveUpdatedReplicas := updatedMachinesCount - 1
+
+				logger.Error(
+					fmt.Errorf("%w: %d updated replica(s) are in excess for index %d",
+						errFoundExcessiveUpdatedReplicas, excessiveUpdatedReplicas, index[0].Index),
+					"Observed an excessive number of updated replica(s) for a single index",
+					"excessUpdatedReplicas", excessiveUpdatedReplicas,
+				)
+
+				meta.SetStatusCondition(&cpms.Status.Conditions, metav1.Condition{
+					Type:   conditionProgressing,
+					Status: metav1.ConditionFalse,
+					Reason: reasonOperatorDegraded,
+				})
+
+				meta.SetStatusCondition(&cpms.Status.Conditions, metav1.Condition{
+					Type:    conditionDegraded,
+					Status:  metav1.ConditionTrue,
+					Reason:  reasonExcessUpdatedReplicas,
+					Message: fmt.Sprintf("Observed %d updated machine(s) in excess for index %d", excessiveUpdatedReplicas, index[0].Index),
+				})
+
+				return false
+			}
+		}
 	}
 
 	return true

--- a/pkg/controllers/controlplanemachineset/controller_test.go
+++ b/pkg/controllers/controlplanemachineset/controller_test.go
@@ -19,6 +19,7 @@ package controlplanemachineset
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -1168,6 +1169,71 @@ var _ = Describe("validateClusterState", func() {
 						"failedReplacements", "machine-replacement-0,machine-replacement-1",
 					},
 					Message: "Observed failed replacement control plane machines",
+				},
+			},
+		}),
+		Entry("with multiple updated machines in a single index and RollingUpdate strategy", validateClusterTableInput{
+			cpmsBuilder: cpmsBuilder.WithConditions([]metav1.Condition{
+				degradedConditionBuilder.WithStatus(metav1.ConditionFalse).Build(),
+				progressingConditionBuilder.WithStatus(metav1.ConditionFalse).Build(),
+			}).WithReplicas(3),
+			machineInfos: map[int32][]machineproviders.MachineInfo{
+				0: {
+					updatedMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("master-0").Build(),
+					updatedMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("master-0").Build(),
+				},
+				1: {updatedMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("master-1").Build()},
+				2: {updatedMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("master-2").Build()},
+			},
+			nodes: []*corev1.Node{
+				masterNodeBuilder.WithName("master-0").Build(),
+				masterNodeBuilder.WithName("master-1").Build(),
+				masterNodeBuilder.WithName("master-2").Build(),
+				workerNodeBuilder.WithName("worker-0").Build(),
+				workerNodeBuilder.WithName("worker-1").Build(),
+				workerNodeBuilder.WithName("worker-2").Build(),
+			},
+			expectedError: nil,
+			expectedConditions: []metav1.Condition{
+				degradedConditionBuilder.WithStatus(metav1.ConditionFalse).Build(),
+				progressingConditionBuilder.WithStatus(metav1.ConditionFalse).Build(),
+			},
+			expectedLogs: []test.LogEntry{},
+		}),
+		Entry("with multiple updated machines in a single index and OnDelete strategy", validateClusterTableInput{
+			cpmsBuilder: cpmsBuilder.WithConditions([]metav1.Condition{
+				degradedConditionBuilder.WithStatus(metav1.ConditionFalse).Build(),
+				progressingConditionBuilder.WithStatus(metav1.ConditionFalse).Build(),
+			}).WithReplicas(3).WithStrategyType(machinev1.OnDelete),
+			machineInfos: map[int32][]machineproviders.MachineInfo{
+				0: {
+					updatedMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("master-0").Build(),
+					updatedMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("master-0").Build(),
+				},
+				1: {updatedMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("master-1").Build()},
+				2: {updatedMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("master-2").Build()},
+			},
+			nodes: []*corev1.Node{
+				masterNodeBuilder.WithName("master-0").Build(),
+				masterNodeBuilder.WithName("master-1").Build(),
+				masterNodeBuilder.WithName("master-2").Build(),
+				workerNodeBuilder.WithName("worker-0").Build(),
+				workerNodeBuilder.WithName("worker-1").Build(),
+				workerNodeBuilder.WithName("worker-2").Build(),
+			},
+			expectedError: nil,
+			expectedConditions: []metav1.Condition{
+				degradedConditionBuilder.WithStatus(metav1.ConditionTrue).WithReason(reasonExcessUpdatedReplicas).WithMessage("Observed 1 updated machine(s) in excess for index 0").Build(),
+				progressingConditionBuilder.WithStatus(metav1.ConditionFalse).WithReason(reasonOperatorDegraded).Build(),
+			},
+
+			expectedLogs: []test.LogEntry{
+				{
+					Error: fmt.Errorf("%w: %s", errFoundExcessiveUpdatedReplicas, "1 updated replica(s) are in excess for index 0"),
+					KeysAndValues: []interface{}{
+						"excessUpdatedReplicas", 1,
+					},
+					Message: "Observed an excessive number of updated replica(s) for a single index",
 				},
 			},
 		}),

--- a/pkg/controllers/controlplanemachineset/controller_test.go
+++ b/pkg/controllers/controlplanemachineset/controller_test.go
@@ -919,7 +919,7 @@ var _ = Describe("validateClusterState", func() {
 		}
 
 		Expect(cpms.Status.Conditions).To(test.MatchConditions(in.expectedConditions))
-		Expect(in.expectedLogs).To(ConsistOf(in.expectedLogs))
+		Expect(logger.Entries()).To(ConsistOf(in.expectedLogs))
 	},
 		Entry("with a valid cluster state", validateClusterTableInput{
 			cpmsBuilder: cpmsBuilder.WithConditions([]metav1.Condition{
@@ -1029,7 +1029,7 @@ var _ = Describe("validateClusterState", func() {
 			},
 			expectedLogs: []test.LogEntry{
 				{
-					Error: errors.New("found unmanaged control plane nodes, the following node(s) do not have associated machines: master-0, master-2"),
+					Error: fmt.Errorf("%w: %s", errFoundUnmanagedControlPlaneNodes, "master-0, master-2"),
 					KeysAndValues: []interface{}{
 						"unmanagedNodes", "master-0,master-2",
 					},
@@ -1063,7 +1063,7 @@ var _ = Describe("validateClusterState", func() {
 			},
 			expectedLogs: []test.LogEntry{
 				{
-					Error: errors.New("found unmanaged control plane nodes, the following node(s) do not have associated machines: master-3"),
+					Error: fmt.Errorf("%w: %s", errFoundUnmanagedControlPlaneNodes, "master-3"),
 					KeysAndValues: []interface{}{
 						"unmanagedNodes", "master-3",
 					},
@@ -1124,7 +1124,7 @@ var _ = Describe("validateClusterState", func() {
 			},
 			expectedLogs: []test.LogEntry{
 				{
-					Error: errors.New("found replacement control plane machines in an error state, the following machines(s) are currently reporting an error: machine-replacement-0"),
+					Error: fmt.Errorf("%w: %s", errFoundErroredReplacementControlPlaneMachine, "machine-replacement-0"),
 					KeysAndValues: []interface{}{
 						"failedReplacements", "machine-replacement-0",
 					},
@@ -1163,7 +1163,7 @@ var _ = Describe("validateClusterState", func() {
 			},
 			expectedLogs: []test.LogEntry{
 				{
-					Error: errors.New("found replacement control plane machines in an error state, the following machines(s) are currently reporting an error: machine-replacement-0,machine-replacement-1"),
+					Error: fmt.Errorf("%w: %s", errFoundErroredReplacementControlPlaneMachine, "machine-replacement-0, machine-replacement-1"),
 					KeysAndValues: []interface{}{
 						"failedReplacements", "machine-replacement-0,machine-replacement-1",
 					},
@@ -1246,9 +1246,9 @@ var _ = Describe("validateClusterState", func() {
 			},
 			expectedLogs: []test.LogEntry{
 				{
-					Error: errors.New("found an excessive number of indexes for the control plane machine set, 1 index(es) are in excess"),
+					Error: fmt.Errorf("%w: %s", errFoundExcessiveIndexes, "1 index(es) are in excess"),
 					KeysAndValues: []interface{}{
-						"excessIndexes", "1",
+						"excessIndexes", int32(1),
 					},
 					Message: "Observed an excessive number of control plane machine indexes",
 				},

--- a/pkg/controllers/controlplanemachineset/controller_test.go
+++ b/pkg/controllers/controlplanemachineset/controller_test.go
@@ -1180,13 +1180,14 @@ var _ = Describe("validateClusterState", func() {
 			machineInfos: map[int32][]machineproviders.MachineInfo{
 				0: {
 					updatedMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("master-0").Build(),
-					updatedMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("master-0").Build(),
+					updatedMachineBuilder.WithIndex(0).WithMachineName("machine-replacement-0").WithNodeName("master-replacement-0").Build(),
 				},
 				1: {updatedMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("master-1").Build()},
 				2: {updatedMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("master-2").Build()},
 			},
 			nodes: []*corev1.Node{
 				masterNodeBuilder.WithName("master-0").Build(),
+				masterNodeBuilder.WithName("master-replacement-0").Build(),
 				masterNodeBuilder.WithName("master-1").Build(),
 				masterNodeBuilder.WithName("master-2").Build(),
 				workerNodeBuilder.WithName("worker-0").Build(),
@@ -1208,13 +1209,14 @@ var _ = Describe("validateClusterState", func() {
 			machineInfos: map[int32][]machineproviders.MachineInfo{
 				0: {
 					updatedMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("master-0").Build(),
-					updatedMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("master-0").Build(),
+					updatedMachineBuilder.WithIndex(0).WithMachineName("machine-replacement-0").WithNodeName("master-replacement-0").Build(),
 				},
 				1: {updatedMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("master-1").Build()},
 				2: {updatedMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("master-2").Build()},
 			},
 			nodes: []*corev1.Node{
 				masterNodeBuilder.WithName("master-0").Build(),
+				masterNodeBuilder.WithName("master-replacement-0").Build(),
 				masterNodeBuilder.WithName("master-1").Build(),
 				masterNodeBuilder.WithName("master-2").Build(),
 				workerNodeBuilder.WithName("worker-0").Build(),

--- a/pkg/controllers/controlplanemachineset/updates_test.go
+++ b/pkg/controllers/controlplanemachineset/updates_test.go
@@ -779,6 +779,79 @@ var _ = Describe("reconcileMachineUpdates", func() {
 					}
 				},
 			}),
+			Entry("with an extra updated machine in a single index", rollingUpdateTableInput{
+				cpmsBuilder: cpmsBuilder.WithReplicas(3),
+				machineInfos: map[int32][]machineproviders.MachineInfo{
+					0: {
+						updatedMachineBuilder.WithIndex(0).WithMachineName("machine-older-extra-0").WithNodeName("node-older-extra-0").Build(),
+						updatedMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build(),
+					},
+					1: {updatedMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").Build()},
+					2: {updatedMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("node-2").Build()},
+				},
+				setupMock: func() {
+					machineInfo0 := updatedMachineBuilder.WithIndex(0).WithMachineName("machine-older-extra-0").Build()
+					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any(), gomock.Any(), machineInfo0.MachineRef).Times(1)
+				},
+				expectedLogsBuilder: func() []test.LogEntry {
+					return []test.LogEntry{
+						{
+							Level: 2,
+							KeysAndValues: []interface{}{
+								"updateStrategy", machinev1.RollingUpdate,
+								"index", 0,
+								"namespace", namespaceName,
+								"name", "machine-older-extra-0",
+							},
+							Message: removingOldMachine,
+						},
+					}
+				},
+			}),
+			Entry("with extra updated machines in multiple indexes", rollingUpdateTableInput{
+				cpmsBuilder: cpmsBuilder.WithReplicas(3),
+				machineInfos: map[int32][]machineproviders.MachineInfo{
+					0: {
+						updatedMachineBuilder.WithIndex(0).WithMachineName("machine-older-extra-0").WithNodeName("node-older-extra-0").Build(),
+						updatedMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build(),
+					},
+					1: {
+						updatedMachineBuilder.WithIndex(1).WithMachineName("machine-older-extra-1").WithNodeName("node-older-extra-1").Build(),
+						updatedMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").Build(),
+					},
+					2: {updatedMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("node-2").Build()},
+				},
+				setupMock: func() {
+					machineInfo1 := updatedMachineBuilder.WithIndex(0).WithMachineName("machine-older-extra-1").Build()
+					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any(), gomock.Any(), machineInfo1.MachineRef).Times(1)
+					machineInfo0 := updatedMachineBuilder.WithIndex(0).WithMachineName("machine-older-extra-0").Build()
+					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any(), gomock.Any(), machineInfo0.MachineRef).Times(1)
+				},
+				expectedLogsBuilder: func() []test.LogEntry {
+					return []test.LogEntry{
+						{
+							Level: 2,
+							KeysAndValues: []interface{}{
+								"updateStrategy", machinev1.RollingUpdate,
+								"index", 0,
+								"namespace", namespaceName,
+								"name", "machine-older-extra-0",
+							},
+							Message: removingOldMachine,
+						},
+						{
+							Level: 2,
+							KeysAndValues: []interface{}{
+								"updateStrategy", machinev1.RollingUpdate,
+								"index", 1,
+								"namespace", namespaceName,
+								"name", "machine-older-extra-1",
+							},
+							Message: removingOldMachine,
+						},
+					}
+				},
+			}),
 			Entry("with an index not starting at zero, and no updates required", rollingUpdateTableInput{
 				cpmsBuilder: cpmsBuilder.WithReplicas(3),
 				machineInfos: map[int32][]machineproviders.MachineInfo{

--- a/pkg/controllers/controlplanemachineset/updates_test.go
+++ b/pkg/controllers/controlplanemachineset/updates_test.go
@@ -19,6 +19,7 @@ package controlplanemachineset
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
@@ -1762,6 +1763,40 @@ var _ = Describe("utils tests", func() {
 			[][]machineproviders.MachineInfo{
 				{updatedMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build()},
 				{updatedMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("node-2").Build()},
+			},
+		),
+	)
+	DescribeTable("should convert an slice of MachineInfo into a slice sorted of MachineInfo sorted by Machine's CreationTimestamp",
+		func(input []machineproviders.MachineInfo, expected []machineproviders.MachineInfo) {
+			output := sortMachineInfoByCreationTimestamp(input)
+			Expect(output).To(Equal(expected))
+		},
+		Entry("when MachineInfo is not sorted by CreationTimestamp",
+			[]machineproviders.MachineInfo{
+				updatedMachineBuilder.WithIndex(0).WithMachineName("machine-newer-0").WithNodeName("node-0").
+					WithMachineCreationTimestamp(metav1.NewTime(time.Date(2022, 02, 01, 01, 01, 01, 01, time.UTC))).Build(),
+				updatedMachineBuilder.WithIndex(0).WithMachineName("machine-older-0").WithNodeName("node-0").
+					WithMachineCreationTimestamp(metav1.NewTime(time.Date(2022, 01, 01, 01, 01, 01, 01, time.UTC))).Build(),
+			},
+			[]machineproviders.MachineInfo{
+				updatedMachineBuilder.WithIndex(0).WithMachineName("machine-older-0").WithNodeName("node-0").
+					WithMachineCreationTimestamp(metav1.NewTime(time.Date(2022, 01, 01, 01, 01, 01, 01, time.UTC))).Build(),
+				updatedMachineBuilder.WithIndex(0).WithMachineName("machine-newer-0").WithNodeName("node-0").
+					WithMachineCreationTimestamp(metav1.NewTime(time.Date(2022, 02, 01, 01, 01, 01, 01, time.UTC))).Build(),
+			},
+		),
+		Entry("when MachineInfo is already sorted by CreationTimestamp",
+			[]machineproviders.MachineInfo{
+				updatedMachineBuilder.WithIndex(0).WithMachineName("machine-older-0").WithNodeName("node-0").
+					WithMachineCreationTimestamp(metav1.NewTime(time.Date(2022, 01, 01, 01, 01, 01, 01, time.UTC))).Build(),
+				updatedMachineBuilder.WithIndex(0).WithMachineName("machine-newer-0").WithNodeName("node-0").
+					WithMachineCreationTimestamp(metav1.NewTime(time.Date(2022, 02, 01, 01, 01, 01, 01, time.UTC))).Build(),
+			},
+			[]machineproviders.MachineInfo{
+				updatedMachineBuilder.WithIndex(0).WithMachineName("machine-older-0").WithNodeName("node-0").
+					WithMachineCreationTimestamp(metav1.NewTime(time.Date(2022, 01, 01, 01, 01, 01, 01, time.UTC))).Build(),
+				updatedMachineBuilder.WithIndex(0).WithMachineName("machine-newer-0").WithNodeName("node-0").
+					WithMachineCreationTimestamp(metav1.NewTime(time.Date(2022, 02, 01, 01, 01, 01, 01, time.UTC))).Build(),
 			},
 		),
 	)

--- a/pkg/test/resourcebuilder/machine_info.go
+++ b/pkg/test/resourcebuilder/machine_info.go
@@ -33,6 +33,7 @@ func MachineInfo() MachineInfoBuilder {
 // MachineInfoBuilder is used to build out a machineinfo object.
 type MachineInfoBuilder struct {
 	machineDeletiontimestamp *metav1.Time
+	machineCreationtimestamp metav1.Time
 	machineGVR               schema.GroupVersionResource
 	machineName              string
 	machineNamespace         string
@@ -62,6 +63,7 @@ func (m MachineInfoBuilder) Build() machineproviders.MachineInfo {
 			GroupVersionResource: m.machineGVR,
 			ObjectMeta: metav1.ObjectMeta{
 				DeletionTimestamp: m.machineDeletiontimestamp,
+				CreationTimestamp: m.machineCreationtimestamp,
 				Labels:            m.machineLabels,
 				Name:              m.machineName,
 				Namespace:         m.machineNamespace,
@@ -80,6 +82,12 @@ func (m MachineInfoBuilder) Build() machineproviders.MachineInfo {
 	}
 
 	return info
+}
+
+// WithMachineCreationTimestamp sets the machine creation timestamp for the machineinfo builder.
+func (m MachineInfoBuilder) WithMachineCreationTimestamp(creation metav1.Time) MachineInfoBuilder {
+	m.machineCreationtimestamp = creation
+	return m
 }
 
 // WithMachineDeletionTimestamp sets the machine deletion timestamp for the machineinfo builder.


### PR DESCRIPTION
This PR adds logic to handle a corner case where there is more than one machine that is Updated (Ready and Up-to-date) in a single index of the Control Plane Machine Set.

As discussed in the [linked issue](https://issues.redhat.com/browse/OCPBUGS-996), the behaviour, covered by the logic introduced in the PR (last two commits) should be the following:
- at cluster state validation stage, check for every index of the CPMS if there is more than one Updated Machine. If that's the case, carry on if the update strategy is `RollingUpdate` or `Recreate`; if instead the strategy is `OnDelete` log an error and put the operator in degraded state.
- if in `RollingUpdate` or `Recreate` in the respective reconcile logics handle the Updated machine in excess by deleting the oldest between the two.

Along the line I found a couple of minor bugs to do with:
- log entries not being checked in the unit tests. I had them checked and fixed their entries to match the expected ones.
- for `fetchControlPlaneNodes` I changed the returning map (that can't be sorted by key) to be a slice, which preserves append order, to have a consistent ordering for the elements in testing.

I suggest reviewing it by commit.