### PR TITLE
OCPBUGS-996: Reverts "Add logic to handle extra updated machines in a single index + minor fixes"

### DIFF
--- a/pkg/controllers/controlplanemachineset/consts.go
+++ b/pkg/controllers/controlplanemachineset/consts.go
@@ -127,11 +127,6 @@ const (
 	// This will typically occur when an old replica has not yet been removed.
 	reasonExcessReplicas = "ExcessReplicas"
 
-	// reasonExcessUpdatedReplicas denotes that the ControlPlaneMachineSet has a more than expected number
-	// of ready and up-to-date replicas.
-	// This will typically occur when extra replica(s) for an index have been created.
-	reasonExcessUpdatedReplicas = "ExcessUpdatedReplicas"
-
 	// reasonNeedsUpdateReplicas denotes that the ControlPlaneMachineSet has identified
 	// replicas under its management that are currently in need of an update.
 	reasonNeedsUpdateReplicas = "NeedsUpdateReplicas"

--- a/pkg/controllers/controlplanemachineset/controller_test.go
+++ b/pkg/controllers/controlplanemachineset/controller_test.go
@@ -19,7 +19,6 @@ package controlplanemachineset
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -920,7 +919,7 @@ var _ = Describe("validateClusterState", func() {
 		}
 
 		Expect(cpms.Status.Conditions).To(test.MatchConditions(in.expectedConditions))
-		Expect(logger.Entries()).To(ConsistOf(in.expectedLogs))
+		Expect(in.expectedLogs).To(ConsistOf(in.expectedLogs))
 	},
 		Entry("with a valid cluster state", validateClusterTableInput{
 			cpmsBuilder: cpmsBuilder.WithConditions([]metav1.Condition{
@@ -1030,7 +1029,7 @@ var _ = Describe("validateClusterState", func() {
 			},
 			expectedLogs: []test.LogEntry{
 				{
-					Error: fmt.Errorf("%w: %s", errFoundUnmanagedControlPlaneNodes, "master-0, master-2"),
+					Error: errors.New("found unmanaged control plane nodes, the following node(s) do not have associated machines: master-0, master-2"),
 					KeysAndValues: []interface{}{
 						"unmanagedNodes", "master-0,master-2",
 					},
@@ -1064,7 +1063,7 @@ var _ = Describe("validateClusterState", func() {
 			},
 			expectedLogs: []test.LogEntry{
 				{
-					Error: fmt.Errorf("%w: %s", errFoundUnmanagedControlPlaneNodes, "master-3"),
+					Error: errors.New("found unmanaged control plane nodes, the following node(s) do not have associated machines: master-3"),
 					KeysAndValues: []interface{}{
 						"unmanagedNodes", "master-3",
 					},
@@ -1125,7 +1124,7 @@ var _ = Describe("validateClusterState", func() {
 			},
 			expectedLogs: []test.LogEntry{
 				{
-					Error: fmt.Errorf("%w: %s", errFoundErroredReplacementControlPlaneMachine, "machine-replacement-0"),
+					Error: errors.New("found replacement control plane machines in an error state, the following machines(s) are currently reporting an error: machine-replacement-0"),
 					KeysAndValues: []interface{}{
 						"failedReplacements", "machine-replacement-0",
 					},
@@ -1164,78 +1163,11 @@ var _ = Describe("validateClusterState", func() {
 			},
 			expectedLogs: []test.LogEntry{
 				{
-					Error: fmt.Errorf("%w: %s", errFoundErroredReplacementControlPlaneMachine, "machine-replacement-0, machine-replacement-1"),
+					Error: errors.New("found replacement control plane machines in an error state, the following machines(s) are currently reporting an error: machine-replacement-0,machine-replacement-1"),
 					KeysAndValues: []interface{}{
 						"failedReplacements", "machine-replacement-0,machine-replacement-1",
 					},
 					Message: "Observed failed replacement control plane machines",
-				},
-			},
-		}),
-		Entry("with multiple updated machines in a single index and RollingUpdate strategy", validateClusterTableInput{
-			cpmsBuilder: cpmsBuilder.WithConditions([]metav1.Condition{
-				degradedConditionBuilder.WithStatus(metav1.ConditionFalse).Build(),
-				progressingConditionBuilder.WithStatus(metav1.ConditionFalse).Build(),
-			}).WithReplicas(3),
-			machineInfos: map[int32][]machineproviders.MachineInfo{
-				0: {
-					updatedMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("master-0").Build(),
-					updatedMachineBuilder.WithIndex(0).WithMachineName("machine-replacement-0").WithNodeName("master-replacement-0").Build(),
-				},
-				1: {updatedMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("master-1").Build()},
-				2: {updatedMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("master-2").Build()},
-			},
-			nodes: []*corev1.Node{
-				masterNodeBuilder.WithName("master-0").Build(),
-				masterNodeBuilder.WithName("master-replacement-0").Build(),
-				masterNodeBuilder.WithName("master-1").Build(),
-				masterNodeBuilder.WithName("master-2").Build(),
-				workerNodeBuilder.WithName("worker-0").Build(),
-				workerNodeBuilder.WithName("worker-1").Build(),
-				workerNodeBuilder.WithName("worker-2").Build(),
-			},
-			expectedError: nil,
-			expectedConditions: []metav1.Condition{
-				degradedConditionBuilder.WithStatus(metav1.ConditionFalse).Build(),
-				progressingConditionBuilder.WithStatus(metav1.ConditionFalse).Build(),
-			},
-			expectedLogs: []test.LogEntry{},
-		}),
-		Entry("with multiple updated machines in a single index and OnDelete strategy", validateClusterTableInput{
-			cpmsBuilder: cpmsBuilder.WithConditions([]metav1.Condition{
-				degradedConditionBuilder.WithStatus(metav1.ConditionFalse).Build(),
-				progressingConditionBuilder.WithStatus(metav1.ConditionFalse).Build(),
-			}).WithReplicas(3).WithStrategyType(machinev1.OnDelete),
-			machineInfos: map[int32][]machineproviders.MachineInfo{
-				0: {
-					updatedMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("master-0").Build(),
-					updatedMachineBuilder.WithIndex(0).WithMachineName("machine-replacement-0").WithNodeName("master-replacement-0").Build(),
-				},
-				1: {updatedMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("master-1").Build()},
-				2: {updatedMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("master-2").Build()},
-			},
-			nodes: []*corev1.Node{
-				masterNodeBuilder.WithName("master-0").Build(),
-				masterNodeBuilder.WithName("master-replacement-0").Build(),
-				masterNodeBuilder.WithName("master-1").Build(),
-				masterNodeBuilder.WithName("master-2").Build(),
-				workerNodeBuilder.WithName("worker-0").Build(),
-				workerNodeBuilder.WithName("worker-1").Build(),
-				workerNodeBuilder.WithName("worker-2").Build(),
-			},
-			expectedError: nil,
-			expectedConditions: []metav1.Condition{
-				degradedConditionBuilder.WithStatus(metav1.ConditionTrue).WithReason(reasonExcessUpdatedReplicas).WithMessage("Observed 1 updated machine(s) in excess for index 0").Build(),
-				progressingConditionBuilder.WithStatus(metav1.ConditionFalse).WithReason(reasonOperatorDegraded).Build(),
-			},
-
-			expectedLogs: []test.LogEntry{
-				{
-					Error: fmt.Errorf("%w: %s", errFoundExcessiveUpdatedReplicas, "1 updated replica(s) are in excess for index 0"),
-					KeysAndValues: []interface{}{
-						"excessUpdatedReplicas", 1,
-					},
-					Message: "Observed an excessive number of updated replica(s) for a single index",
 				},
 			},
 		}),
@@ -1314,9 +1246,9 @@ var _ = Describe("validateClusterState", func() {
 			},
 			expectedLogs: []test.LogEntry{
 				{
-					Error: fmt.Errorf("%w: %s", errFoundExcessiveIndexes, "1 index(es) are in excess"),
+					Error: errors.New("found an excessive number of indexes for the control plane machine set, 1 index(es) are in excess"),
 					KeysAndValues: []interface{}{
-						"excessIndexes", int32(1),
+						"excessIndexes", "1",
 					},
 					Message: "Observed an excessive number of control plane machine indexes",
 				},

--- a/pkg/controllers/controlplanemachineset/updates.go
+++ b/pkg/controllers/controlplanemachineset/updates.go
@@ -317,13 +317,6 @@ func (r *ControlPlaneMachineSetReconciler) deleteReplacedMachines(ctx context.Co
 		toDeleteMachine = machinesOutdatedNonReady[0]
 	}
 
-	if len(machinesUpdated) > 1 {
-		// More than one Updated (Ready and Up-to-date) Machine exists for this index.
-		// This means there is an excess in Updated Machines for this index and
-		// the oldest Machine in this state should be deleted.
-		toDeleteMachine = sortMachineInfoByCreationTimestamp(machinesUpdated)[0]
-	}
-
 	// Check if any Machine was deemed for deletion.
 	if toDeleteMachine.MachineRef != nil {
 		logger := logger.WithValues("index", int(toDeleteMachine.Index), "namespace", r.Namespace, "name", toDeleteMachine.MachineRef.ObjectMeta.Name)
@@ -594,15 +587,6 @@ func sortMachineInfosByIndex(indexedMachineInfos map[int32][]machineproviders.Ma
 	}
 
 	return slice
-}
-
-// sortMachineInfoByCreationTimestamp returns a slice of MachineInfo sorted by Machine's CreationTimestamp.
-func sortMachineInfoByCreationTimestamp(machineInfos []machineproviders.MachineInfo) []machineproviders.MachineInfo {
-	sort.Slice(machineInfos, func(i, j int) bool {
-		return machineInfos[i].MachineRef.ObjectMeta.CreationTimestamp.Before(&machineInfos[j].MachineRef.ObjectMeta.CreationTimestamp)
-	})
-
-	return machineInfos
 }
 
 // deviseExistingSurge computes the current amount of replicas surge for the ControlPlaneMachineSet.

--- a/pkg/controllers/controlplanemachineset/updates_test.go
+++ b/pkg/controllers/controlplanemachineset/updates_test.go
@@ -19,7 +19,6 @@ package controlplanemachineset
 import (
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
@@ -775,79 +774,6 @@ var _ = Describe("reconcileMachineUpdates", func() {
 								"name", "machine-3",
 							},
 							Message: noCapacityForExpansion,
-						},
-					}
-				},
-			}),
-			Entry("with an extra updated machine in a single index", rollingUpdateTableInput{
-				cpmsBuilder: cpmsBuilder.WithReplicas(3),
-				machineInfos: map[int32][]machineproviders.MachineInfo{
-					0: {
-						updatedMachineBuilder.WithIndex(0).WithMachineName("machine-older-extra-0").WithNodeName("node-older-extra-0").Build(),
-						updatedMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build(),
-					},
-					1: {updatedMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").Build()},
-					2: {updatedMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("node-2").Build()},
-				},
-				setupMock: func() {
-					machineInfo0 := updatedMachineBuilder.WithIndex(0).WithMachineName("machine-older-extra-0").Build()
-					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any(), gomock.Any(), machineInfo0.MachineRef).Times(1)
-				},
-				expectedLogsBuilder: func() []test.LogEntry {
-					return []test.LogEntry{
-						{
-							Level: 2,
-							KeysAndValues: []interface{}{
-								"updateStrategy", machinev1.RollingUpdate,
-								"index", 0,
-								"namespace", namespaceName,
-								"name", "machine-older-extra-0",
-							},
-							Message: removingOldMachine,
-						},
-					}
-				},
-			}),
-			Entry("with extra updated machines in multiple indexes", rollingUpdateTableInput{
-				cpmsBuilder: cpmsBuilder.WithReplicas(3),
-				machineInfos: map[int32][]machineproviders.MachineInfo{
-					0: {
-						updatedMachineBuilder.WithIndex(0).WithMachineName("machine-older-extra-0").WithNodeName("node-older-extra-0").Build(),
-						updatedMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build(),
-					},
-					1: {
-						updatedMachineBuilder.WithIndex(1).WithMachineName("machine-older-extra-1").WithNodeName("node-older-extra-1").Build(),
-						updatedMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").Build(),
-					},
-					2: {updatedMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("node-2").Build()},
-				},
-				setupMock: func() {
-					machineInfo1 := updatedMachineBuilder.WithIndex(0).WithMachineName("machine-older-extra-1").Build()
-					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any(), gomock.Any(), machineInfo1.MachineRef).Times(1)
-					machineInfo0 := updatedMachineBuilder.WithIndex(0).WithMachineName("machine-older-extra-0").Build()
-					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any(), gomock.Any(), machineInfo0.MachineRef).Times(1)
-				},
-				expectedLogsBuilder: func() []test.LogEntry {
-					return []test.LogEntry{
-						{
-							Level: 2,
-							KeysAndValues: []interface{}{
-								"updateStrategy", machinev1.RollingUpdate,
-								"index", 0,
-								"namespace", namespaceName,
-								"name", "machine-older-extra-0",
-							},
-							Message: removingOldMachine,
-						},
-						{
-							Level: 2,
-							KeysAndValues: []interface{}{
-								"updateStrategy", machinev1.RollingUpdate,
-								"index", 1,
-								"namespace", namespaceName,
-								"name", "machine-older-extra-1",
-							},
-							Message: removingOldMachine,
 						},
 					}
 				},
@@ -1836,40 +1762,6 @@ var _ = Describe("utils tests", func() {
 			[][]machineproviders.MachineInfo{
 				{updatedMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build()},
 				{updatedMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("node-2").Build()},
-			},
-		),
-	)
-	DescribeTable("should convert an slice of MachineInfo into a slice sorted of MachineInfo sorted by Machine's CreationTimestamp",
-		func(input []machineproviders.MachineInfo, expected []machineproviders.MachineInfo) {
-			output := sortMachineInfoByCreationTimestamp(input)
-			Expect(output).To(Equal(expected))
-		},
-		Entry("when MachineInfo is not sorted by CreationTimestamp",
-			[]machineproviders.MachineInfo{
-				updatedMachineBuilder.WithIndex(0).WithMachineName("machine-newer-0").WithNodeName("node-0").
-					WithMachineCreationTimestamp(metav1.NewTime(time.Date(2022, 02, 01, 01, 01, 01, 01, time.UTC))).Build(),
-				updatedMachineBuilder.WithIndex(0).WithMachineName("machine-older-0").WithNodeName("node-0").
-					WithMachineCreationTimestamp(metav1.NewTime(time.Date(2022, 01, 01, 01, 01, 01, 01, time.UTC))).Build(),
-			},
-			[]machineproviders.MachineInfo{
-				updatedMachineBuilder.WithIndex(0).WithMachineName("machine-older-0").WithNodeName("node-0").
-					WithMachineCreationTimestamp(metav1.NewTime(time.Date(2022, 01, 01, 01, 01, 01, 01, time.UTC))).Build(),
-				updatedMachineBuilder.WithIndex(0).WithMachineName("machine-newer-0").WithNodeName("node-0").
-					WithMachineCreationTimestamp(metav1.NewTime(time.Date(2022, 02, 01, 01, 01, 01, 01, time.UTC))).Build(),
-			},
-		),
-		Entry("when MachineInfo is already sorted by CreationTimestamp",
-			[]machineproviders.MachineInfo{
-				updatedMachineBuilder.WithIndex(0).WithMachineName("machine-older-0").WithNodeName("node-0").
-					WithMachineCreationTimestamp(metav1.NewTime(time.Date(2022, 01, 01, 01, 01, 01, 01, time.UTC))).Build(),
-				updatedMachineBuilder.WithIndex(0).WithMachineName("machine-newer-0").WithNodeName("node-0").
-					WithMachineCreationTimestamp(metav1.NewTime(time.Date(2022, 02, 01, 01, 01, 01, 01, time.UTC))).Build(),
-			},
-			[]machineproviders.MachineInfo{
-				updatedMachineBuilder.WithIndex(0).WithMachineName("machine-older-0").WithNodeName("node-0").
-					WithMachineCreationTimestamp(metav1.NewTime(time.Date(2022, 01, 01, 01, 01, 01, 01, time.UTC))).Build(),
-				updatedMachineBuilder.WithIndex(0).WithMachineName("machine-newer-0").WithNodeName("node-0").
-					WithMachineCreationTimestamp(metav1.NewTime(time.Date(2022, 02, 01, 01, 01, 01, 01, time.UTC))).Build(),
 			},
 		),
 	)

--- a/pkg/test/resourcebuilder/machine_info.go
+++ b/pkg/test/resourcebuilder/machine_info.go
@@ -33,7 +33,6 @@ func MachineInfo() MachineInfoBuilder {
 // MachineInfoBuilder is used to build out a machineinfo object.
 type MachineInfoBuilder struct {
 	machineDeletiontimestamp *metav1.Time
-	machineCreationtimestamp metav1.Time
 	machineGVR               schema.GroupVersionResource
 	machineName              string
 	machineNamespace         string
@@ -63,7 +62,6 @@ func (m MachineInfoBuilder) Build() machineproviders.MachineInfo {
 			GroupVersionResource: m.machineGVR,
 			ObjectMeta: metav1.ObjectMeta{
 				DeletionTimestamp: m.machineDeletiontimestamp,
-				CreationTimestamp: m.machineCreationtimestamp,
 				Labels:            m.machineLabels,
 				Name:              m.machineName,
 				Namespace:         m.machineNamespace,
@@ -82,12 +80,6 @@ func (m MachineInfoBuilder) Build() machineproviders.MachineInfo {
 	}
 
 	return info
-}
-
-// WithMachineCreationTimestamp sets the machine creation timestamp for the machineinfo builder.
-func (m MachineInfoBuilder) WithMachineCreationTimestamp(creation metav1.Time) MachineInfoBuilder {
-	m.machineCreationtimestamp = creation
-	return m
 }
 
 // WithMachineDeletionTimestamp sets the machine deletion timestamp for the machineinfo builder.


### PR DESCRIPTION
Reverts openshift/cluster-control-plane-machine-set-operator#98 ; tracked by OCPBUGS-1752

Per TRT policy, we are reverting this breaking change to get ci and/or nightly payloads flowing again.  Since this PR merged, aws-sdn-serial has been failing on control plate-related tasks, such as the etcd scaling test which adds an additional control plane node.  Looking at the run history on the PR, the test was also failing in presubmits.  Prior to this merging, this test passed at 95%, and has since dropped to under 60%. https://amd64.ocp.releases.ci.openshift.org/releasestream/4.12.0-0.ci/release/4.12.0-0.ci-2022-09-26-133725 is the first payload that failed, and this looks like the most obvious change to me.

To unrevert this revert, revert this PR, and layer an additional separate commit on top that addresses the problem.  Ensure e2e-aws-serial passes.

CC: @damdo, @JoelSpeed 