### PR TITLE
Updating ose-cluster-control-plane-machine-set-operator images to be consistent with ART

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.18-openshift-4.12
+  tag: rhel-8-release-golang-1.19-openshift-4.12

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.12 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.12 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-control-plane-machine-set-operator
 COPY . .
 RUN make build

--- a/pkg/controllers/controlplanemachineset/controller.go
+++ b/pkg/controllers/controlplanemachineset/controller.go
@@ -437,14 +437,14 @@ func (r *ControlPlaneMachineSetReconciler) ensureOwnerReferences(ctx context.Con
 }
 
 // validateClusterState uses the machineInfos to validate that:
-// - All Nodes in the cluster claiming to be control plane nodes have a valid machine.
-// - At least 1 of the control plane machines is in the ready state (if there are no ready Machines then the cluster
-//   is likely misconfigured).
-// - We have the correct number of indexes:
-//   + Right number of indexes, valid.
-//   + Too few indexes, valid. We will later scale up without user intervention when we perform reconcileMachineUpdates.
-//   + Too many indexes, invalid. We set the operator to degraded and ask the user for manual intervention.
-// - No replacement machines (one that doesn't need update but has an equivalent in the index that needs update) have an error.
+//   - All Nodes in the cluster claiming to be control plane nodes have a valid machine.
+//   - At least 1 of the control plane machines is in the ready state (if there are no ready Machines then the cluster
+//     is likely misconfigured).
+//   - We have the correct number of indexes:
+//     -- Right number of indexes, valid.
+//     -- Too few indexes, valid. We will later scale up without user intervention when we perform reconcileMachineUpdates.
+//     -- Too many indexes, invalid. We set the operator to degraded and ask the user for manual intervention.
+//   - No replacement machines (one that doesn't need update but has an equivalent in the index that needs update) have an error.
 func (r *ControlPlaneMachineSetReconciler) validateClusterState(ctx context.Context, logger logr.Logger, cpms *machinev1.ControlPlaneMachineSet, machineInfos map[int32][]machineproviders.MachineInfo) error {
 	sortedIndexedMs := sortMachineInfosByIndex(machineInfos)
 

--- a/pkg/controllers/controlplanemachineset/status.go
+++ b/pkg/controllers/controlplanemachineset/status.go
@@ -65,12 +65,12 @@ func (r *ControlPlaneMachineSetReconciler) updateControlPlaneMachineSetStatus(ct
 // In particular, it will update the ObservedGeneration, Replicas, ReadyReplicas, UnavailableReplicas and UpdatedReplicas
 // fields based on the information gathered, and then set any relevant conditions if applicable.
 // It observes the following rules for setting the status:
-// - Replicas is the number of Machines present
-// - ReadyReplicas is the number of the above Replicas which are reporting as Ready
-// - UpdatedReplicas is the number of Ready Replicas that do not need an update (this should be at most 1 per index).
-// - UnavailableReplicas is the number of Machines required to satisfy the requirement of at least 1 Ready Replica per
-//   index. Eg. if one index has no ready replicas, this is 1, if an index has 2 ready replicas, this does not count as
-//   2 available replicas.
+//   - Replicas is the number of Machines present
+//   - ReadyReplicas is the number of the above Replicas which are reporting as Ready
+//   - UpdatedReplicas is the number of Ready Replicas that do not need an update (this should be at most 1 per index).
+//   - UnavailableReplicas is the number of Machines required to satisfy the requirement of at least 1 Ready Replica per
+//     index. Eg. if one index has no ready replicas, this is 1, if an index has 2 ready replicas, this does not count as
+//     2 available replicas.
 func reconcileStatusWithMachineInfo(logger logr.Logger, cpms *machinev1.ControlPlaneMachineSet, machineInfosByIndex map[int32][]machineproviders.MachineInfo) error {
 	replicas := int32(0)
 	readyReplicas := int32(0)

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/mapping.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/mapping.go
@@ -407,9 +407,10 @@ func removeExtraIndexes(mapping, target map[int32]failuredomain.FailureDomain) {
 // parseMachineNameIndex returns an integer suffix from the machine name. If there is no sufficient suffix, it
 // returns "false" as a second value.
 // Example:
-//   machine-master-3 -> 3, true
-//   machine-master-a -> 0, false
-//   machine-master3  -> 0 , false
+//
+//	machine-master-3 -> 3, true
+//	machine-master-a -> 0, false
+//	machine-master3  -> 0 , false
 func parseMachineNameIndex(machineName string) (int, bool) {
 	machineNameIndex, err := strconv.ParseInt(machineName[strings.LastIndex(machineName, "-")+1:], 10, 32)
 	if err != nil {

--- a/pkg/test/conditions.go
+++ b/pkg/test/conditions.go
@@ -80,6 +80,7 @@ type matchCondition struct {
 }
 
 // Match checks for equality between the actual and expected objects.
+//
 //nolint:dupl
 func (m matchCondition) Match(actual interface{}) (success bool, err error) {
 	actualCondition, ok := actual.(metav1.Condition)
@@ -174,6 +175,7 @@ type matchClusterOperatorCondition struct {
 }
 
 // Match checks for equality between the actual and expected objects.
+//
 //nolint:dupl
 func (m matchClusterOperatorCondition) Match(actual interface{}) (success bool, err error) {
 	actualCondition, ok := actual.(configv1.ClusterOperatorStatusCondition)

--- a/pkg/test/resourcebuilder/azure_failure_domains.go
+++ b/pkg/test/resourcebuilder/azure_failure_domains.go
@@ -16,7 +16,8 @@ limitations under the License.
 
 // Linter warns about duplicated code with OpenStack, GCP, and Azure FailureDomains builders.
 // While the builders are almost identical, we need to keep them separate because they build different objects.
-//nolint: dupl
+//
+//nolint:dupl
 package resourcebuilder
 
 import (

--- a/pkg/test/resourcebuilder/gcp_failure_domains.go
+++ b/pkg/test/resourcebuilder/gcp_failure_domains.go
@@ -16,7 +16,8 @@ limitations under the License.
 
 // Linter warns about duplicated code with OpenStack, GCP, and Azure FailureDomains builders.
 // While the builders are almost identical, we need to keep them separate because they build different objects.
-//nolint: dupl
+//
+//nolint:dupl
 package resourcebuilder
 
 import (


### PR DESCRIPTION
Cherry-picked from https://github.com/openshift/cluster-control-plane-machine-set-operator/pull/108

Updated comments formatting due to changes in golang 1.19