### PR TITLE
OCPBUGS-1645: Ensure the ControlPlaneMachineSet can handle machines that are not indexed from 0

### DIFF
--- a/pkg/controllers/controlplanemachineset/controller.go
+++ b/pkg/controllers/controlplanemachineset/controller.go
@@ -502,13 +502,17 @@ func machineInfosByIndex(cpms *machinev1.ControlPlaneMachineSet, machineInfos []
 		return nil, errReplicasRequired
 	}
 
-	// Make sure that every expected index is accounted for.
-	for i := int32(0); i < *cpms.Spec.Replicas; i++ {
-		out[i] = []machineproviders.MachineInfo{}
-	}
-
 	for _, machineInfo := range machineInfos {
 		out[machineInfo.Index] = append(out[machineInfo.Index], machineInfo)
+	}
+
+	// If for any reason there aren't enough indexes to meet the replica count,
+	// populate empty indexes starting from index 0 until we have the correct
+	// number of indexes.
+	for i := int32(0); int32(len(out)) < *cpms.Spec.Replicas; i++ {
+		if _, ok := out[i]; !ok {
+			out[i] = []machineproviders.MachineInfo{}
+		}
 	}
 
 	return out, nil

--- a/pkg/controllers/controlplanemachineset/controller_test.go
+++ b/pkg/controllers/controlplanemachineset/controller_test.go
@@ -239,6 +239,118 @@ var _ = Describe("With a running controller", func() {
 					HaveField("Replicas", Equal(int32(3))),
 					HaveField("ReadyReplicas", Equal(int32(3))),
 					HaveField("UpdatedReplicas", Equal(int32(3))),
+					HaveField("UnavailableReplicas", Equal(int32(0))),
+				)))
+			})
+
+			It("should add an owner reference to each machine", func() {
+				Eventually(komega.ObjectList(&machinev1beta1.MachineList{})).Should(HaveField("Items", Not(ContainElement(HaveField("ObjectMeta.OwnerReferences", BeEmpty())))), "No machine should not have an owner reference")
+			})
+		})
+
+		Context("with machines indexed 0, 1, 2", func() {
+			BeforeEach(func() {
+				By("Creating Machines owned by the ControlPlaneMachineSet")
+				machineBuilder := resourcebuilder.Machine().AsMaster().WithNamespace(namespaceName)
+
+				Expect(k8sClient.Create(ctx, machineBuilder.WithName("master-0").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build())).To(Succeed())
+				Expect(k8sClient.Create(ctx, machineBuilder.WithName("master-1").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build())).To(Succeed())
+				Expect(k8sClient.Create(ctx, machineBuilder.WithName("master-2").WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build())).To(Succeed())
+
+				By("Ensuring Machines are Running")
+				machines := &machinev1beta1.MachineList{}
+				Expect(k8sClient.List(ctx, machines)).To(Succeed())
+
+				for _, machine := range machines.Items {
+					m := machine.DeepCopy()
+
+					Eventually(komega.UpdateStatus(m, func() {
+						m.Status.Phase = &running
+					})).Should(Succeed())
+				}
+			})
+
+			It("should update the status", func() {
+				Eventually(komega.Object(cpms)).Should(HaveField("Status", SatisfyAll(
+					HaveField("ObservedGeneration", Equal(int64(1))),
+					HaveField("Replicas", Equal(int32(3))),
+					HaveField("ReadyReplicas", Equal(int32(3))),
+					HaveField("UpdatedReplicas", Equal(int32(3))),
+					HaveField("UnavailableReplicas", Equal(int32(0))),
+				)))
+			})
+
+			It("should add an owner reference to each machine", func() {
+				Eventually(komega.ObjectList(&machinev1beta1.MachineList{})).Should(HaveField("Items", Not(ContainElement(HaveField("ObjectMeta.OwnerReferences", BeEmpty())))), "No machine should not have an owner reference")
+			})
+		})
+
+		Context("with machines indexed 4, 0, 2", func() {
+			BeforeEach(func() {
+				By("Creating Machines owned by the ControlPlaneMachineSet")
+				machineBuilder := resourcebuilder.Machine().AsMaster().WithNamespace(namespaceName)
+
+				Expect(k8sClient.Create(ctx, machineBuilder.WithName("master-4").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build())).To(Succeed())
+				Expect(k8sClient.Create(ctx, machineBuilder.WithName("master-0").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build())).To(Succeed())
+				Expect(k8sClient.Create(ctx, machineBuilder.WithName("master-2").WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build())).To(Succeed())
+
+				By("Ensuring Machines are Running")
+				machines := &machinev1beta1.MachineList{}
+				Expect(k8sClient.List(ctx, machines)).To(Succeed())
+
+				for _, machine := range machines.Items {
+					m := machine.DeepCopy()
+
+					Eventually(komega.UpdateStatus(m, func() {
+						m.Status.Phase = &running
+					})).Should(Succeed())
+				}
+			})
+
+			It("should update the status", func() {
+				Eventually(komega.Object(cpms)).Should(HaveField("Status", SatisfyAll(
+					HaveField("ObservedGeneration", Equal(int64(1))),
+					HaveField("Replicas", Equal(int32(3))),
+					HaveField("ReadyReplicas", Equal(int32(3))),
+					HaveField("UpdatedReplicas", Equal(int32(3))),
+					HaveField("UnavailableReplicas", Equal(int32(0))),
+				)))
+			})
+
+			It("should add an owner reference to each machine", func() {
+				Eventually(komega.ObjectList(&machinev1beta1.MachineList{})).Should(HaveField("Items", Not(ContainElement(HaveField("ObjectMeta.OwnerReferences", BeEmpty())))), "No machine should not have an owner reference")
+			})
+		})
+
+		Context("with machines indexed 3, 4, 5", func() {
+			BeforeEach(func() {
+				By("Creating Machines owned by the ControlPlaneMachineSet")
+				machineBuilder := resourcebuilder.Machine().AsMaster().WithNamespace(namespaceName)
+
+				Expect(k8sClient.Create(ctx, machineBuilder.WithName("master-3").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build())).To(Succeed())
+				Expect(k8sClient.Create(ctx, machineBuilder.WithName("master-4").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build())).To(Succeed())
+				Expect(k8sClient.Create(ctx, machineBuilder.WithName("master-5").WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build())).To(Succeed())
+
+				By("Ensuring Machines are Running")
+				machines := &machinev1beta1.MachineList{}
+				Expect(k8sClient.List(ctx, machines)).To(Succeed())
+
+				for _, machine := range machines.Items {
+					m := machine.DeepCopy()
+
+					Eventually(komega.UpdateStatus(m, func() {
+						m.Status.Phase = &running
+					})).Should(Succeed())
+				}
+			})
+
+			It("should update the status", func() {
+				Eventually(komega.Object(cpms)).Should(HaveField("Status", SatisfyAll(
+					HaveField("ObservedGeneration", Equal(int64(1))),
+					HaveField("Replicas", Equal(int32(3))),
+					HaveField("ReadyReplicas", Equal(int32(3))),
+					HaveField("UpdatedReplicas", Equal(int32(3))),
+					HaveField("UnavailableReplicas", Equal(int32(0))),
 				)))
 			})
 
@@ -1105,11 +1217,13 @@ var _ = Describe("ensureOwnerRefrences", func() {
 
 var _ = Describe("machineInfosByIndex", func() {
 	i0m0 := resourcebuilder.MachineInfo().WithIndex(0).WithMachineName("machine-0-0").Build()
-	i0m1 := resourcebuilder.MachineInfo().WithIndex(0).WithMachineName("machine-0-1").Build()
-	i0m2 := resourcebuilder.MachineInfo().WithIndex(0).WithMachineName("machine-0-2").Build()
-	i1m0 := resourcebuilder.MachineInfo().WithIndex(1).WithMachineName("machine-1-0").Build()
+	i0m1 := resourcebuilder.MachineInfo().WithIndex(0).WithMachineName("machine-1-0").Build()
+	i0m2 := resourcebuilder.MachineInfo().WithIndex(0).WithMachineName("machine-2-0").Build()
+	i1m0 := resourcebuilder.MachineInfo().WithIndex(1).WithMachineName("machine-0-1").Build()
 	i1m1 := resourcebuilder.MachineInfo().WithIndex(1).WithMachineName("machine-1-1").Build()
-	i2m0 := resourcebuilder.MachineInfo().WithIndex(2).WithMachineName("machine-2-0").Build()
+	i2m0 := resourcebuilder.MachineInfo().WithIndex(2).WithMachineName("machine-0-2").Build()
+	i3m0 := resourcebuilder.MachineInfo().WithIndex(3).WithMachineName("machine-0-3").Build()
+	i4m0 := resourcebuilder.MachineInfo().WithIndex(4).WithMachineName("machine-0-4").Build()
 
 	type tableInput struct {
 		cpmsBuilder   resourcebuilder.ControlPlaneMachineSetInterface
@@ -1189,6 +1303,44 @@ var _ = Describe("machineInfosByIndex", func() {
 				0: {i0m0, i0m1, i0m2},
 				1: {},
 				2: {},
+			},
+		}),
+		Entry("with machines in indexes 0, 1 and 3", tableInput{
+			cpmsBuilder:  resourcebuilder.ControlPlaneMachineSet().WithReplicas(3),
+			machineInfos: []machineproviders.MachineInfo{i0m0, i1m0, i3m0},
+			expected: map[int32][]machineproviders.MachineInfo{
+				0: {i0m0},
+				1: {i1m0},
+				3: {i3m0},
+			},
+		}),
+		Entry("with machines in indexes 0, 2 and 3", tableInput{
+			cpmsBuilder:  resourcebuilder.ControlPlaneMachineSet().WithReplicas(3),
+			machineInfos: []machineproviders.MachineInfo{i0m0, i2m0, i3m0},
+			expected: map[int32][]machineproviders.MachineInfo{
+				0: {i0m0},
+				2: {i2m0},
+				3: {i3m0},
+			},
+		}),
+		Entry("with machines in indexes 2, 3 and 4", tableInput{
+			cpmsBuilder:  resourcebuilder.ControlPlaneMachineSet().WithReplicas(3),
+			machineInfos: []machineproviders.MachineInfo{i2m0, i3m0, i4m0},
+			expected: map[int32][]machineproviders.MachineInfo{
+				2: {i2m0},
+				3: {i3m0},
+				4: {i4m0},
+			},
+		}),
+		Entry("with machines in indexes 2, 3 and 4 with 5 replicas", tableInput{
+			cpmsBuilder:  resourcebuilder.ControlPlaneMachineSet().WithReplicas(5),
+			machineInfos: []machineproviders.MachineInfo{i2m0, i3m0, i4m0},
+			expected: map[int32][]machineproviders.MachineInfo{
+				0: {},
+				1: {},
+				2: {i2m0},
+				3: {i3m0},
+				4: {i4m0},
 			},
 		}),
 	)

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/mapping_test.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/mapping_test.go
@@ -803,12 +803,185 @@ var _ = Describe("Failure Domain Mapping", func() {
 					},
 				},
 			}),
+			Entry("with three failure domains matching three machines indexed from 3 (a,b,c)", mappingMachineIndexesTableInput{
+				cpmsBuilder: cpmsBuilder,
+				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
+					usEast1aFailureDomainBuilder,
+					usEast1bFailureDomainBuilder,
+					usEast1cFailureDomainBuilder,
+				).BuildFailureDomains(),
+				machines: []*machinev1beta1.Machine{
+					machineBuilder.WithName("machine-3").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-4").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-5").WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build(),
+				},
+				expectedMapping: map[int32]failuredomain.FailureDomain{
+					3: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					4: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					5: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+				},
+				expectedLogs: []test.LogEntry{
+					{
+						Level: 4,
+						KeysAndValues: []interface{}{
+							"mapping", fmt.Sprintf("%v", map[int32]failuredomain.FailureDomain{
+								3: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+								4: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+								5: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+							}),
+						},
+						Message: "Mapped provided failure domains",
+					},
+				},
+			}),
+			Entry("with three failure domains matching four machines that are not sequentially indexed (b,a,b,c)", mappingMachineIndexesTableInput{
+				cpmsBuilder: cpmsBuilder,
+				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
+					usEast1aFailureDomainBuilder,
+					usEast1bFailureDomainBuilder,
+					usEast1cFailureDomainBuilder,
+				).BuildFailureDomains(),
+				machines: []*machinev1beta1.Machine{
+					machineBuilder.WithName("machine-1").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-4").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-6").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-9").WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build(),
+				},
+				expectedMapping: map[int32]failuredomain.FailureDomain{
+					1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					4: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					6: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					9: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+				},
+				expectedLogs: []test.LogEntry{
+					{
+						Level: 4,
+						KeysAndValues: []interface{}{
+							"mapping", fmt.Sprintf("%v", map[int32]failuredomain.FailureDomain{
+								1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+								4: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+								6: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+								9: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+							}),
+						},
+						Message: "Mapped provided failure domains",
+					},
+				},
+			}),
+			Entry("with three failure domains matching five machines that are not sequentially indexed (c,a,a,b,c)", mappingMachineIndexesTableInput{
+				cpmsBuilder: cpmsBuilder,
+				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
+					usEast1aFailureDomainBuilder,
+					usEast1bFailureDomainBuilder,
+					usEast1cFailureDomainBuilder,
+				).BuildFailureDomains(),
+				machines: []*machinev1beta1.Machine{
+					machineBuilder.WithName("machine-2").WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-3").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-5").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-8").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-13").WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build(),
+				},
+				expectedMapping: map[int32]failuredomain.FailureDomain{
+					2:  failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+					3:  failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					5:  failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					8:  failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					13: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+				},
+				expectedLogs: []test.LogEntry{
+					{
+						Level: 4,
+						KeysAndValues: []interface{}{
+							"mapping", fmt.Sprintf("%v", map[int32]failuredomain.FailureDomain{
+								2:  failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+								3:  failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+								5:  failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+								8:  failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+								13: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+							}),
+						},
+						Message: "Mapped provided failure domains",
+					},
+				},
+			}),
+			Entry("with three failure domains matching five machines which duplicate indexes", mappingMachineIndexesTableInput{
+				cpmsBuilder: cpmsBuilder,
+				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
+					usEast1aFailureDomainBuilder,
+					usEast1bFailureDomainBuilder,
+					usEast1cFailureDomainBuilder,
+				).BuildFailureDomains(),
+				machines: []*machinev1beta1.Machine{
+					machineBuilder.WithName("machine-3").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-replacement-3").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-4").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-replacement-4").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-5").WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build(),
+				},
+				expectedMapping: map[int32]failuredomain.FailureDomain{
+					3: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					4: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					5: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+				},
+				expectedLogs: []test.LogEntry{
+					{
+						Level: 4,
+						KeysAndValues: []interface{}{
+							"mapping", fmt.Sprintf("%v", map[int32]failuredomain.FailureDomain{
+								3: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+								4: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+								5: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+							}),
+						},
+						Message: "Mapped provided failure domains",
+					},
+				},
+			}),
+			Entry("with three failure domains matching 7 machines which duplicate indexes", mappingMachineIndexesTableInput{
+				cpmsBuilder: cpmsBuilder,
+				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
+					usEast1aFailureDomainBuilder,
+					usEast1bFailureDomainBuilder,
+					usEast1cFailureDomainBuilder,
+				).BuildFailureDomains(),
+				machines: []*machinev1beta1.Machine{
+					machineBuilder.WithName("machine-0").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-replacement-0").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-3").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-replacement-3").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-4").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-replacement-4").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-5").WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build(),
+				},
+				expectedMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					3: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					4: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					5: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+				},
+				expectedLogs: []test.LogEntry{
+					{
+						Level: 4,
+						KeysAndValues: []interface{}{
+							"mapping", fmt.Sprintf("%v", map[int32]failuredomain.FailureDomain{
+								0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+								3: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+								4: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+								5: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+							}),
+						},
+						Message: "Mapped provided failure domains",
+					},
+				},
+			}),
 		)
 	})
 
 	Context("createBaseFailureDomainMapping", func() {
 		type createBaseMappingTableInput struct {
 			cpmsBuilder     resourcebuilder.ControlPlaneMachineSetInterface
+			machineCount    int
 			failureDomains  machinev1.FailureDomains
 			expectedMapping map[int32]failuredomain.FailureDomain
 			expectedError   error
@@ -819,7 +992,7 @@ var _ = Describe("Failure Domain Mapping", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			cpms := in.cpmsBuilder.Build()
-			mapping, err := createBaseFailureDomainMapping(cpms, failureDomains)
+			mapping, err := createBaseFailureDomainMapping(cpms, failureDomains, in.machineCount)
 			if in.expectedError != nil {
 				Expect(err).To(MatchError(in.expectedError))
 			} else {
@@ -838,7 +1011,8 @@ var _ = Describe("Failure Domain Mapping", func() {
 				expectedError: errReplicasRequired,
 			}),
 			Entry("with three replicas and three failure domains (order a,b,c)", createBaseMappingTableInput{
-				cpmsBuilder: cpmsBuilder.WithReplicas(3),
+				cpmsBuilder:  cpmsBuilder.WithReplicas(3),
+				machineCount: 3,
 				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
 					usEast1aFailureDomainBuilder,
 					usEast1bFailureDomainBuilder,
@@ -851,7 +1025,8 @@ var _ = Describe("Failure Domain Mapping", func() {
 				},
 			}),
 			Entry("with three replicas and three failure domains (order b,c,a)", createBaseMappingTableInput{
-				cpmsBuilder: cpmsBuilder.WithReplicas(3),
+				cpmsBuilder:  cpmsBuilder.WithReplicas(3),
+				machineCount: 3,
 				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
 					usEast1bFailureDomainBuilder,
 					usEast1cFailureDomainBuilder,
@@ -864,7 +1039,8 @@ var _ = Describe("Failure Domain Mapping", func() {
 				},
 			}),
 			Entry("with three replicas and three failure domains (order b,a,c)", createBaseMappingTableInput{
-				cpmsBuilder: cpmsBuilder.WithReplicas(3),
+				cpmsBuilder:  cpmsBuilder.WithReplicas(3),
+				machineCount: 3,
 				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
 					usEast1bFailureDomainBuilder,
 					usEast1aFailureDomainBuilder,
@@ -877,7 +1053,8 @@ var _ = Describe("Failure Domain Mapping", func() {
 				},
 			}),
 			Entry("with three replicas and one failure domains", createBaseMappingTableInput{
-				cpmsBuilder: cpmsBuilder.WithReplicas(3),
+				cpmsBuilder:  cpmsBuilder.WithReplicas(3),
+				machineCount: 3,
 				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
 					usEast1aFailureDomainBuilder,
 				).BuildFailureDomains(),
@@ -888,7 +1065,8 @@ var _ = Describe("Failure Domain Mapping", func() {
 				},
 			}),
 			Entry("with three replicas and two failure domains (order a,b)", createBaseMappingTableInput{
-				cpmsBuilder: cpmsBuilder.WithReplicas(3),
+				cpmsBuilder:  cpmsBuilder.WithReplicas(3),
+				machineCount: 3,
 				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
 					usEast1aFailureDomainBuilder,
 					usEast1bFailureDomainBuilder,
@@ -900,7 +1078,8 @@ var _ = Describe("Failure Domain Mapping", func() {
 				},
 			}),
 			Entry("with three replicas and two failure domains (order b,a)", createBaseMappingTableInput{
-				cpmsBuilder: cpmsBuilder.WithReplicas(3),
+				cpmsBuilder:  cpmsBuilder.WithReplicas(3),
+				machineCount: 3,
 				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
 					usEast1bFailureDomainBuilder,
 					usEast1aFailureDomainBuilder,
@@ -912,7 +1091,8 @@ var _ = Describe("Failure Domain Mapping", func() {
 				},
 			}),
 			Entry("with five replicas and three failure domains (order a,b,c)", createBaseMappingTableInput{
-				cpmsBuilder: cpmsBuilder.WithReplicas(5),
+				cpmsBuilder:  cpmsBuilder.WithReplicas(5),
+				machineCount: 5,
 				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
 					usEast1aFailureDomainBuilder,
 					usEast1bFailureDomainBuilder,
@@ -927,7 +1107,8 @@ var _ = Describe("Failure Domain Mapping", func() {
 				},
 			}),
 			Entry("with five replicas and three failure domains (order b,c,a)", createBaseMappingTableInput{
-				cpmsBuilder: cpmsBuilder.WithReplicas(5),
+				cpmsBuilder:  cpmsBuilder.WithReplicas(5),
+				machineCount: 5,
 				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
 					usEast1bFailureDomainBuilder,
 					usEast1cFailureDomainBuilder,
@@ -942,7 +1123,8 @@ var _ = Describe("Failure Domain Mapping", func() {
 				},
 			}),
 			Entry("with five replicas and two failure domains (order a,b)", createBaseMappingTableInput{
-				cpmsBuilder: cpmsBuilder.WithReplicas(5),
+				cpmsBuilder:  cpmsBuilder.WithReplicas(5),
+				machineCount: 5,
 				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
 					usEast1aFailureDomainBuilder,
 					usEast1bFailureDomainBuilder,
@@ -956,7 +1138,8 @@ var _ = Describe("Failure Domain Mapping", func() {
 				},
 			}),
 			Entry("with five replicas and two failure domains (order b,a)", createBaseMappingTableInput{
-				cpmsBuilder: cpmsBuilder.WithReplicas(5),
+				cpmsBuilder:  cpmsBuilder.WithReplicas(5),
+				machineCount: 5,
 				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
 					usEast1bFailureDomainBuilder,
 					usEast1aFailureDomainBuilder,
@@ -967,6 +1150,51 @@ var _ = Describe("Failure Domain Mapping", func() {
 					2: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
 					3: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
 					4: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+				},
+			}),
+			Entry("with three replicas but a machine count of five", createBaseMappingTableInput{
+				cpmsBuilder:  cpmsBuilder.WithReplicas(3),
+				machineCount: 5,
+				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
+					usEast1aFailureDomainBuilder,
+					usEast1bFailureDomainBuilder,
+					usEast1cFailureDomainBuilder,
+				).BuildFailureDomains(),
+				expectedMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+					3: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					4: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+				},
+			}),
+			Entry("with four replicas but a machine count of 2", createBaseMappingTableInput{
+				cpmsBuilder:  cpmsBuilder.WithReplicas(4),
+				machineCount: 2,
+				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
+					usEast1aFailureDomainBuilder,
+					usEast1bFailureDomainBuilder,
+					usEast1cFailureDomainBuilder,
+				).BuildFailureDomains(),
+				expectedMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+					3: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+				},
+			}),
+			Entry("with 3 replicas but a machine count of 1", createBaseMappingTableInput{
+				cpmsBuilder:  cpmsBuilder.WithReplicas(3),
+				machineCount: 1,
+				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
+					usEast1aFailureDomainBuilder,
+					usEast1bFailureDomainBuilder,
+					usEast1cFailureDomainBuilder,
+				).BuildFailureDomains(),
+				expectedMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
 				},
 			}),
 		)
@@ -1405,6 +1633,7 @@ var _ = Describe("Failure Domain Mapping", func() {
 					0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
 					1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
 					2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+					3: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
 				},
 				machineMapping: map[int32]failuredomain.FailureDomain{
 					0: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
@@ -1453,6 +1682,48 @@ var _ = Describe("Failure Domain Mapping", func() {
 					0: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
 					2: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
 					4: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+				},
+				expectedLogs: []test.LogEntry{},
+			}),
+			Entry("when a machines are not sequentially indexed, it keeps the ordering of the failure domains (a,b,a,c)", reconcileMappingsTableInput{
+				baseMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+					3: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+				},
+				machineMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					3: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					4: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+				},
+				expectedMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					3: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					4: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+				},
+				expectedLogs: []test.LogEntry{},
+			}),
+			Entry("when a machines are not sequentially indexed, it keeps the ordering of the failure domains (b,b,a,c)", reconcileMappingsTableInput{
+				baseMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+					3: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+				},
+				machineMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					4: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					6: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+				},
+				expectedMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					4: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					6: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
 				},
 				expectedLogs: []test.LogEntry{},
 			}),

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/provider_test.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/provider_test.go
@@ -1135,6 +1135,122 @@ var _ = Describe("MachineProvider", func() {
 					},
 				},
 			}),
+			Entry("with ready Machines that are indexed from 3", getMachineInfosTableInput{
+				machines: []*machinev1beta1.Machine{
+					masterMachineBuilder.WithName(masterMachineName("3")).WithProviderSpecBuilder(providerSpecBuilder.WithAvailabilityZone("us-east-1a").WithSubnet(usEast1aSubnetbeta1)).
+						WithPhase("Running").WithNodeRef(corev1.ObjectReference{Name: "node-3"}).Build(),
+					masterMachineBuilder.WithName(masterMachineName("4")).WithProviderSpecBuilder(providerSpecBuilder.WithAvailabilityZone("us-east-1b").WithSubnet(usEast1bSubnetbeta1)).
+						WithPhase("Running").WithNodeRef(corev1.ObjectReference{Name: "node-4"}).Build(),
+					masterMachineBuilder.WithName(masterMachineName("5")).WithProviderSpecBuilder(providerSpecBuilder.WithAvailabilityZone("us-east-1c").WithSubnet(usEast1cSubnetbeta1)).
+						WithPhase("Running").WithNodeRef(corev1.ObjectReference{Name: "node-5"}).Build(),
+				},
+				failureDomains: map[int32]failuredomain.FailureDomain{
+					3: failuredomain.NewAWSFailureDomain(resourcebuilder.AWSFailureDomain().WithAvailabilityZone("us-east-1a").WithSubnet(usEast1aSubnet).Build()),
+					4: failuredomain.NewAWSFailureDomain(resourcebuilder.AWSFailureDomain().WithAvailabilityZone("us-east-1b").WithSubnet(usEast1bSubnet).Build()),
+					5: failuredomain.NewAWSFailureDomain(resourcebuilder.AWSFailureDomain().WithAvailabilityZone("us-east-1c").WithSubnet(usEast1cSubnet).Build()),
+				},
+				expectedMachineInfos: []machineproviders.MachineInfo{
+					readyMachineInfoBuilder.WithIndex(3).WithMachineName(masterMachineName("3")).WithNodeName("node-3").Build(),
+					readyMachineInfoBuilder.WithIndex(4).WithMachineName(masterMachineName("4")).WithNodeName("node-4").Build(),
+					readyMachineInfoBuilder.WithIndex(5).WithMachineName(masterMachineName("5")).WithNodeName("node-5").Build(),
+				},
+				expectedLogs: []test.LogEntry{
+					{
+						Level: 4,
+						KeysAndValues: []interface{}{
+							"machineName", masterMachineName("3"),
+							"nodeName", "node-3",
+							"index", int32(3),
+							"ready", true,
+							"needsUpdate", false,
+							"errorMessage", "",
+						},
+						Message: "Gathered Machine Info",
+					},
+					{
+						Level: 4,
+						KeysAndValues: []interface{}{
+							"machineName", masterMachineName("4"),
+							"nodeName", "node-4",
+							"index", int32(4),
+							"ready", true,
+							"needsUpdate", false,
+							"errorMessage", "",
+						},
+						Message: "Gathered Machine Info",
+					},
+					{
+						Level: 4,
+						KeysAndValues: []interface{}{
+							"machineName", masterMachineName("5"),
+							"nodeName", "node-5",
+							"index", int32(5),
+							"ready", true,
+							"needsUpdate", false,
+							"errorMessage", "",
+						},
+						Message: "Gathered Machine Info",
+					},
+				},
+			}),
+			Entry("with ready Machines that are not sequntially indexed", getMachineInfosTableInput{
+				machines: []*machinev1beta1.Machine{
+					masterMachineBuilder.WithName(masterMachineName("0")).WithProviderSpecBuilder(providerSpecBuilder.WithAvailabilityZone("us-east-1a").WithSubnet(usEast1aSubnetbeta1)).
+						WithPhase("Running").WithNodeRef(corev1.ObjectReference{Name: "node-0"}).Build(),
+					masterMachineBuilder.WithName(masterMachineName("2")).WithProviderSpecBuilder(providerSpecBuilder.WithAvailabilityZone("us-east-1b").WithSubnet(usEast1bSubnetbeta1)).
+						WithPhase("Running").WithNodeRef(corev1.ObjectReference{Name: "node-2"}).Build(),
+					masterMachineBuilder.WithName(masterMachineName("4")).WithProviderSpecBuilder(providerSpecBuilder.WithAvailabilityZone("us-east-1c").WithSubnet(usEast1cSubnetbeta1)).
+						WithPhase("Running").WithNodeRef(corev1.ObjectReference{Name: "node-4"}).Build(),
+				},
+				failureDomains: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(resourcebuilder.AWSFailureDomain().WithAvailabilityZone("us-east-1a").WithSubnet(usEast1aSubnet).Build()),
+					2: failuredomain.NewAWSFailureDomain(resourcebuilder.AWSFailureDomain().WithAvailabilityZone("us-east-1b").WithSubnet(usEast1bSubnet).Build()),
+					4: failuredomain.NewAWSFailureDomain(resourcebuilder.AWSFailureDomain().WithAvailabilityZone("us-east-1c").WithSubnet(usEast1cSubnet).Build()),
+				},
+				expectedMachineInfos: []machineproviders.MachineInfo{
+					readyMachineInfoBuilder.WithIndex(0).WithMachineName(masterMachineName("0")).WithNodeName("node-0").Build(),
+					readyMachineInfoBuilder.WithIndex(2).WithMachineName(masterMachineName("2")).WithNodeName("node-2").Build(),
+					readyMachineInfoBuilder.WithIndex(4).WithMachineName(masterMachineName("4")).WithNodeName("node-4").Build(),
+				},
+				expectedLogs: []test.LogEntry{
+					{
+						Level: 4,
+						KeysAndValues: []interface{}{
+							"machineName", masterMachineName("0"),
+							"nodeName", "node-0",
+							"index", int32(0),
+							"ready", true,
+							"needsUpdate", false,
+							"errorMessage", "",
+						},
+						Message: "Gathered Machine Info",
+					},
+					{
+						Level: 4,
+						KeysAndValues: []interface{}{
+							"machineName", masterMachineName("2"),
+							"nodeName", "node-2",
+							"index", int32(2),
+							"ready", true,
+							"needsUpdate", false,
+							"errorMessage", "",
+						},
+						Message: "Gathered Machine Info",
+					},
+					{
+						Level: 4,
+						KeysAndValues: []interface{}{
+							"machineName", masterMachineName("4"),
+							"nodeName", "node-4",
+							"index", int32(4),
+							"ready", true,
+							"needsUpdate", false,
+							"errorMessage", "",
+						},
+						Message: "Gathered Machine Info",
+					},
+				},
+			}),
 		)
 	})
 


### PR DESCRIPTION
We expect over time that cluster may have renamed their control plane machines, for example rather than being 0, 1, 2, they may now be , 3, 4, 5 or even 2, 4, 6. Previously the CPMS was not handling this and would degrade if it ever saw non 0, 1, 2 indexes.

This PR updates the logic and adds a number of tests to ensure that the entire controller supports these topologies:
* Tests added for full integration checking that the status is set correctly when observing a machine state with various indexes
* Fixed the machineInfosByIndex so that it only adds empty indexes when there aren't the expected number
* Fixed machine provider so that it maps the indexes based on the preferred indexes gathered from the Machines
* Added tests for various parts of the machine provider to check it works as expected

Have then manually tested this on a cluster and can confirm it now is working as we would expect.