### PR TITLE
OCPCLOUD-1675: Add support for generic platforms without failure domains

### DIFF
--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/failuredomain/failuredomain.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/failuredomain/failuredomain.go
@@ -82,7 +82,7 @@ func (f failureDomain) String() string {
 	case configv1.GCPPlatformType:
 		return gcpFailureDomainToString(f.gcp)
 	default:
-		return unknownFailureDomain
+		return fmt.Sprintf("%sFailureDomain{}", f.platformType)
 	}
 }
 
@@ -125,7 +125,7 @@ func (f failureDomain) Equal(other FailureDomain) bool {
 		return f.gcp == other.GCP()
 	}
 
-	return false
+	return true
 }
 
 // NewFailureDomains creates a set of FailureDomains representing the input failure
@@ -212,6 +212,11 @@ func NewGCPFailureDomain(fd machinev1.GCPFailureDomain) FailureDomain {
 		platformType: configv1.GCPPlatformType,
 		gcp:          fd,
 	}
+}
+
+// NewGenericFailureDomain creates a dummy failure domain for generic platforms that don't support failure domains.
+func NewGenericFailureDomain() FailureDomain {
+	return failureDomain{}
 }
 
 // azString formats AvailabilityZone for awsFailureDomainToString function.

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/generic_platform.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/generic_platform.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package providerconfig
+
+import (
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/cluster-control-plane-machine-set-operator/pkg/machineproviders/providers/openshift/machine/v1beta1/failuredomain"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// GenericProviderConfig holds the provider spec for machine on platforms that
+// don't support failure domains and can be handled generically.
+type GenericProviderConfig struct {
+	// We don't know the exact type of the providerSpec, but we need to store it to be able to tell if two specs are identical.
+	providerSpec *runtime.RawExtension
+}
+
+// ExtractFailureDomain extract generic failure domain that contains just the platform type.
+func (g GenericProviderConfig) ExtractFailureDomain() failuredomain.FailureDomain {
+	return failuredomain.NewGenericFailureDomain()
+}
+
+// newGenericProviderConfig creates a generic ProviderConfig that can contain providerSpec for any platform.
+func newGenericProviderConfig(providerSpec *runtime.RawExtension, platform configv1.PlatformType) (ProviderConfig, error) {
+	config := providerConfig{
+		platformType: platform,
+		generic: GenericProviderConfig{
+			providerSpec: providerSpec,
+		},
+	}
+
+	return config, nil
+}

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/providerconfig_test.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/providerconfig_test.go
@@ -17,9 +17,6 @@ limitations under the License.
 package providerconfig
 
 import (
-	"encoding/json"
-	"fmt"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
@@ -68,12 +65,12 @@ var _ = Describe("Provider Config", func() {
 			Expect(providerConfig.Type()).To(Equal(in.expectedPlatformType))
 			Expect(providerConfig).To(in.providerConfigMatcher)
 		},
-			Entry("with an invalid platform type", providerConfigTableInput{
+			Entry("with missing provider spec on unknown platform type", providerConfigTableInput{
 				modifyTemplate: func(in *machinev1.ControlPlaneMachineSetTemplate) {
 					// The platform type should be inferred from here first.
-					in.OpenShiftMachineV1Beta1Machine.FailureDomains.Platform = configv1.PlatformType("invalid")
+					in.OpenShiftMachineV1Beta1Machine.FailureDomains.Platform = configv1.PlatformType("unknown")
 				},
-				expectedError: fmt.Errorf("%w: %s", errUnsupportedPlatformType, "invalid"),
+				expectedError: errNilProviderSpec,
 			}),
 			Entry("with an AWS config with failure domains", providerConfigTableInput{
 				expectedPlatformType:  configv1.AWSPlatformType,
@@ -266,18 +263,12 @@ var _ = Describe("Provider Config", func() {
 			Expect(providerConfig.Type()).To(Equal(in.expectedPlatformType))
 			Expect(providerConfig).To(in.providerConfigMatcher)
 		},
-			Entry("with an invalid platform type", providerConfigTableInput{
+			Entry("with nil provider spec", providerConfigTableInput{
 				modifyMachine: func(in *machinev1beta1.Machine) {
-					var awsProviderConfig machinev1beta1.AWSMachineProviderConfig
-					err := json.Unmarshal(in.Spec.ProviderSpec.Value.Raw, &awsProviderConfig)
-					Expect(err).To(BeNil())
-
-					awsProviderConfig.TypeMeta.Kind = "InvalidProviderSpecKind"
-					in.Spec.ProviderSpec.Value.Raw, err = json.Marshal(awsProviderConfig)
-					Expect(err).To(BeNil())
+					in.Spec.ProviderSpec.Value = nil
 				},
 				providerSpecBuilder: resourcebuilder.AWSProviderSpec(),
-				expectedError:       fmt.Errorf("could not determine platform type: %w", fmt.Errorf("%w: %s", errUnknownProviderConfigType, "InvalidProviderSpecKind")),
+				expectedError:       errNilProviderSpec,
 			}),
 			Entry("with an AWS config with failure domains", providerConfigTableInput{
 				expectedPlatformType:  configv1.AWSPlatformType,
@@ -409,6 +400,15 @@ var _ = Describe("Provider Config", func() {
 					resourcebuilder.GCPFailureDomain().WithZone("us-central1-a").Build(),
 				),
 			}),
+			Entry("with a VSphere dummy failure domain", extractFailureDomainTableInput{
+				providerConfig: &providerConfig{
+					platformType: configv1.VSpherePlatformType,
+					generic: GenericProviderConfig{
+						providerSpec: resourcebuilder.VSphereProviderSpec().BuildRawExtension(),
+					},
+				},
+				expectedFailureDomain: failuredomain.NewGenericFailureDomain(),
+			}),
 		)
 	})
 
@@ -538,6 +538,52 @@ var _ = Describe("Provider Config", func() {
 				},
 				expectedEqual: false,
 			}),
+			Entry("with matching Generic configs", equalTableInput{
+				basePC: &providerConfig{
+					platformType: configv1.VSpherePlatformType,
+					generic: GenericProviderConfig{
+						providerSpec: resourcebuilder.VSphereProviderSpec().BuildRawExtension(),
+					},
+				},
+				comparePC: &providerConfig{
+					platformType: configv1.VSpherePlatformType,
+					generic: GenericProviderConfig{
+						providerSpec: resourcebuilder.VSphereProviderSpec().BuildRawExtension(),
+					},
+				},
+				expectedEqual: true,
+			}),
+			Entry("with mis-matched spec using Generic configs", equalTableInput{
+				basePC: &providerConfig{
+					platformType: configv1.VSpherePlatformType,
+					generic: GenericProviderConfig{
+						providerSpec: resourcebuilder.VSphereProviderSpec().BuildRawExtension(),
+					},
+				},
+				comparePC: &providerConfig{
+					platformType: configv1.VSpherePlatformType,
+					generic: GenericProviderConfig{
+						providerSpec: resourcebuilder.VSphereProviderSpec().WithTemplate("different-template").BuildRawExtension(),
+					},
+				},
+				expectedEqual: false,
+			}),
+			Entry("with mis-matched platform type using Generic configs", equalTableInput{
+				basePC: &providerConfig{
+					platformType: configv1.BareMetalPlatformType,
+					generic: GenericProviderConfig{
+						providerSpec: resourcebuilder.VSphereProviderSpec().BuildRawExtension(),
+					},
+				},
+				comparePC: &providerConfig{
+					platformType: configv1.VSpherePlatformType,
+					generic: GenericProviderConfig{
+						providerSpec: resourcebuilder.VSphereProviderSpec().BuildRawExtension(),
+					},
+				},
+				expectedEqual: false,
+				expectedError: errMismatchedPlatformTypes,
+			}),
 		)
 	})
 
@@ -585,6 +631,15 @@ var _ = Describe("Provider Config", func() {
 					},
 				},
 				expectedOut: resourcebuilder.GCPProviderSpec().BuildRawExtension().Raw,
+			}),
+			Entry("with a VSphere config", rawConfigTableInput{
+				providerConfig: providerConfig{
+					platformType: configv1.VSpherePlatformType,
+					generic: GenericProviderConfig{
+						providerSpec: resourcebuilder.VSphereProviderSpec().BuildRawExtension(),
+					},
+				},
+				expectedOut: resourcebuilder.VSphereProviderSpec().BuildRawExtension().Raw,
 			}),
 		)
 	})

--- a/pkg/test/resourcebuilder/vsphere_provider_spec.go
+++ b/pkg/test/resourcebuilder/vsphere_provider_spec.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcebuilder
+
+import (
+	"encoding/json"
+
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// VSphereProviderSpec creates a new VSphere machine config builder.
+func VSphereProviderSpec() VSphereProviderSpecBuilder {
+	return VSphereProviderSpecBuilder{
+		template: "test-ln-xw89i22-c1627-rvtrn-rhcos",
+	}
+}
+
+// VSphereProviderSpecBuilder is used to build out a VSphere machine config object.
+type VSphereProviderSpecBuilder struct {
+	template string
+}
+
+// Build builds a new VSphere machine config based on the configuration provided.
+func (v VSphereProviderSpecBuilder) Build() *machinev1beta1.VSphereMachineProviderSpec {
+	return &machinev1beta1.VSphereMachineProviderSpec{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "VSphereMachineProviderSpec",
+			APIVersion: "machine.openshift.io/v1beta1",
+		},
+		NumCoresPerSocket: 4,
+		DiskGiB:           120,
+		UserDataSecret: &v1.LocalObjectReference{
+			Name: "master-user-data",
+		},
+		MemoryMiB: 16384,
+		CredentialsSecret: &v1.LocalObjectReference{
+			Name: "vsphere-cloud-credentials",
+		},
+		Network: machinev1beta1.NetworkSpec{
+			Devices: []machinev1beta1.NetworkDeviceSpec{
+				{
+					NetworkName: "test-segment-01",
+				},
+			},
+		},
+		NumCPUs:  4,
+		Template: v.template,
+	}
+}
+
+// BuildRawExtension builds a new VSphere machine config based on the configuration provided.
+func (v VSphereProviderSpecBuilder) BuildRawExtension() *runtime.RawExtension {
+	providerConfig := v.Build()
+
+	raw, err := json.Marshal(providerConfig)
+	if err != nil {
+		// As we are building the input to json.Marshal, this should never happen.
+		panic(err)
+	}
+
+	return &runtime.RawExtension{
+		Raw: raw,
+	}
+}
+
+// WithTemplate sets the template for the VSphere machine config builder.
+func (v VSphereProviderSpecBuilder) WithTemplate(template string) VSphereProviderSpecBuilder {
+	v.template = template
+	return v
+}


### PR DESCRIPTION
This PR allows CPMS to manage control plane machines on all platforms that do not require modification of machine spec for failure domains. 
It does so by creating a generic provider config that contains the spec as RawExtension to allow us to compare machine spec to template spec. 
I've also added resourcebuilder for VSphere for use in test as an example of platform without failure domains.