### PR TITLE
OCPBUGS-1348: Fix machine not being marked as deleting

### DIFF
--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/mapping.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/mapping.go
@@ -29,7 +29,6 @@ import (
 	machinev1 "github.com/openshift/api/machine/v1"
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
 
 	"github.com/openshift/cluster-control-plane-machine-set-operator/pkg/machineproviders/providers/openshift/machine/v1beta1/failuredomain"
 	"github.com/openshift/cluster-control-plane-machine-set-operator/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig"
@@ -129,9 +128,9 @@ func mapIndexesToFailureDomainsForMachines(logger logr.Logger, machineList *mach
 	indexToMachine := make(map[int32]machinev1beta1.Machine)
 
 	for _, machine := range machineList.Items {
-		// When the machine is in deleting phase,
+		// When the machine is being deleted,
 		// we should not take it into account when calculating where to place the new machine.
-		if pointer.StringDeref(machine.Status.Phase, "") == "Deleting" {
+		if machine.DeletionTimestamp != nil {
 			continue
 		}
 


### PR DESCRIPTION
In my previous attempt to fix [OCPBUGS-1348](https://issues.redhat.com/browse/OCPBUGS-1348), I relied on the machine having phase set to "Deleting". For this to be set, it requires the machine to be reconciled by MAO. Unfortunately, CPMS can get the machine before it is reconciled into deleting phase.
 I have changed the code to use DeletionTimestamp. It is set by the apiserver when it processes the deletion, so it should be reliably set when CPMS sees the deletion.