### PR TITLE
OCPBUGS-2446: Expose an error condition if an error is repeated more than 15 times in a row

### DIFF
--- a/pkg/controllers/controlplanemachineset/cluster_operator.go
+++ b/pkg/controllers/controlplanemachineset/cluster_operator.go
@@ -59,12 +59,16 @@ func (r *ControlPlaneMachineSetReconciler) updateClusterOperatorStatus(ctx conte
 
 	// Copying status conditions from control plane machine set to cluster operator
 	conds := []configv1.ClusterOperatorStatusCondition{}
+
 	for _, c := range cpms.Status.Conditions {
-		conds = append(conds, newClusterOperatorStatusCondition(
-			configv1.ClusterStatusConditionType(c.Type),
-			configv1.ConditionStatus(c.Status),
-			c.Reason,
-			c.Message))
+		switch c.Type {
+		case conditionAvailable, conditionDegraded, conditionProgressing:
+			conds = append(conds, newClusterOperatorStatusCondition(
+				configv1.ClusterStatusConditionType(c.Type),
+				configv1.ConditionStatus(c.Status),
+				c.Reason,
+				c.Message))
+		}
 	}
 
 	// Define upgradable condition

--- a/pkg/controllers/controlplanemachineset/consts.go
+++ b/pkg/controllers/controlplanemachineset/consts.go
@@ -43,6 +43,12 @@ const (
 	// detail with a reason and appropriate message.
 	conditionDegraded = "Degraded"
 
+	// conditionError is used to denote when the ControlPlaneMachineSet is repeatedly
+	// unable to operate in the manner expected of it. For example, if there are issues
+	// creating machines that are persisting over time, the operator should set this
+	// condition to true and add detail with a reason and appropriate message.
+	conditionError = "Error"
+
 	// conditionProgressing is used to denote when the ControlPlaneMachineSet is
 	// going through the process of making updates to the Machines within its
 	// management. Typically this condition is expected to be false.
@@ -110,6 +116,14 @@ const (
 	reasonExcessIndexes = "ExcessIndexes"
 
 	// END: Degraded reasons.
+
+	// BEGIN: Error reasons.
+
+	// reasonContinuousErrors denotes that the ControlPlaneMachineSet has encountered a
+	// specific error repeatedly over time.
+	reasonContinuousErrors = "ContinuousErrors"
+
+	// END: Error reasons.
 
 	// BEGIN: Progressing reasons.
 

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/provider.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/provider.go
@@ -410,7 +410,7 @@ func (m *openshiftMachineProvider) CreateMachine(ctx context.Context, logger log
 			"version", machinev1beta1.GroupVersion.Version,
 		)
 
-		return fmt.Errorf("cannot create machine %s in namespace %s: %w", machine.Name, machine.Namespace, err)
+		return fmt.Errorf("cannot create machine: %w", err)
 	}
 
 	logger.V(2).Info(


### PR DESCRIPTION
In an effort to improve the observability of errors, this PR sets an error condition on the CPMS status when the reconciler returns an identical error 15 times or more in a row. This happens after approximately 80s since the error first occurs.

This should help reveal spurious errors such as those like when we cannot create a machine because the validation webhooks are failing.

I've manually tested this and it seems to be working as expected.