### PR TITLE
OCPBUGS-2340: Ensure OnDelete strategy can handle non-standard indexes

### DIFF
--- a/pkg/controllers/controlplanemachineset/controller_test.go
+++ b/pkg/controllers/controlplanemachineset/controller_test.go
@@ -195,7 +195,7 @@ var _ = Describe("With a running controller", func() {
 		)
 	})
 
-	Context("when a new Control Plane Machine Set is created", func() {
+	Context("when a new Control Plane Machine Set is created with a RollingUpdate strategy", func() {
 		var cpms *machinev1.ControlPlaneMachineSet
 
 		// Create the CPMS just before each test so that we can set up
@@ -396,6 +396,329 @@ var _ = Describe("With a running controller", func() {
 
 			It("should create a replacement for the machine", func() {
 				Eventually(komega.ObjectList(&machinev1beta1.MachineList{})).Should(HaveField("Items", HaveLen(4)))
+			})
+		})
+
+		Context("with no running machines", func() {
+			BeforeEach(func() {
+				By("Creating Machines owned by the ControlPlaneMachineSet")
+				machineBuilder := resourcebuilder.Machine().AsMaster().WithGenerateName("state-test-").WithNamespace(namespaceName)
+
+				Expect(k8sClient.Create(ctx, machineBuilder.WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build())).To(Succeed())
+				Expect(k8sClient.Create(ctx, machineBuilder.WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build())).To(Succeed())
+				Expect(k8sClient.Create(ctx, machineBuilder.WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build())).To(Succeed())
+			})
+
+			It("should update the status", func() {
+				Eventually(komega.Object(cpms)).Should(HaveField("Status", SatisfyAll(
+					HaveField("ObservedGeneration", Equal(int64(1))),
+					HaveField("Replicas", Equal(int32(3))),
+					HaveField("ReadyReplicas", Equal(int32(0))),
+					HaveField("UpdatedReplicas", Equal(int32(0))),
+					HaveField("UnavailableReplicas", Equal(int32(3))),
+				)))
+			})
+
+			It("should not add owner references", func() {
+				Consistently(komega.ObjectList(&machinev1beta1.MachineList{})).Should(HaveField("Items", Not(ContainElement(HaveField("ObjectMeta.OwnerReferences", Not(BeEmpty()))))), "No machine should have an owner reference")
+			})
+
+			It("should be degraded", func() {
+				degradedCondition := resourcebuilder.StatusCondition().
+					WithType(conditionDegraded).
+					WithStatus(metav1.ConditionTrue).
+					WithReason(reasonNoReadyMachines).
+					WithMessage("No ready control plane machines found").
+					Build()
+
+				Eventually(komega.Object(cpms)).Should(HaveField("Status.Conditions", ContainElement(test.MatchCondition(degradedCondition))))
+			})
+
+			It("should mark the cluster operator as degraded", func() {
+				Eventually(komega.Object(co)).Should(HaveField("Status.Conditions", test.MatchClusterOperatorStatusConditions([]configv1.ClusterOperatorStatusCondition{
+					{
+						Type:    configv1.OperatorAvailable,
+						Status:  configv1.ConditionFalse,
+						Reason:  reasonUnavailableReplicas,
+						Message: "Missing 3 available replica(s)",
+					},
+					{
+						Type:   configv1.OperatorProgressing,
+						Status: configv1.ConditionFalse,
+						Reason: reasonOperatorDegraded,
+					},
+					{
+						Type:    configv1.OperatorDegraded,
+						Status:  configv1.ConditionTrue,
+						Reason:  reasonNoReadyMachines,
+						Message: "No ready control plane machines found",
+					},
+					{
+						Type:    configv1.OperatorUpgradeable,
+						Status:  configv1.ConditionFalse,
+						Reason:  reasonAsExpected,
+						Message: "cluster operator is not upgradable",
+					},
+				})))
+			})
+		})
+	})
+
+	Context("when a new Control Plane Machine Set is created with an OnDelete strategy", func() {
+		var cpms *machinev1.ControlPlaneMachineSet
+
+		// Create the CPMS just before each test so that we can set up
+		// various test cases in BeforeEach blocks.
+		JustBeforeEach(func() {
+			// The default CPMS should be sufficient for this test.
+			cpms = resourcebuilder.ControlPlaneMachineSet().WithNamespace(namespaceName).WithStrategyType(machinev1.OnDelete).WithMachineTemplateBuilder(tmplBuilder).Build()
+
+			Expect(k8sClient.Create(ctx, cpms)).Should(Succeed())
+		})
+
+		It("should add the controlplanemachineset.machine.openshift.io finalizer", func() {
+			Eventually(komega.Object(cpms)).Should(HaveField("ObjectMeta.Finalizers", ContainElement(controlPlaneMachineSetFinalizer)))
+		})
+
+		Context("with updated and running machines", func() {
+			BeforeEach(func() {
+				By("Creating Machines owned by the ControlPlaneMachineSet")
+				machineBuilder := resourcebuilder.Machine().AsMaster().WithGenerateName("state-test-").WithNamespace(namespaceName)
+
+				Expect(k8sClient.Create(ctx, machineBuilder.WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build())).To(Succeed())
+				Expect(k8sClient.Create(ctx, machineBuilder.WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build())).To(Succeed())
+				Expect(k8sClient.Create(ctx, machineBuilder.WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build())).To(Succeed())
+
+				By("Ensuring Machines are Running")
+				machines := &machinev1beta1.MachineList{}
+				Expect(k8sClient.List(ctx, machines)).To(Succeed())
+
+				for _, machine := range machines.Items {
+					m := machine.DeepCopy()
+
+					Eventually(komega.UpdateStatus(m, func() {
+						m.Status.Phase = &running
+					})).Should(Succeed())
+				}
+			})
+
+			It("should update the status", func() {
+				Eventually(komega.Object(cpms)).Should(HaveField("Status", SatisfyAll(
+					HaveField("ObservedGeneration", Equal(int64(1))),
+					HaveField("Replicas", Equal(int32(3))),
+					HaveField("ReadyReplicas", Equal(int32(3))),
+					HaveField("UpdatedReplicas", Equal(int32(3))),
+					HaveField("UnavailableReplicas", Equal(int32(0))),
+				)))
+			})
+
+			It("should add an owner reference to each machine", func() {
+				Eventually(komega.ObjectList(&machinev1beta1.MachineList{})).Should(HaveField("Items", Not(ContainElement(HaveField("ObjectMeta.OwnerReferences", BeEmpty())))), "No machine should not have an owner reference")
+			})
+		})
+
+		Context("with machines indexed 0, 1, 2", func() {
+			BeforeEach(func() {
+				By("Creating Machines owned by the ControlPlaneMachineSet")
+				machineBuilder := resourcebuilder.Machine().AsMaster().WithNamespace(namespaceName)
+
+				Expect(k8sClient.Create(ctx, machineBuilder.WithName("master-0").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build())).To(Succeed())
+				Expect(k8sClient.Create(ctx, machineBuilder.WithName("master-1").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build())).To(Succeed())
+				Expect(k8sClient.Create(ctx, machineBuilder.WithName("master-2").WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build())).To(Succeed())
+
+				By("Ensuring Machines are Running")
+				machines := &machinev1beta1.MachineList{}
+				Expect(k8sClient.List(ctx, machines)).To(Succeed())
+
+				for _, machine := range machines.Items {
+					m := machine.DeepCopy()
+
+					Eventually(komega.UpdateStatus(m, func() {
+						m.Status.Phase = &running
+					})).Should(Succeed())
+				}
+			})
+
+			It("should update the status", func() {
+				Eventually(komega.Object(cpms)).Should(HaveField("Status", SatisfyAll(
+					HaveField("ObservedGeneration", Equal(int64(1))),
+					HaveField("Replicas", Equal(int32(3))),
+					HaveField("ReadyReplicas", Equal(int32(3))),
+					HaveField("UpdatedReplicas", Equal(int32(3))),
+					HaveField("UnavailableReplicas", Equal(int32(0))),
+				)))
+			})
+
+			It("should add an owner reference to each machine", func() {
+				Eventually(komega.ObjectList(&machinev1beta1.MachineList{})).Should(HaveField("Items", Not(ContainElement(HaveField("ObjectMeta.OwnerReferences", BeEmpty())))), "No machine should not have an owner reference")
+			})
+		})
+
+		Context("with machines indexed 4, 0, 2", func() {
+			BeforeEach(func() {
+				By("Creating Machines owned by the ControlPlaneMachineSet")
+				machineBuilder := resourcebuilder.Machine().AsMaster().WithNamespace(namespaceName)
+
+				Expect(k8sClient.Create(ctx, machineBuilder.WithName("master-4").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build())).To(Succeed())
+				Expect(k8sClient.Create(ctx, machineBuilder.WithName("master-0").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build())).To(Succeed())
+				Expect(k8sClient.Create(ctx, machineBuilder.WithName("master-2").WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build())).To(Succeed())
+
+				By("Ensuring Machines are Running")
+				machines := &machinev1beta1.MachineList{}
+				Expect(k8sClient.List(ctx, machines)).To(Succeed())
+
+				for _, machine := range machines.Items {
+					m := machine.DeepCopy()
+
+					Eventually(komega.UpdateStatus(m, func() {
+						m.Status.Phase = &running
+					})).Should(Succeed())
+				}
+			})
+
+			It("should update the status", func() {
+				Eventually(komega.Object(cpms)).Should(HaveField("Status", SatisfyAll(
+					HaveField("ObservedGeneration", Equal(int64(1))),
+					HaveField("Replicas", Equal(int32(3))),
+					HaveField("ReadyReplicas", Equal(int32(3))),
+					HaveField("UpdatedReplicas", Equal(int32(3))),
+					HaveField("UnavailableReplicas", Equal(int32(0))),
+				)))
+			})
+
+			It("should add an owner reference to each machine", func() {
+				Eventually(komega.ObjectList(&machinev1beta1.MachineList{})).Should(HaveField("Items", Not(ContainElement(HaveField("ObjectMeta.OwnerReferences", BeEmpty())))), "No machine should not have an owner reference")
+			})
+		})
+
+		Context("with machines indexed 3, 4, 5", func() {
+			var toDeleteMachine *machinev1beta1.Machine
+
+			BeforeEach(func() {
+				By("Creating Machines owned by the ControlPlaneMachineSet")
+				machineBuilder := resourcebuilder.Machine().AsMaster().WithNamespace(namespaceName)
+
+				Expect(k8sClient.Create(ctx, machineBuilder.WithName("master-3").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build())).To(Succeed())
+
+				toDeleteMachine = machineBuilder.WithName("master-4").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build()
+				Expect(k8sClient.Create(ctx, toDeleteMachine)).To(Succeed())
+				Expect(k8sClient.Create(ctx, machineBuilder.WithName("master-5").WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build())).To(Succeed())
+
+				By("Ensuring Machines are Running")
+				machines := &machinev1beta1.MachineList{}
+				Expect(k8sClient.List(ctx, machines)).To(Succeed())
+
+				for _, machine := range machines.Items {
+					m := machine.DeepCopy()
+
+					Eventually(komega.UpdateStatus(m, func() {
+						m.Status.Phase = &running
+					})).Should(Succeed())
+				}
+			})
+
+			It("should update the status", func() {
+				Eventually(komega.Object(cpms)).Should(HaveField("Status", SatisfyAll(
+					HaveField("ObservedGeneration", Equal(int64(1))),
+					HaveField("Replicas", Equal(int32(3))),
+					HaveField("ReadyReplicas", Equal(int32(3))),
+					HaveField("UpdatedReplicas", Equal(int32(3))),
+					HaveField("UnavailableReplicas", Equal(int32(0))),
+				)))
+			})
+
+			It("should add an owner reference to each machine", func() {
+				Eventually(komega.ObjectList(&machinev1beta1.MachineList{})).Should(HaveField("Items", Not(ContainElement(HaveField("ObjectMeta.OwnerReferences", BeEmpty())))), "No machine should not have an owner reference")
+			})
+
+			Context("and a machine is deleted", func() {
+				BeforeEach(func() {
+					Eventually(komega.Update(toDeleteMachine, func() {
+						toDeleteMachine.SetFinalizers([]string{"machine.openshift.io/machine"})
+					})).Should(Succeed())
+
+					Expect(k8sClient.Delete(ctx, toDeleteMachine)).To(Succeed())
+				})
+
+				It("should create a replacement for the machine", func() {
+					Eventually(komega.ObjectList(&machinev1beta1.MachineList{})).Should(HaveField("Items", HaveLen(4)))
+				})
+
+				It("should update the status", func() {
+					Eventually(komega.Object(cpms)).Should(HaveField("Status", SatisfyAll(
+						HaveField("ObservedGeneration", Equal(int64(1))),
+						HaveField("Replicas", Equal(int32(4))), // Replicas should be 4 once an updated replica is created.
+						HaveField("ReadyReplicas", Equal(int32(3))),
+						HaveField("UpdatedReplicas", Equal(int32(3))),
+					)))
+				})
+			})
+		})
+
+		Context("with a machine needing an update", func() {
+			var differentMachine *machinev1beta1.Machine
+
+			BeforeEach(func() {
+				By("Creating Machines owned by the ControlPlaneMachineSet")
+				machineBuilder := resourcebuilder.Machine().AsMaster().WithGenerateName("state-test-").WithNamespace(namespaceName)
+
+				differentMachine = machineBuilder.WithProviderSpecBuilder(usEast1aProviderSpecBuilder.WithInstanceType("different")).Build()
+				Expect(k8sClient.Create(ctx, differentMachine)).To(Succeed())
+
+				Expect(k8sClient.Create(ctx, machineBuilder.WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build())).To(Succeed())
+				Expect(k8sClient.Create(ctx, machineBuilder.WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build())).To(Succeed())
+
+				By("Ensuring Machines are Running")
+				machines := &machinev1beta1.MachineList{}
+				Expect(k8sClient.List(ctx, machines)).To(Succeed())
+
+				for _, machine := range machines.Items {
+					m := machine.DeepCopy()
+
+					Eventually(komega.UpdateStatus(m, func() {
+						m.Status.Phase = &running
+					})).Should(Succeed())
+				}
+			})
+
+			It("should update the status", func() {
+				Eventually(komega.Object(cpms)).Should(HaveField("Status", SatisfyAll(
+					HaveField("ObservedGeneration", Equal(int64(1))),
+					HaveField("Replicas", Equal(int32(3))),
+					HaveField("ReadyReplicas", Equal(int32(3))),
+					HaveField("UpdatedReplicas", Equal(int32(2))),
+				)))
+			})
+
+			It("should add an owner reference to each machine", func() {
+				Eventually(komega.ObjectList(&machinev1beta1.MachineList{})).Should(HaveField("Items", Not(ContainElement(HaveField("ObjectMeta.OwnerReferences", BeEmpty())))), "No machine should not have an owner reference")
+			})
+
+			It("should not create a replacement for the machine", func() {
+				Consistently(komega.ObjectList(&machinev1beta1.MachineList{})).Should(HaveField("Items", HaveLen(3)))
+			})
+
+			Context("and the machine is deleted", func() {
+				BeforeEach(func() {
+					Eventually(komega.Update(differentMachine, func() {
+						differentMachine.SetFinalizers([]string{"machine.openshift.io/machine"})
+					})).Should(Succeed())
+
+					Expect(k8sClient.Delete(ctx, differentMachine)).To(Succeed())
+				})
+
+				It("should create a replacement for the machine", func() {
+					Eventually(komega.ObjectList(&machinev1beta1.MachineList{})).Should(HaveField("Items", HaveLen(4)))
+				})
+
+				It("should update the status", func() {
+					Eventually(komega.Object(cpms)).Should(HaveField("Status", SatisfyAll(
+						HaveField("ObservedGeneration", Equal(int64(1))),
+						HaveField("Replicas", Equal(int32(4))), // Replicas should be 4 once an updated replica is created.
+						HaveField("ReadyReplicas", Equal(int32(3))),
+						HaveField("UpdatedReplicas", Equal(int32(2))),
+					)))
+				})
 			})
 		})
 

--- a/pkg/controllers/controlplanemachineset/updates_test.go
+++ b/pkg/controllers/controlplanemachineset/updates_test.go
@@ -165,7 +165,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 							Level: 2,
 							KeysAndValues: []interface{}{
 								"updateStrategy", machinev1.RollingUpdate,
-								"index", 1,
+								"index", int32(1),
 								"namespace", namespaceName,
 								"name", "machine-1",
 							},
@@ -192,7 +192,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 							Error: fmt.Errorf("error creating new Machine for index %d: %w", 1, transientError),
 							KeysAndValues: []interface{}{
 								"updateStrategy", machinev1.RollingUpdate,
-								"index", 1,
+								"index", int32(1),
 								"namespace", namespaceName,
 								"name", "machine-1",
 							},
@@ -220,7 +220,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 						Level: 2,
 						KeysAndValues: []interface{}{
 							"updateStrategy", machinev1.RollingUpdate,
-							"index", 1,
+							"index", int32(1),
 							"namespace", namespaceName,
 							"name", "machine-1",
 							"replacementName", "machine-replacement-1",
@@ -253,7 +253,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 							Level: 2,
 							KeysAndValues: []interface{}{
 								"updateStrategy", machinev1.RollingUpdate,
-								"index", 1,
+								"index", int32(1),
 								"namespace", namespaceName,
 								"name", "machine-1",
 							},
@@ -288,7 +288,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 							Error: fmt.Errorf("error deleting Machine %s/%s: %w", namespaceName, "machine-1", transientError),
 							KeysAndValues: []interface{}{
 								"updateStrategy", machinev1.RollingUpdate,
-								"index", 1,
+								"index", int32(1),
 								"namespace", namespaceName,
 								"name", "machine-1",
 							},
@@ -316,7 +316,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 						Level: 2,
 						KeysAndValues: []interface{}{
 							"updateStrategy", machinev1.RollingUpdate,
-							"index", 1,
+							"index", int32(1),
 							"namespace", namespaceName,
 							"name", "machine-1",
 						},
@@ -343,7 +343,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 							Level: 2,
 							KeysAndValues: []interface{}{
 								"updateStrategy", machinev1.RollingUpdate,
-								"index", 0,
+								"index", int32(0),
 								"namespace", namespaceName,
 								"name", "machine-0",
 							},
@@ -353,7 +353,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 							Level: 2,
 							KeysAndValues: []interface{}{
 								"updateStrategy", machinev1.RollingUpdate,
-								"index", 1,
+								"index", int32(1),
 								"namespace", namespaceName,
 								"name", "machine-1",
 							},
@@ -383,7 +383,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 							Level: 2,
 							KeysAndValues: []interface{}{
 								"updateStrategy", machinev1.RollingUpdate,
-								"index", 0,
+								"index", int32(0),
 								"namespace", namespaceName,
 								"name", "machine-0",
 								"replacementName", "machine-replacement-0",
@@ -394,7 +394,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 							Level: 2,
 							KeysAndValues: []interface{}{
 								"updateStrategy", machinev1.RollingUpdate,
-								"index", 1,
+								"index", int32(1),
 								"namespace", namespaceName,
 								"name", "machine-1",
 							},
@@ -428,7 +428,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 							Level: 2,
 							KeysAndValues: []interface{}{
 								"updateStrategy", machinev1.RollingUpdate,
-								"index", 0,
+								"index", int32(0),
 								"namespace", namespaceName,
 								"name", "machine-0",
 							},
@@ -438,7 +438,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 							Level: 2,
 							KeysAndValues: []interface{}{
 								"updateStrategy", machinev1.RollingUpdate,
-								"index", 1,
+								"index", int32(1),
 								"namespace", namespaceName,
 								"name", "machine-1",
 							},
@@ -467,7 +467,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 							Level: 2,
 							KeysAndValues: []interface{}{
 								"updateStrategy", machinev1.RollingUpdate,
-								"index", 0,
+								"index", int32(0),
 								"namespace", namespaceName,
 								"name", "machine-0",
 							},
@@ -477,7 +477,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 							Level: 2,
 							KeysAndValues: []interface{}{
 								"updateStrategy", machinev1.RollingUpdate,
-								"index", 1,
+								"index", int32(1),
 								"namespace", namespaceName,
 								"name", "machine-1",
 							},
@@ -502,7 +502,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 						Level: 2,
 						KeysAndValues: []interface{}{
 							"updateStrategy", machinev1.RollingUpdate,
-							"index", 2,
+							"index", int32(2),
 							"namespace", namespaceName,
 							"name", "<Unknown>",
 						},
@@ -527,7 +527,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 						Level: 2,
 						KeysAndValues: []interface{}{
 							"updateStrategy", machinev1.RollingUpdate,
-							"index", 2,
+							"index", int32(2),
 							"namespace", namespaceName,
 							"name", "machine-replacement-2",
 						},
@@ -555,7 +555,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 							Level: 2,
 							KeysAndValues: []interface{}{
 								"updateStrategy", machinev1.RollingUpdate,
-								"index", 1,
+								"index", int32(1),
 								"namespace", namespaceName,
 								"name", "machine-1",
 							},
@@ -565,7 +565,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 							Level: 2,
 							KeysAndValues: []interface{}{
 								"updateStrategy", machinev1.RollingUpdate,
-								"index", 2,
+								"index", int32(2),
 								"namespace", namespaceName,
 								"name", "<Unknown>",
 							},
@@ -591,7 +591,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 							Level: 2,
 							KeysAndValues: []interface{}{
 								"updateStrategy", machinev1.RollingUpdate,
-								"index", 1,
+								"index", int32(1),
 								"namespace", namespaceName,
 								"name", "machine-1",
 							},
@@ -601,7 +601,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 							Level: 2,
 							KeysAndValues: []interface{}{
 								"updateStrategy", machinev1.RollingUpdate,
-								"index", 2,
+								"index", int32(2),
 								"namespace", namespaceName,
 								"name", "machine-replacement-2",
 							},
@@ -638,7 +638,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 							Level: 2,
 							KeysAndValues: []interface{}{
 								"updateStrategy", machinev1.RollingUpdate,
-								"index", 0,
+								"index", int32(0),
 								"namespace", namespaceName,
 								"name", "machine-0",
 							},
@@ -648,7 +648,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 							Level: 2,
 							KeysAndValues: []interface{}{
 								"updateStrategy", machinev1.RollingUpdate,
-								"index", 1,
+								"index", int32(1),
 								"namespace", namespaceName,
 								"name", "machine-1",
 							},
@@ -658,7 +658,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 							Level: 2,
 							KeysAndValues: []interface{}{
 								"updateStrategy", machinev1.RollingUpdate,
-								"index", 2,
+								"index", int32(2),
 								"namespace", namespaceName,
 								"name", "<Unknown>",
 							},
@@ -692,7 +692,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 							Level: 2,
 							KeysAndValues: []interface{}{
 								"updateStrategy", machinev1.RollingUpdate,
-								"index", 0,
+								"index", int32(0),
 								"namespace", namespaceName,
 								"name", "machine-0",
 							},
@@ -702,7 +702,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 							Level: 2,
 							KeysAndValues: []interface{}{
 								"updateStrategy", machinev1.RollingUpdate,
-								"index", 1,
+								"index", int32(1),
 								"namespace", namespaceName,
 								"name", "machine-1",
 							},
@@ -712,7 +712,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 							Level: 2,
 							KeysAndValues: []interface{}{
 								"updateStrategy", machinev1.RollingUpdate,
-								"index", 2,
+								"index", int32(2),
 								"namespace", namespaceName,
 								"name", "<Unknown>",
 							},
@@ -739,7 +739,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 							Level: 2,
 							KeysAndValues: []interface{}{
 								"updateStrategy", machinev1.RollingUpdate,
-								"index", 0,
+								"index", int32(0),
 								"namespace", namespaceName,
 								"name", "machine-0",
 							},
@@ -749,7 +749,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 							Level: 2,
 							KeysAndValues: []interface{}{
 								"updateStrategy", machinev1.RollingUpdate,
-								"index", 1,
+								"index", int32(1),
 								"namespace", namespaceName,
 								"name", "machine-1",
 							},
@@ -759,7 +759,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 							Level: 2,
 							KeysAndValues: []interface{}{
 								"updateStrategy", machinev1.RollingUpdate,
-								"index", 2,
+								"index", int32(2),
 								"namespace", namespaceName,
 								"name", "machine-2",
 							},
@@ -769,7 +769,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 							Level: 2,
 							KeysAndValues: []interface{}{
 								"updateStrategy", machinev1.RollingUpdate,
-								"index", 3,
+								"index", int32(3),
 								"namespace", namespaceName,
 								"name", "machine-3",
 							},
@@ -824,7 +824,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 							Level: 2,
 							KeysAndValues: []interface{}{
 								"updateStrategy", machinev1.RollingUpdate,
-								"index", 0,
+								"index", int32(0),
 								"namespace", namespaceName,
 								"name", "machine-replacement-0",
 							},
@@ -834,7 +834,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 							Level: 2,
 							KeysAndValues: []interface{}{
 								"updateStrategy", machinev1.RollingUpdate,
-								"index", 0,
+								"index", int32(0),
 								"namespace", namespaceName,
 								"name", "machine-0",
 							},
@@ -844,7 +844,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 							Level: 2,
 							KeysAndValues: []interface{}{
 								"updateStrategy", machinev1.RollingUpdate,
-								"index", 1,
+								"index", int32(1),
 								"namespace", namespaceName,
 								"name", "machine-1",
 							},
@@ -854,7 +854,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 							Level: 2,
 							KeysAndValues: []interface{}{
 								"updateStrategy", machinev1.RollingUpdate,
-								"index", 2,
+								"index", int32(2),
 								"namespace", namespaceName,
 								"name", "machine-2",
 							},
@@ -883,7 +883,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 							Level: 2,
 							KeysAndValues: []interface{}{
 								"updateStrategy", machinev1.RollingUpdate,
-								"index", 1,
+								"index", int32(1),
 								"namespace", namespaceName,
 								"name", "machine-1",
 							},
@@ -915,7 +915,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 							Level: 2,
 							KeysAndValues: []interface{}{
 								"updateStrategy", machinev1.RollingUpdate,
-								"index", 1,
+								"index", int32(1),
 								"namespace", namespaceName,
 								"name", "machine-1",
 								"replacementName", "machine-replacement-1",
@@ -945,7 +945,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 							Level: 2,
 							KeysAndValues: []interface{}{
 								"updateStrategy", machinev1.RollingUpdate,
-								"index", 1,
+								"index", int32(1),
 								"namespace", namespaceName,
 								"name", "machine-1",
 							},
@@ -1028,7 +1028,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 						Level: 2,
 						KeysAndValues: []interface{}{
 							"updateStrategy", machinev1.OnDelete,
-							"index", 1,
+							"index", int32(1),
 							"namespace", namespaceName,
 							"name", "machine-1",
 						},
@@ -1053,9 +1053,34 @@ var _ = Describe("reconcileMachineUpdates", func() {
 						Level: 2,
 						KeysAndValues: []interface{}{
 							"updateStrategy", machinev1.OnDelete,
-							"index", 1,
+							"index", int32(1),
 							"namespace", namespaceName,
 							"name", "machine-1",
+						},
+						Message: createdReplacement,
+					},
+					}
+				},
+			}),
+			Entry("with updates required in a single index, and the machine has been deleted (with no standard machine indexes)", onDeleteUpdateTableInput{
+				cpmsBuilder: cpmsBuilder.WithReplicas(3),
+				machineInfos: map[int32][]machineproviders.MachineInfo{
+					3: {updatedMachineBuilder.WithIndex(3).WithMachineName("machine-3").WithNodeName("node-3").Build()},
+					4: {updatedMachineBuilder.WithIndex(4).WithMachineName("machine-4").WithNodeName("node-4").WithNeedsUpdate(true).WithMachineDeletionTimestamp(metav1.Now()).Build()},
+					5: {updatedMachineBuilder.WithIndex(5).WithMachineName("machine-5").WithNodeName("node-5").Build()},
+				},
+				setupMock: func() {
+					mockMachineProvider.EXPECT().CreateMachine(gomock.Any(), gomock.Any(), int32(4)).Return(nil).Times(1)
+					mockMachineProvider.EXPECT().DeleteMachine(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+				},
+				expectedLogsBuilder: func() []test.LogEntry {
+					return []test.LogEntry{{
+						Level: 2,
+						KeysAndValues: []interface{}{
+							"updateStrategy", machinev1.OnDelete,
+							"index", int32(4),
+							"namespace", namespaceName,
+							"name", "machine-4",
 						},
 						Message: createdReplacement,
 					},
@@ -1079,7 +1104,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 						Error: fmt.Errorf("error creating new Machine for index %d: %w", 1, transientError),
 						KeysAndValues: []interface{}{
 							"updateStrategy", machinev1.OnDelete,
-							"index", 1,
+							"index", int32(1),
 							"namespace", namespaceName,
 							"name", "machine-1",
 						},
@@ -1107,7 +1132,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 						Level: 2,
 						KeysAndValues: []interface{}{
 							"updateStrategy", machinev1.OnDelete,
-							"index", 1,
+							"index", int32(1),
 							"namespace", namespaceName,
 							"name", "machine-1",
 							"replacementName", "machine-replacement-1",
@@ -1136,7 +1161,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 						Level: 2,
 						KeysAndValues: []interface{}{
 							"updateStrategy", machinev1.OnDelete,
-							"index", 1,
+							"index", int32(1),
 							"namespace", namespaceName,
 							"name", "machine-1",
 						},
@@ -1161,7 +1186,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 						Level: 2,
 						KeysAndValues: []interface{}{
 							"updateStrategy", machinev1.OnDelete,
-							"index", 0,
+							"index", int32(0),
 							"namespace", namespaceName,
 							"name", "machine-0",
 						},
@@ -1171,7 +1196,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 							Level: 2,
 							KeysAndValues: []interface{}{
 								"updateStrategy", machinev1.OnDelete,
-								"index", 1,
+								"index", int32(1),
 								"namespace", namespaceName,
 								"name", "machine-1",
 							},
@@ -1197,7 +1222,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 						Level: 2,
 						KeysAndValues: []interface{}{
 							"updateStrategy", machinev1.OnDelete,
-							"index", 0,
+							"index", int32(0),
 							"namespace", namespaceName,
 							"name", "machine-0",
 						},
@@ -1207,7 +1232,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 							Error: fmt.Errorf("error creating new Machine for index %d: %w", 1, transientError),
 							KeysAndValues: []interface{}{
 								"updateStrategy", machinev1.OnDelete,
-								"index", 1,
+								"index", int32(1),
 								"namespace", namespaceName,
 								"name", "machine-1",
 							},
@@ -1232,7 +1257,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 						Level: 2,
 						KeysAndValues: []interface{}{
 							"updateStrategy", machinev1.OnDelete,
-							"index", 0,
+							"index", int32(0),
 							"namespace", namespaceName,
 							"name", "machine-0",
 						},
@@ -1242,7 +1267,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 							Level: 2,
 							KeysAndValues: []interface{}{
 								"updateStrategy", machinev1.OnDelete,
-								"index", 1,
+								"index", int32(1),
 								"namespace", namespaceName,
 								"name", "machine-1",
 							},
@@ -1268,7 +1293,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 						Level: 2,
 						KeysAndValues: []interface{}{
 							"updateStrategy", machinev1.OnDelete,
-							"index", 0,
+							"index", int32(0),
 							"namespace", namespaceName,
 							"name", "machine-0",
 						},
@@ -1278,7 +1303,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 							Level: 2,
 							KeysAndValues: []interface{}{
 								"updateStrategy", machinev1.OnDelete,
-								"index", 1,
+								"index", int32(1),
 								"namespace", namespaceName,
 								"name", "machine-1",
 							},
@@ -1306,7 +1331,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 						Level: 2,
 						KeysAndValues: []interface{}{
 							"updateStrategy", machinev1.OnDelete,
-							"index", 0,
+							"index", int32(0),
 							"namespace", namespaceName,
 							"name", "machine-0",
 						},
@@ -1316,7 +1341,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 							Level: 2,
 							KeysAndValues: []interface{}{
 								"updateStrategy", machinev1.OnDelete,
-								"index", 1,
+								"index", int32(1),
 								"namespace", namespaceName,
 								"name", "machine-1",
 								"replacementName", "machine-replacement-1",
@@ -1348,7 +1373,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 						Level: 2,
 						KeysAndValues: []interface{}{
 							"updateStrategy", machinev1.OnDelete,
-							"index", 0,
+							"index", int32(0),
 							"namespace", namespaceName,
 							"name", "machine-0",
 							"replacementName", "machine-replacement-0",
@@ -1359,7 +1384,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 							Level: 2,
 							KeysAndValues: []interface{}{
 								"updateStrategy", machinev1.OnDelete,
-								"index", 1,
+								"index", int32(1),
 								"namespace", namespaceName,
 								"name", "machine-1",
 								"replacementName", "machine-replacement-1",
@@ -1388,7 +1413,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 						Level: 2,
 						KeysAndValues: []interface{}{
 							"updateStrategy", machinev1.OnDelete,
-							"index", 0,
+							"index", int32(0),
 							"namespace", namespaceName,
 							"name", "machine-0",
 						},
@@ -1398,7 +1423,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 							Level: 2,
 							KeysAndValues: []interface{}{
 								"updateStrategy", machinev1.OnDelete,
-								"index", 1,
+								"index", int32(1),
 								"namespace", namespaceName,
 								"name", "machine-1",
 							},
@@ -1429,7 +1454,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 						Level: 2,
 						KeysAndValues: []interface{}{
 							"updateStrategy", machinev1.OnDelete,
-							"index", 0,
+							"index", int32(0),
 							"namespace", namespaceName,
 							"name", "machine-0",
 							"replacementName", "machine-replacement-0",
@@ -1440,7 +1465,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 							Level: 2,
 							KeysAndValues: []interface{}{
 								"updateStrategy", machinev1.OnDelete,
-								"index", 1,
+								"index", int32(1),
 								"namespace", namespaceName,
 								"name", "machine-1",
 							},
@@ -1471,7 +1496,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 						Level: 2,
 						KeysAndValues: []interface{}{
 							"updateStrategy", machinev1.OnDelete,
-							"index", 0,
+							"index", int32(0),
 							"namespace", namespaceName,
 							"name", "machine-0",
 						},
@@ -1481,7 +1506,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 							Level: 2,
 							KeysAndValues: []interface{}{
 								"updateStrategy", machinev1.OnDelete,
-								"index", 1,
+								"index", int32(1),
 								"namespace", namespaceName,
 								"name", "machine-1",
 							},
@@ -1506,7 +1531,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 						Level: 2,
 						KeysAndValues: []interface{}{
 							"updateStrategy", machinev1.OnDelete,
-							"index", 2,
+							"index", int32(2),
 							"namespace", namespaceName,
 							"name", "<Unknown>",
 						},
@@ -1531,7 +1556,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 						Level: 2,
 						KeysAndValues: []interface{}{
 							"updateStrategy", machinev1.OnDelete,
-							"index", 2,
+							"index", int32(2),
 							"namespace", namespaceName,
 							"name", "machine-replacement-2",
 						},
@@ -1556,7 +1581,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 						Level: 2,
 						KeysAndValues: []interface{}{
 							"updateStrategy", machinev1.OnDelete,
-							"index", 1,
+							"index", int32(1),
 							"namespace", namespaceName,
 							"name", "machine-1",
 						},
@@ -1566,7 +1591,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 							Level: 2,
 							KeysAndValues: []interface{}{
 								"updateStrategy", machinev1.OnDelete,
-								"index", 2,
+								"index", int32(2),
 								"namespace", namespaceName,
 								"name", "<Unknown>",
 							},
@@ -1591,7 +1616,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 						Level: 2,
 						KeysAndValues: []interface{}{
 							"updateStrategy", machinev1.OnDelete,
-							"index", 1,
+							"index", int32(1),
 							"namespace", namespaceName,
 							"name", "machine-1",
 						},
@@ -1601,7 +1626,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 							Level: 2,
 							KeysAndValues: []interface{}{
 								"updateStrategy", machinev1.OnDelete,
-								"index", 2,
+								"index", int32(2),
 								"namespace", namespaceName,
 								"name", "machine-replacement-2",
 							},
@@ -1627,7 +1652,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 							Level: 2,
 							KeysAndValues: []interface{}{
 								"updateStrategy", machinev1.OnDelete,
-								"index", 2,
+								"index", int32(2),
 								"namespace", namespaceName,
 								"name", "machine-2",
 							},
@@ -1726,7 +1751,7 @@ var _ = Describe("utils tests", func() {
 		WithNeedsUpdate(false)
 
 	DescribeTable("should convert an indexed map of MachineInfo into a slice sorted by index",
-		func(input map[int32][]machineproviders.MachineInfo, expected [][]machineproviders.MachineInfo) {
+		func(input map[int32][]machineproviders.MachineInfo, expected []indexToMachineInfos) {
 			output := sortMachineInfosByIndex(input)
 			Expect(output).To(Equal(expected))
 		},
@@ -1736,10 +1761,10 @@ var _ = Describe("utils tests", func() {
 				0: {updatedMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build()},
 				2: {updatedMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("node-2").Build()},
 			},
-			[][]machineproviders.MachineInfo{
-				{updatedMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build()},
-				{updatedMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").Build()},
-				{updatedMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("node-2").Build()},
+			[]indexToMachineInfos{
+				{index: 0, machineInfos: []machineproviders.MachineInfo{updatedMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build()}},
+				{index: 1, machineInfos: []machineproviders.MachineInfo{updatedMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").Build()}},
+				{index: 2, machineInfos: []machineproviders.MachineInfo{updatedMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("node-2").Build()}},
 			},
 		),
 		Entry("when index starts at 1",
@@ -1748,10 +1773,10 @@ var _ = Describe("utils tests", func() {
 				2: {updatedMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("node-2").Build()},
 				1: {updatedMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").Build()},
 			},
-			[][]machineproviders.MachineInfo{
-				{updatedMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").Build()},
-				{updatedMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("node-2").Build()},
-				{updatedMachineBuilder.WithIndex(3).WithMachineName("machine-3").WithNodeName("node-3").Build()},
+			[]indexToMachineInfos{
+				{index: 1, machineInfos: []machineproviders.MachineInfo{updatedMachineBuilder.WithIndex(1).WithMachineName("machine-1").WithNodeName("node-1").Build()}},
+				{index: 2, machineInfos: []machineproviders.MachineInfo{updatedMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("node-2").Build()}},
+				{index: 3, machineInfos: []machineproviders.MachineInfo{updatedMachineBuilder.WithIndex(3).WithMachineName("machine-3").WithNodeName("node-3").Build()}},
 			},
 		),
 		Entry("when one index is missing",
@@ -1759,9 +1784,9 @@ var _ = Describe("utils tests", func() {
 				2: {updatedMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("node-2").Build()},
 				0: {updatedMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build()},
 			},
-			[][]machineproviders.MachineInfo{
-				{updatedMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build()},
-				{updatedMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("node-2").Build()},
+			[]indexToMachineInfos{
+				{index: 0, machineInfos: []machineproviders.MachineInfo{updatedMachineBuilder.WithIndex(0).WithMachineName("machine-0").WithNodeName("node-0").Build()}},
+				{index: 2, machineInfos: []machineproviders.MachineInfo{updatedMachineBuilder.WithIndex(2).WithMachineName("machine-2").WithNodeName("node-2").Build()}},
 			},
 		),
 	)


### PR DESCRIPTION
There were two issues at hand here.

The first of the two is that the OnDelete strategy was using the list index rather than machine indexes to create new machines. This would mean, if the machine index was 4 but that was the second item in the list, it would ask to create a new Machine in index 1 (indexed from 0). So the second commit here changes the behaviour of the sorted machine info so that it returns a struct with the machine index rather than just a list of the machine infos, this allows us to get the machine index and loop over that instead.

The second issue was in the way we handled indexes that only contain deleting machines within the provider mapping. We were ignoring them at the wrong stage. By ignoring them in the machine mapping generation, there was no opportunity for the output mapping to contain the correct index if that machine had a non-standard index.
Instead, I've moved the ignore to when we are matching candidates, with this approach the deleting machine is a lower priority than non-deleting machines and so when there is a rebalance action, the deleting machine is the one that changes  failure domain rather than a non-deleting machine.