### PR TITLE
OCPBUGS-2469: Don't set a name in related objects

### DIFF
--- a/manifests/0000_31_control-plane-machine-set-operator_04_clusteroperator.yaml
+++ b/manifests/0000_31_control-plane-machine-set-operator_04_clusteroperator.yaml
@@ -15,7 +15,7 @@ status:
     name: openshift-machine-api
     resource: namespaces
   - group: machine.openshift.io
-    name: cluster
+    name: ""
     resource: controlplanemachinesets
   - group: machine.openshift.io
     name: ""


### PR DESCRIPTION
When running `oc adm must-gather` we do not download controlplanemachineset resources.

Must gather uses `oc adm inspect` under the hood which looks at cluster operator related resources to identify what it should download. In must-gather, it does this across all namespaces.

When gathering across all namespaces, you cannot set a name for the related object else an error is produced:
```
error: errors occurred while gathering data:
    skipping gathering controlplanemachinesets.machine.openshift.io/cluster due to error: a resource cannot be retrieved by name across all namespaces
```
We currently set the name of the CPMS in our related objects so we do not get it included in the gather.