### PR TITLE
OCPBUGS-2741: Deduplicate failure domains when generating a ControlPlaneMachineSet

### DIFF
--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/failuredomain/set.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/failuredomain/set.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package failuredomain
+
+import "sort"
+
+// Set implements a set symantic for a FailureDomain.
+// As this is an interface we cannot use a map directly.
+// We must compare the failure domains directly.
+type Set struct {
+	items []FailureDomain
+}
+
+// NewSet creates a new set from the given items.
+func NewSet(items ...FailureDomain) *Set {
+	s := Set{}
+
+	for _, item := range items {
+		fd := item
+		s.items = append(s.items, fd)
+	}
+
+	return &s
+}
+
+// Has returns true if the item is in the set.
+func (s *Set) Has(item FailureDomain) bool {
+	for _, fd := range s.items {
+		if fd.Equal(item) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Insert adds the item to the set.
+func (s *Set) Insert(item FailureDomain) {
+	if s.Has(item) {
+		return
+	}
+
+	s.items = append(s.items, item)
+}
+
+// List returns the items in the set as a sorted slice.
+func (s *Set) List() []FailureDomain {
+	out := []FailureDomain{}
+	out = append(out, s.items...)
+
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].String() < out[j].String()
+	})
+
+	return out
+}

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/failuredomain/set_test.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/failuredomain/set_test.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package failuredomain
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	configv1 "github.com/openshift/api/config/v1"
+	machinev1 "github.com/openshift/api/machine/v1"
+)
+
+var _ = Describe("Set suite", func() {
+	Context("when creating a new set", func() {
+		Context("with AWS failure domains", func() {
+			usEast1aFailureDomain := &failureDomain{
+				platformType: configv1.AWSPlatformType,
+				aws: machinev1.AWSFailureDomain{
+					Placement: machinev1.AWSFailureDomainPlacement{
+						AvailabilityZone: "us-east-1a",
+					},
+				},
+			}
+
+			usEast1bFailureDomain := &failureDomain{
+				platformType: configv1.AWSPlatformType,
+				aws: machinev1.AWSFailureDomain{
+					Placement: machinev1.AWSFailureDomainPlacement{
+						AvailabilityZone: "us-east-1b",
+					},
+				},
+			}
+
+			usEast1cFailureDomain := &failureDomain{
+				platformType: configv1.AWSPlatformType,
+				aws: machinev1.AWSFailureDomain{
+					Placement: machinev1.AWSFailureDomainPlacement{
+						AvailabilityZone: "us-east-1c",
+					},
+				},
+			}
+
+			usEast1dFailureDomain := &failureDomain{
+				platformType: configv1.AWSPlatformType,
+				aws: machinev1.AWSFailureDomain{
+					Placement: machinev1.AWSFailureDomainPlacement{
+						AvailabilityZone: "us-east-1d",
+					},
+				},
+			}
+
+			var set *Set
+
+			BeforeEach(func() {
+				By("creating a new set with 2 failure domains")
+				set = NewSet(usEast1aFailureDomain, usEast1cFailureDomain)
+			})
+
+			It("should have the initial failure domains", func() {
+				Expect(set.Has(usEast1aFailureDomain)).To(BeTrue(), "Set should contain the us-east-1a failure domain")
+				Expect(set.Has(usEast1cFailureDomain)).To(BeTrue(), "Set should contain the us-east-1c failure domain")
+			})
+
+			It("should not have other failure domains", func() {
+				Expect(set.Has(usEast1bFailureDomain)).ToNot(BeTrue(), "Set not should contain the us-east-1b failure domain")
+				Expect(set.Has(usEast1dFailureDomain)).ToNot(BeTrue(), "Set not should contain the us-east-1d failure domain")
+			})
+
+			It("should return a sorted list of the failure domains", func() {
+				Expect(set.List()).To(Equal([]FailureDomain{
+					usEast1aFailureDomain,
+					usEast1cFailureDomain,
+				}))
+			})
+
+			Context("when adding additional failure domains", func() {
+				Context("that are not already in the set", func() {
+					BeforeEach(func() {
+						set.Insert(usEast1bFailureDomain)
+						set.Insert(usEast1dFailureDomain)
+					})
+
+					It("should have the initial failure domains and the new failure domains", func() {
+						Expect(set.Has(usEast1aFailureDomain)).To(BeTrue(), "Set should contain the us-east-1a failure domain")
+						Expect(set.Has(usEast1bFailureDomain)).To(BeTrue(), "Set should contain the us-east-1b failure domain")
+						Expect(set.Has(usEast1cFailureDomain)).To(BeTrue(), "Set should contain the us-east-1c failure domain")
+						Expect(set.Has(usEast1dFailureDomain)).To(BeTrue(), "Set should contain the us-east-1d failure domain")
+					})
+
+					It("should return a sorted list of the failure domains without duplicates", func() {
+						Expect(set.List()).To(Equal([]FailureDomain{
+							usEast1aFailureDomain,
+							usEast1bFailureDomain,
+							usEast1cFailureDomain,
+							usEast1dFailureDomain,
+						}))
+					})
+				})
+
+				Context("that are already in the set", func() {
+					BeforeEach(func() {
+						set.Insert(usEast1aFailureDomain)
+						set.Insert(usEast1cFailureDomain)
+					})
+
+					It("should still have the initial failure domains", func() {
+						Expect(set.Has(usEast1aFailureDomain)).To(BeTrue(), "Set should contain the us-east-1a failure domain")
+						Expect(set.Has(usEast1cFailureDomain)).To(BeTrue(), "Set should contain the us-east-1c failure domain")
+					})
+
+					It("should return a sorted list of the failure domains without duplicates", func() {
+						Expect(set.List()).To(Equal([]FailureDomain{
+							usEast1aFailureDomain,
+							usEast1cFailureDomain,
+						}))
+					})
+				})
+			})
+		})
+	})
+})

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/providerconfig.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/providerconfig.go
@@ -327,7 +327,7 @@ func getPlatformTypeFromProviderSpec(providerSpec machinev1beta1.ProviderSpec) (
 
 // ExtractFailureDomainsFromMachines creates list of FailureDomains extracted from the provided list of machines.
 func ExtractFailureDomainsFromMachines(machines []machinev1beta1.Machine) ([]failuredomain.FailureDomain, error) {
-	machineFailureDomains := []failuredomain.FailureDomain{}
+	machineFailureDomains := failuredomain.NewSet()
 
 	for _, machine := range machines {
 		providerconfig, err := NewProviderConfigFromMachineSpec(machine.Spec)
@@ -335,10 +335,10 @@ func ExtractFailureDomainsFromMachines(machines []machinev1beta1.Machine) ([]fai
 			return nil, fmt.Errorf("error getting failure domain from machine %s: %w", machine.Name, err)
 		}
 
-		machineFailureDomains = append(machineFailureDomains, providerconfig.ExtractFailureDomain())
+		machineFailureDomains.Insert(providerconfig.ExtractFailureDomain())
 	}
 
-	return machineFailureDomains, nil
+	return machineFailureDomains.List(), nil
 }
 
 // ExtractFailureDomainFromMachine FailureDomain extracted from the provided machine.
@@ -353,7 +353,7 @@ func ExtractFailureDomainFromMachine(machine machinev1beta1.Machine) (failuredom
 
 // ExtractFailureDomainsFromMachineSets creates list of FailureDomains extracted from the provided list of machineSets.
 func ExtractFailureDomainsFromMachineSets(machineSets []machinev1beta1.MachineSet) ([]failuredomain.FailureDomain, error) {
-	machineSetFailureDomains := []failuredomain.FailureDomain{}
+	machineSetFailureDomains := failuredomain.NewSet()
 
 	for _, machineSet := range machineSets {
 		providerconfig, err := NewProviderConfigFromMachineSpec(machineSet.Spec.Template.Spec)
@@ -361,8 +361,8 @@ func ExtractFailureDomainsFromMachineSets(machineSets []machinev1beta1.MachineSe
 			return nil, fmt.Errorf("error getting failure domain from machineSet %s: %w", machineSet.Name, err)
 		}
 
-		machineSetFailureDomains = append(machineSetFailureDomains, providerconfig.ExtractFailureDomain())
+		machineSetFailureDomains.Insert(providerconfig.ExtractFailureDomain())
 	}
 
-	return machineSetFailureDomains, nil
+	return machineSetFailureDomains.List(), nil
 }

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/providerconfig_test.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/providerconfig_test.go
@@ -335,6 +335,22 @@ var _ = Describe("Provider Config", func() {
 					failuredomain.NewAWSFailureDomain(resourcebuilder.AWSFailureDomain().WithAvailabilityZone("us-east-1c").WithSubnet(awsSubnet).Build()),
 				},
 			}),
+			Entry("with machines that duplicate failure domains", extractFailureDomainsFromMachinesTableInput{
+				machines: []machinev1beta1.Machine{
+					*resourcebuilder.Machine().WithProviderSpecBuilder(resourcebuilder.AWSProviderSpec().WithAvailabilityZone("us-east-1a")).Build(),
+					*resourcebuilder.Machine().WithProviderSpecBuilder(resourcebuilder.AWSProviderSpec().WithAvailabilityZone("us-east-1b")).Build(),
+					*resourcebuilder.Machine().WithProviderSpecBuilder(resourcebuilder.AWSProviderSpec().WithAvailabilityZone("us-east-1c")).Build(),
+					*resourcebuilder.Machine().WithProviderSpecBuilder(resourcebuilder.AWSProviderSpec().WithAvailabilityZone("us-east-1a")).Build(),
+					*resourcebuilder.Machine().WithProviderSpecBuilder(resourcebuilder.AWSProviderSpec().WithAvailabilityZone("us-east-1b")).Build(),
+					*resourcebuilder.Machine().WithProviderSpecBuilder(resourcebuilder.AWSProviderSpec().WithAvailabilityZone("us-east-1c")).Build(),
+				},
+				expectedError: nil,
+				expectedFailureDomains: []failuredomain.FailureDomain{
+					failuredomain.NewAWSFailureDomain(resourcebuilder.AWSFailureDomain().WithAvailabilityZone("us-east-1a").WithSubnet(awsSubnet).Build()),
+					failuredomain.NewAWSFailureDomain(resourcebuilder.AWSFailureDomain().WithAvailabilityZone("us-east-1b").WithSubnet(awsSubnet).Build()),
+					failuredomain.NewAWSFailureDomain(resourcebuilder.AWSFailureDomain().WithAvailabilityZone("us-east-1c").WithSubnet(awsSubnet).Build()),
+				},
+			}),
 		)
 
 	})


### PR DESCRIPTION
On upgrade, when we generate a CPMS, there may be more than the initial set of failure domains in the cluster. To prevent duplication, I've updated the failure domain extraction so that it uses a set symantic and returns each failure domain only once.
This prevents scenarios where the CPMS could be configured with the set `{a, b, a, c}` which we have seen in upgrade tests.