### PR TITLE
OCPBUGS-2854: Ensure generated CPMS includes any failure domain already present in control plane machines

### DIFF
--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/failuredomain/set.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/failuredomain/set.go
@@ -49,12 +49,12 @@ func (s *Set) Has(item FailureDomain) bool {
 }
 
 // Insert adds the item to the set.
-func (s *Set) Insert(item FailureDomain) {
-	if s.Has(item) {
-		return
+func (s *Set) Insert(items ...FailureDomain) {
+	for _, item := range items {
+		if !s.Has(item) {
+			s.items = append(s.items, item)
+		}
 	}
-
-	s.items = append(s.items, item)
 }
 
 // List returns the items in the set as a sorted slice.

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/failuredomain/set_test.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/failuredomain/set_test.go
@@ -87,11 +87,33 @@ var _ = Describe("Set suite", func() {
 				}))
 			})
 
-			Context("when adding additional failure domains", func() {
+			Context("when adding additional failure domains (separately)", func() {
 				Context("that are not already in the set", func() {
 					BeforeEach(func() {
 						set.Insert(usEast1bFailureDomain)
 						set.Insert(usEast1dFailureDomain)
+					})
+
+					It("should have the initial failure domains and the new failure domains", func() {
+						Expect(set.Has(usEast1aFailureDomain)).To(BeTrue(), "Set should contain the us-east-1a failure domain")
+						Expect(set.Has(usEast1bFailureDomain)).To(BeTrue(), "Set should contain the us-east-1b failure domain")
+						Expect(set.Has(usEast1cFailureDomain)).To(BeTrue(), "Set should contain the us-east-1c failure domain")
+						Expect(set.Has(usEast1dFailureDomain)).To(BeTrue(), "Set should contain the us-east-1d failure domain")
+					})
+
+					It("should return a sorted list of the failure domains without duplicates", func() {
+						Expect(set.List()).To(Equal([]FailureDomain{
+							usEast1aFailureDomain,
+							usEast1bFailureDomain,
+							usEast1cFailureDomain,
+							usEast1dFailureDomain,
+						}))
+					})
+				})
+
+				Context("that are not already in the set (together)", func() {
+					BeforeEach(func() {
+						set.Insert(usEast1bFailureDomain, usEast1dFailureDomain)
 					})
 
 					It("should have the initial failure domains and the new failure domains", func() {


### PR DESCRIPTION
If the cluster has control plane machines that do not have a failure domain also represented by the machineset failure domains, then the generator does not include the failure domain for the control plane machine and the CPMS cannot be created.

This updates the failure domain gathering logic to include both the Machine and MachineSet failure domains, so that we create a superset from the two.

This should ensure we always include all available failure domains.