### PR TITLE
[OCPCLOUD-1765] Azure: Generate ControlPlaneMachineSet for clusters t…

### DIFF
--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -88,12 +88,12 @@ Please ensure that you have 3 (or 5) control plane machines before creating the 
 The control plane machine set is currently supported for a number of platforms and OpenShift versions.
 The matrix shows in detail the support for each specific combination.
 
-| Platform \ OpenShift version |      <=4.11    |      4.12           |
-|------------------------------|:---------------|:--------------------|
-| AWS                          |  Not Supported | Full                |
-| Azure                        |  Not Supported | Manual              |
-| VSphere                      |  Not Supported | Manual (Single Zone)|
-| Other Platforms              |  Not Supported | Not Supported       |
+| Platform \ OpenShift version |      <=4.11    |      4.12           |      4.13           |
+|------------------------------|:---------------|:--------------------|:--------------------|
+| AWS                          |  Not Supported | Full                | Full                |
+| Azure                        |  Not Supported | Manual              | Manual              |
+| VSphere                      |  Not Supported | Manual (Single Zone)| Manual (Signle Zone)|
+| Other Platforms              |  Not Supported | Not Supported       | Not Supported       |
 
 > Note: Google Cloud Platform and OpenStack are planned for inclusion from OpenShift version 4.13 onwards.
 

--- a/pkg/controllers/controlplanemachinesetgenerator/azure.go
+++ b/pkg/controllers/controlplanemachinesetgenerator/azure.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controlplanemachinesetgenerator
+
+import (
+	"encoding/json"
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+	machinev1 "github.com/openshift/api/machine/v1"
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+	machinev1builder "github.com/openshift/client-go/machine/applyconfigurations/machine/v1"
+	machinev1beta1builder "github.com/openshift/client-go/machine/applyconfigurations/machine/v1beta1"
+	"github.com/openshift/cluster-control-plane-machine-set-operator/pkg/machineproviders/providers/openshift/machine/v1beta1/failuredomain"
+	"github.com/openshift/cluster-control-plane-machine-set-operator/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// generateControlPlaneMachineSetAzureSpec generates an Azure flavored ControlPlaneMachineSet Spec.
+func generateControlPlaneMachineSetAzureSpec(machines []machinev1beta1.Machine, machineSets []machinev1beta1.MachineSet) (machinev1builder.ControlPlaneMachineSetSpecApplyConfiguration, error) {
+	controlPlaneMachineSetMachineFailureDomainsApplyConfig, err := buildAzureFailureDomains(machineSets, machines)
+	if err != nil {
+		return machinev1builder.ControlPlaneMachineSetSpecApplyConfiguration{}, fmt.Errorf("failed to build ControlPlaneMachineSet's Azure failure domains: %w", err)
+	}
+
+	controlPlaneMachineSetMachineSpecApplyConfig, err := buildControlPlaneMachineSetAzureMachineSpec(machines)
+	if err != nil {
+		return machinev1builder.ControlPlaneMachineSetSpecApplyConfiguration{}, fmt.Errorf("failed to build ControlPlaneMachineSet's Azure spec: %w", err)
+	}
+
+	// We want to work with the newest machine
+	controlPlaneMachineSetApplyConfigSpec := genericControlPlaneMachineSetSpec(replicas, machines[0].ObjectMeta.Labels[clusterIDLabelKey])
+	controlPlaneMachineSetApplyConfigSpec.Template.OpenShiftMachineV1Beta1Machine.FailureDomains = controlPlaneMachineSetMachineFailureDomainsApplyConfig
+	controlPlaneMachineSetApplyConfigSpec.Template.OpenShiftMachineV1Beta1Machine.Spec = controlPlaneMachineSetMachineSpecApplyConfig
+
+	return controlPlaneMachineSetApplyConfigSpec, nil
+}
+
+// buildAzureFailureDomains builds an AzureFailureDomain config for the ControlPaneMachineSet from the cluster's Machines and MachineSets.
+func buildAzureFailureDomains(machineSets []machinev1beta1.MachineSet, machines []machinev1beta1.Machine) (*machinev1builder.FailureDomainsApplyConfiguration, error) {
+	// Fetch failure domains from the machines
+	machineFailureDomains, err := providerconfig.ExtractFailureDomainsFromMachines(machines)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract failure domains from machines: %w", err)
+	}
+
+	// Fetch failure domains from the machineSets
+	machineSetFailureDomains, err := providerconfig.ExtractFailureDomainsFromMachineSets(machineSets)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract failure domains from machine sets: %w", err)
+	}
+
+	// We have to get rid of duplicates from the failure domains.
+	// We construct a set from the failure domains, since a set can't have duplicates.
+	failureDomains := failuredomain.NewSet(machineFailureDomains...)
+	// Construction of a union of failure domains of machines and machineSets
+	failureDomains.Insert(machineSetFailureDomains...)
+
+	azureFailureDomains := []machinev1.AzureFailureDomain{}
+	for _, fd := range failureDomains.List() {
+		azureFailureDomains = append(azureFailureDomains, fd.Azure())
+	}
+
+	cpmsFailureDomain := machinev1.FailureDomains{
+		Azure:    &azureFailureDomains,
+		Platform: configv1.AzurePlatformType,
+	}
+
+	cpmsFailureDomainsApplyConfig := &machinev1builder.FailureDomainsApplyConfiguration{}
+	if err := convertViaJSON(cpmsFailureDomain, cpmsFailureDomainsApplyConfig); err != nil {
+		return nil, fmt.Errorf("failed to convert machinev1.FailureDomains to machinev1builder.FailureDomainsApplyConfiguration: %w", err)
+	}
+
+	return cpmsFailureDomainsApplyConfig, nil
+}
+
+// buildControlPlaneMachineSetAzureMachineSpec builds an Azure flavored MachineSpec for the ControlPlaneMachineSet.
+func buildControlPlaneMachineSetAzureMachineSpec(machines []machinev1beta1.Machine) (*machinev1beta1builder.MachineSpecApplyConfiguration, error) {
+	// The machines slice is sorted by the creation time.
+	// We want to get the provider config for the newest machine.
+	providerConfig, err := providerconfig.NewProviderConfigFromMachineSpec(machines[0].Spec)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract machine's azure providerSpec: %w", err)
+	}
+
+	azureProviderSpec := providerConfig.Azure().Config()
+	// Remove field related to the faliure domain
+	azureProviderSpec.Zone = nil
+
+	rawBytes, err := json.Marshal(azureProviderSpec)
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling azure providerSpec: %w", err)
+	}
+
+	re := runtime.RawExtension{
+		Raw: rawBytes,
+	}
+
+	return &machinev1beta1builder.MachineSpecApplyConfiguration{
+		ProviderSpec: &machinev1beta1builder.ProviderSpecApplyConfiguration{Value: &re},
+	}, nil
+}

--- a/pkg/controllers/controlplanemachinesetgenerator/azure.go
+++ b/pkg/controllers/controlplanemachinesetgenerator/azure.go
@@ -42,7 +42,7 @@ func generateControlPlaneMachineSetAzureSpec(machines []machinev1beta1.Machine, 
 		return machinev1builder.ControlPlaneMachineSetSpecApplyConfiguration{}, fmt.Errorf("failed to build ControlPlaneMachineSet's Azure spec: %w", err)
 	}
 
-	// We want to work with the newest machine
+	// We want to work with the newest machine.
 	controlPlaneMachineSetApplyConfigSpec := genericControlPlaneMachineSetSpec(replicas, machines[0].ObjectMeta.Labels[clusterIDLabelKey])
 	controlPlaneMachineSetApplyConfigSpec.Template.OpenShiftMachineV1Beta1Machine.FailureDomains = controlPlaneMachineSetMachineFailureDomainsApplyConfig
 	controlPlaneMachineSetApplyConfigSpec.Template.OpenShiftMachineV1Beta1Machine.Spec = controlPlaneMachineSetMachineSpecApplyConfig
@@ -67,7 +67,7 @@ func buildAzureFailureDomains(machineSets []machinev1beta1.MachineSet, machines 
 	// We have to get rid of duplicates from the failure domains.
 	// We construct a set from the failure domains, since a set can't have duplicates.
 	failureDomains := failuredomain.NewSet(machineFailureDomains...)
-	// Construction of a union of failure domains of machines and machineSets
+	// Construction of a union of failure domains of machines and machineSets.
 	failureDomains.Insert(machineSetFailureDomains...)
 
 	azureFailureDomains := []machinev1.AzureFailureDomain{}
@@ -98,7 +98,7 @@ func buildControlPlaneMachineSetAzureMachineSpec(machines []machinev1beta1.Machi
 	}
 
 	azureProviderSpec := providerConfig.Azure().Config()
-	// Remove field related to the faliure domain
+	// Remove field related to the faliure domain.
 	azureProviderSpec.Zone = nil
 
 	rawBytes, err := json.Marshal(azureProviderSpec)

--- a/pkg/controllers/controlplanemachinesetgenerator/controller.go
+++ b/pkg/controllers/controlplanemachinesetgenerator/controller.go
@@ -223,6 +223,11 @@ func (r *ControlPlaneMachineSetGeneratorReconciler) generateControlPlaneMachineS
 		if err != nil {
 			return nil, fmt.Errorf("unable to generate control plane machine set spec: %w", err)
 		}
+	case configv1.AzurePlatformType:
+		cpmsSpecApplyConfig, err = generateControlPlaneMachineSetAzureSpec(machines, machineSets)
+		if err != nil {
+			return nil, fmt.Errorf("unable to generate control plane machine set spec: %w", err)
+		}
 	default:
 		logger.V(1).WithValues("platform", platformType).Info(unsupportedPlatform)
 		return nil, errUnsupportedPlatform

--- a/pkg/controllers/controlplanemachinesetgenerator/controller_test.go
+++ b/pkg/controllers/controlplanemachinesetgenerator/controller_test.go
@@ -37,212 +37,213 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
-var (
-	usEast1aSubnet = machinev1beta1.AWSResourceReference{
-		Filters: []machinev1beta1.Filter{
-			{
-				Name: "tag:Name",
-				Values: []string{
-					"subnet-us-east-1a",
-				},
-			},
-		},
-	}
+var _ = Describe("controlplanemachinesetgenerator controller on AWS", func() {
 
-	usEast1bSubnet = machinev1beta1.AWSResourceReference{
-		Filters: []machinev1beta1.Filter{
-			{
-				Name: "tag:Name",
-				Values: []string{
-					"subnet-us-east-1b",
-				},
-			},
-		},
-	}
-
-	usEast1cSubnet = machinev1beta1.AWSResourceReference{
-		Filters: []machinev1beta1.Filter{
-			{
-				Name: "tag:Name",
-				Values: []string{
-					"subnet-us-east-1c",
-				},
-			},
-		},
-	}
-
-	usEast1dSubnet = machinev1beta1.AWSResourceReference{
-		Filters: []machinev1beta1.Filter{
-			{
-				Name: "tag:Name",
-				Values: []string{
-					"subnet-us-east-1d",
-				},
-			},
-		},
-	}
-
-	usEast1eSubnet = machinev1beta1.AWSResourceReference{
-		Filters: []machinev1beta1.Filter{
-			{
-				Name: "tag:Name",
-				Values: []string{
-					"subnet-us-east-1e",
-				},
-			},
-		},
-	}
-
-	usEast1aFailureDomainBuilder = resourcebuilder.AWSFailureDomain().
-					WithAvailabilityZone("us-east-1a").
-					WithSubnet(machinev1.AWSResourceReference{
-			Type: machinev1.AWSFiltersReferenceType,
-			Filters: &[]machinev1.AWSResourceFilter{
+	var (
+		usEast1aSubnetAWS = machinev1beta1.AWSResourceReference{
+			Filters: []machinev1beta1.Filter{
 				{
-					Name:   "tag:Name",
-					Values: []string{"subnet-us-east-1a"},
+					Name: "tag:Name",
+					Values: []string{
+						"subnet-us-east-1a",
+					},
 				},
 			},
-		})
+		}
 
-	usEast1bFailureDomainBuilder = resourcebuilder.AWSFailureDomain().
-					WithAvailabilityZone("us-east-1b").
-					WithSubnet(machinev1.AWSResourceReference{
-			Type: machinev1.AWSFiltersReferenceType,
-			Filters: &[]machinev1.AWSResourceFilter{
+		usEast1bSubnetAWS = machinev1beta1.AWSResourceReference{
+			Filters: []machinev1beta1.Filter{
 				{
-					Name:   "tag:Name",
-					Values: []string{"subnet-us-east-1b"},
+					Name: "tag:Name",
+					Values: []string{
+						"subnet-us-east-1b",
+					},
 				},
 			},
-		})
+		}
 
-	usEast1cFailureDomainBuilder = resourcebuilder.AWSFailureDomain().
-					WithAvailabilityZone("us-east-1c").
-					WithSubnet(machinev1.AWSResourceReference{
-			Type: machinev1.AWSFiltersReferenceType,
-			Filters: &[]machinev1.AWSResourceFilter{
+		usEast1cSubnetAWS = machinev1beta1.AWSResourceReference{
+			Filters: []machinev1beta1.Filter{
 				{
-					Name:   "tag:Name",
-					Values: []string{"subnet-us-east-1c"},
+					Name: "tag:Name",
+					Values: []string{
+						"subnet-us-east-1c",
+					},
 				},
 			},
-		})
+		}
 
-	usEast1dFailureDomainBuilder = resourcebuilder.AWSFailureDomain().
-					WithAvailabilityZone("us-east-1d").
-					WithSubnet(machinev1.AWSResourceReference{
-			Type: machinev1.AWSFiltersReferenceType,
-			Filters: &[]machinev1.AWSResourceFilter{
+		usEast1dSubnetAWS = machinev1beta1.AWSResourceReference{
+			Filters: []machinev1beta1.Filter{
 				{
-					Name:   "tag:Name",
-					Values: []string{"subnet-us-east-1d"},
+					Name: "tag:Name",
+					Values: []string{
+						"subnet-us-east-1d",
+					},
 				},
 			},
-		})
+		}
 
-	usEast1eFailureDomainBuilder = resourcebuilder.AWSFailureDomain().
-					WithAvailabilityZone("us-east-1e").
-					WithSubnet(machinev1.AWSResourceReference{
-			Type: machinev1.AWSFiltersReferenceType,
-			Filters: &[]machinev1.AWSResourceFilter{
+		usEast1eSubnetAWS = machinev1beta1.AWSResourceReference{
+			Filters: []machinev1beta1.Filter{
 				{
-					Name:   "tag:Name",
-					Values: []string{"subnet-us-east-1e"},
+					Name: "tag:Name",
+					Values: []string{
+						"subnet-us-east-1e",
+					},
 				},
 			},
-		})
+		}
 
-	usEast1aProviderSpecBuilder = resourcebuilder.AWSProviderSpec().
-					WithAvailabilityZone("us-east-1a").
-					WithSubnet(usEast1aSubnet)
+		usEast1aFailureDomainBuilderAWS = resourcebuilder.AWSFailureDomain().
+						WithAvailabilityZone("us-east-1a").
+						WithSubnet(machinev1.AWSResourceReference{
+				Type: machinev1.AWSFiltersReferenceType,
+				Filters: &[]machinev1.AWSResourceFilter{
+					{
+						Name:   "tag:Name",
+						Values: []string{"subnet-us-east-1a"},
+					},
+				},
+			})
 
-	usEast1bProviderSpecBuilder = resourcebuilder.AWSProviderSpec().
-					WithAvailabilityZone("us-east-1b").
-					WithSubnet(usEast1bSubnet)
+		usEast1bFailureDomainBuilderAWS = resourcebuilder.AWSFailureDomain().
+						WithAvailabilityZone("us-east-1b").
+						WithSubnet(machinev1.AWSResourceReference{
+				Type: machinev1.AWSFiltersReferenceType,
+				Filters: &[]machinev1.AWSResourceFilter{
+					{
+						Name:   "tag:Name",
+						Values: []string{"subnet-us-east-1b"},
+					},
+				},
+			})
 
-	usEast1cProviderSpecBuilder = resourcebuilder.AWSProviderSpec().
-					WithAvailabilityZone("us-east-1c").
-					WithSubnet(usEast1cSubnet)
+		usEast1cFailureDomainBuilderAWS = resourcebuilder.AWSFailureDomain().
+						WithAvailabilityZone("us-east-1c").
+						WithSubnet(machinev1.AWSResourceReference{
+				Type: machinev1.AWSFiltersReferenceType,
+				Filters: &[]machinev1.AWSResourceFilter{
+					{
+						Name:   "tag:Name",
+						Values: []string{"subnet-us-east-1c"},
+					},
+				},
+			})
 
-	usEast1dProviderSpecBuilder = resourcebuilder.AWSProviderSpec().
-					WithAvailabilityZone("us-east-1d").
-					WithSubnet(usEast1dSubnet)
+		usEast1dFailureDomainBuilderAWS = resourcebuilder.AWSFailureDomain().
+						WithAvailabilityZone("us-east-1d").
+						WithSubnet(machinev1.AWSResourceReference{
+				Type: machinev1.AWSFiltersReferenceType,
+				Filters: &[]machinev1.AWSResourceFilter{
+					{
+						Name:   "tag:Name",
+						Values: []string{"subnet-us-east-1d"},
+					},
+				},
+			})
 
-	usEast1eProviderSpecBuilder = resourcebuilder.AWSProviderSpec().
-					WithAvailabilityZone("us-east-1e").
-					WithSubnet(usEast1eSubnet)
+		usEast1eFailureDomainBuilderAWS = resourcebuilder.AWSFailureDomain().
+						WithAvailabilityZone("us-east-1e").
+						WithSubnet(machinev1.AWSResourceReference{
+				Type: machinev1.AWSFiltersReferenceType,
+				Filters: &[]machinev1.AWSResourceFilter{
+					{
+						Name:   "tag:Name",
+						Values: []string{"subnet-us-east-1e"},
+					},
+				},
+			})
 
-	cpms3FailureDomainsBuilder = resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
-		usEast1aFailureDomainBuilder,
-		usEast1bFailureDomainBuilder,
-		usEast1cFailureDomainBuilder,
+		usEast1aProviderSpecBuilderAWS = resourcebuilder.AWSProviderSpec().
+						WithAvailabilityZone("us-east-1a").
+						WithSubnet(usEast1aSubnetAWS)
+
+		usEast1bProviderSpecBuilderAWS = resourcebuilder.AWSProviderSpec().
+						WithAvailabilityZone("us-east-1b").
+						WithSubnet(usEast1bSubnetAWS)
+
+		usEast1cProviderSpecBuilderAWS = resourcebuilder.AWSProviderSpec().
+						WithAvailabilityZone("us-east-1c").
+						WithSubnet(usEast1cSubnetAWS)
+
+		usEast1dProviderSpecBuilderAWS = resourcebuilder.AWSProviderSpec().
+						WithAvailabilityZone("us-east-1d").
+						WithSubnet(usEast1dSubnetAWS)
+
+		usEast1eProviderSpecBuilderAWS = resourcebuilder.AWSProviderSpec().
+						WithAvailabilityZone("us-east-1e").
+						WithSubnet(usEast1eSubnetAWS)
+
+		cpms3FailureDomainsBuilderAWS = resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
+			usEast1aFailureDomainBuilderAWS,
+			usEast1bFailureDomainBuilderAWS,
+			usEast1cFailureDomainBuilderAWS,
+		)
+
+		cpms5FailureDomainsBuilderAWS = resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
+			usEast1aFailureDomainBuilderAWS,
+			usEast1bFailureDomainBuilderAWS,
+			usEast1cFailureDomainBuilderAWS,
+			usEast1dFailureDomainBuilderAWS,
+			usEast1eFailureDomainBuilderAWS,
+		)
+
+		cpmsInactive3FDsBuilderAWS = resourcebuilder.ControlPlaneMachineSet().
+						WithState(machinev1.ControlPlaneMachineSetStateInactive).
+						WithMachineTemplateBuilder(
+				resourcebuilder.OpenShiftMachineV1Beta1Template().
+					WithProviderSpecBuilder(
+						usEast1aProviderSpecBuilderAWS.WithAvailabilityZone("").WithSubnet(machinev1beta1.AWSResourceReference{}).WithInstanceType("c5.8xlarge"),
+					).
+					WithFailureDomainsBuilder(resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
+						usEast1aFailureDomainBuilderAWS,
+						usEast1bFailureDomainBuilderAWS,
+						usEast1cFailureDomainBuilderAWS,
+					)),
+			)
+
+		cpmsInactive5FDsBuilderAWS = resourcebuilder.ControlPlaneMachineSet().
+						WithState(machinev1.ControlPlaneMachineSetStateInactive).
+						WithMachineTemplateBuilder(
+				resourcebuilder.OpenShiftMachineV1Beta1Template().
+					WithProviderSpecBuilder(
+						usEast1aProviderSpecBuilderAWS.WithAvailabilityZone("").WithSubnet(machinev1beta1.AWSResourceReference{}).WithInstanceType("c5.2xlarge"),
+					).
+					WithFailureDomainsBuilder(resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
+						usEast1aFailureDomainBuilderAWS,
+						usEast1bFailureDomainBuilderAWS,
+						usEast1cFailureDomainBuilderAWS,
+						usEast1dFailureDomainBuilderAWS,
+						usEast1eFailureDomainBuilderAWS,
+					)),
+			)
+
+		cpmsActiveOutdatedBuilderAWS = resourcebuilder.ControlPlaneMachineSet().
+						WithState(machinev1.ControlPlaneMachineSetStateActive).
+						WithMachineTemplateBuilder(
+				resourcebuilder.OpenShiftMachineV1Beta1Template().
+					WithProviderSpecBuilder(
+						usEast1aProviderSpecBuilderAWS.WithAvailabilityZone("").WithSubnet(machinev1beta1.AWSResourceReference{}).WithInstanceType("c5.8xlarge"),
+					).
+					WithFailureDomainsBuilder(resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
+						usEast1aFailureDomainBuilderAWS,
+						usEast1bFailureDomainBuilderAWS,
+						usEast1cFailureDomainBuilderAWS,
+					)),
+			)
+
+		cpmsActiveUpToDateBuilderAWS = resourcebuilder.ControlPlaneMachineSet().
+						WithState(machinev1.ControlPlaneMachineSetStateActive).
+						WithMachineTemplateBuilder(
+				resourcebuilder.OpenShiftMachineV1Beta1Template().
+					WithProviderSpecBuilder(
+						usEast1aProviderSpecBuilderAWS.WithAvailabilityZone("").WithSubnet(machinev1beta1.AWSResourceReference{}).WithInstanceType("c5.2xlarge"),
+					).
+					WithFailureDomainsBuilder(cpms5FailureDomainsBuilderAWS),
+			)
 	)
 
-	cpms5FailureDomainsBuilder = resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
-		usEast1aFailureDomainBuilder,
-		usEast1bFailureDomainBuilder,
-		usEast1cFailureDomainBuilder,
-		usEast1dFailureDomainBuilder,
-		usEast1eFailureDomainBuilder,
-	)
-
-	cpmsInactive3FDsBuilder = resourcebuilder.ControlPlaneMachineSet().
-				WithState(machinev1.ControlPlaneMachineSetStateInactive).
-				WithMachineTemplateBuilder(
-			resourcebuilder.OpenShiftMachineV1Beta1Template().
-				WithProviderSpecBuilder(
-					usEast1aProviderSpecBuilder.WithAvailabilityZone("").WithSubnet(machinev1beta1.AWSResourceReference{}).WithInstanceType("c5.8xlarge"),
-				).
-				WithFailureDomainsBuilder(resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
-					usEast1aFailureDomainBuilder,
-					usEast1bFailureDomainBuilder,
-					usEast1cFailureDomainBuilder,
-				)),
-		)
-
-	cpmsInactive5FDsBuilder = resourcebuilder.ControlPlaneMachineSet().
-				WithState(machinev1.ControlPlaneMachineSetStateInactive).
-				WithMachineTemplateBuilder(
-			resourcebuilder.OpenShiftMachineV1Beta1Template().
-				WithProviderSpecBuilder(
-					usEast1aProviderSpecBuilder.WithAvailabilityZone("").WithSubnet(machinev1beta1.AWSResourceReference{}).WithInstanceType("c5.2xlarge"),
-				).
-				WithFailureDomainsBuilder(resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
-					usEast1aFailureDomainBuilder,
-					usEast1bFailureDomainBuilder,
-					usEast1cFailureDomainBuilder,
-					usEast1dFailureDomainBuilder,
-					usEast1eFailureDomainBuilder,
-				)),
-		)
-
-	cpmsActiveOutdatedBuilder = resourcebuilder.ControlPlaneMachineSet().
-					WithState(machinev1.ControlPlaneMachineSetStateActive).
-					WithMachineTemplateBuilder(
-			resourcebuilder.OpenShiftMachineV1Beta1Template().
-				WithProviderSpecBuilder(
-					usEast1aProviderSpecBuilder.WithAvailabilityZone("").WithSubnet(machinev1beta1.AWSResourceReference{}).WithInstanceType("c5.8xlarge"),
-				).
-				WithFailureDomainsBuilder(resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
-					usEast1aFailureDomainBuilder,
-					usEast1bFailureDomainBuilder,
-					usEast1cFailureDomainBuilder,
-				)),
-		)
-
-	cpmsActiveUpToDateBuilder = resourcebuilder.ControlPlaneMachineSet().
-					WithState(machinev1.ControlPlaneMachineSetStateActive).
-					WithMachineTemplateBuilder(
-			resourcebuilder.OpenShiftMachineV1Beta1Template().
-				WithProviderSpecBuilder(
-					usEast1aProviderSpecBuilder.WithAvailabilityZone("").WithSubnet(machinev1beta1.AWSResourceReference{}).WithInstanceType("c5.2xlarge"),
-				).
-				WithFailureDomainsBuilder(cpms5FailureDomainsBuilder),
-		)
-)
-
-var _ = Describe("controlplanemachinesetgenerator controller", func() {
 	var mgrCancel context.CancelFunc
 	var mgrDone chan struct{}
 	var mgr manager.Manager
@@ -275,9 +276,9 @@ var _ = Describe("controlplanemachinesetgenerator controller", func() {
 
 	create3MachineSets := func() {
 		machineSetBuilder := resourcebuilder.MachineSet().WithNamespace(namespaceName)
-		machineSet0 = machineSetBuilder.WithProviderSpecBuilder(usEast1aProviderSpecBuilder).WithGenerateName("machineset-us-east-1a-").Build()
-		machineSet1 = machineSetBuilder.WithProviderSpecBuilder(usEast1bProviderSpecBuilder).WithGenerateName("machineset-us-east-1b-").Build()
-		machineSet2 = machineSetBuilder.WithProviderSpecBuilder(usEast1cProviderSpecBuilder).WithGenerateName("machineset-us-east-1c-").Build()
+		machineSet0 = machineSetBuilder.WithProviderSpecBuilder(usEast1aProviderSpecBuilderAWS).WithGenerateName("machineset-us-east-1a-").Build()
+		machineSet1 = machineSetBuilder.WithProviderSpecBuilder(usEast1bProviderSpecBuilderAWS).WithGenerateName("machineset-us-east-1b-").Build()
+		machineSet2 = machineSetBuilder.WithProviderSpecBuilder(usEast1cProviderSpecBuilderAWS).WithGenerateName("machineset-us-east-1c-").Build()
 
 		Expect(k8sClient.Create(ctx, machineSet0)).To(Succeed())
 		Expect(k8sClient.Create(ctx, machineSet1)).To(Succeed())
@@ -288,8 +289,8 @@ var _ = Describe("controlplanemachinesetgenerator controller", func() {
 		create3MachineSets()
 
 		machineSetBuilder := resourcebuilder.MachineSet().WithNamespace(namespaceName)
-		machineSet3 = machineSetBuilder.WithProviderSpecBuilder(usEast1dProviderSpecBuilder).WithGenerateName("machineset-us-east-1d-").Build()
-		machineSet4 = machineSetBuilder.WithProviderSpecBuilder(usEast1eProviderSpecBuilder).WithGenerateName("machineset-us-east-1e-").Build()
+		machineSet3 = machineSetBuilder.WithProviderSpecBuilder(usEast1dProviderSpecBuilderAWS).WithGenerateName("machineset-us-east-1d-").Build()
+		machineSet4 = machineSetBuilder.WithProviderSpecBuilder(usEast1eProviderSpecBuilderAWS).WithGenerateName("machineset-us-east-1e-").Build()
 
 		Expect(k8sClient.Create(ctx, machineSet3)).To(Succeed())
 		Expect(k8sClient.Create(ctx, machineSet4)).To(Succeed())
@@ -299,9 +300,9 @@ var _ = Describe("controlplanemachinesetgenerator controller", func() {
 		// Create 3 control plane machines with differing Provider Specs,
 		// so then we can reliably check which machine Provider Spec is picked for the ControlPlaneMachineSet.
 		machineBuilder := resourcebuilder.Machine().AsMaster().WithNamespace(namespaceName)
-		machine0 = machineBuilder.WithProviderSpecBuilder(usEast1aProviderSpecBuilder.WithInstanceType("c5.xlarge")).WithName("master-0").Build()
-		machine1 = machineBuilder.WithProviderSpecBuilder(usEast1bProviderSpecBuilder.WithInstanceType("c5.2xlarge")).WithName("master-1").Build()
-		machine2 = machineBuilder.WithProviderSpecBuilder(usEast1cProviderSpecBuilder.WithInstanceType("c5.4xlarge")).WithName("master-2").Build()
+		machine0 = machineBuilder.WithProviderSpecBuilder(usEast1aProviderSpecBuilderAWS.WithInstanceType("c5.xlarge")).WithName("master-0").Build()
+		machine1 = machineBuilder.WithProviderSpecBuilder(usEast1bProviderSpecBuilderAWS.WithInstanceType("c5.2xlarge")).WithName("master-1").Build()
+		machine2 = machineBuilder.WithProviderSpecBuilder(usEast1cProviderSpecBuilderAWS.WithInstanceType("c5.4xlarge")).WithName("master-2").Build()
 
 		// Create Machines with some wait time between them
 		// to achieve staggered CreationTimestamp(s).
@@ -314,7 +315,7 @@ var _ = Describe("controlplanemachinesetgenerator controller", func() {
 
 	createUsEast1dMachine := func() *machinev1beta1.Machine {
 		machineBuilder := resourcebuilder.Machine().AsMaster().WithNamespace(namespaceName)
-		machine := machineBuilder.WithProviderSpecBuilder(usEast1dProviderSpecBuilder.WithInstanceType("c5.xlarge")).WithName("master-3").Build()
+		machine := machineBuilder.WithProviderSpecBuilder(usEast1dProviderSpecBuilderAWS.WithInstanceType("c5.xlarge")).WithName("master-3").Build()
 
 		Expect(k8sClient.Create(ctx, machine)).To(Succeed())
 
@@ -323,7 +324,7 @@ var _ = Describe("controlplanemachinesetgenerator controller", func() {
 
 	createUsEast1eMachine := func() *machinev1beta1.Machine {
 		machineBuilder := resourcebuilder.Machine().AsMaster().WithNamespace(namespaceName)
-		machine := machineBuilder.WithProviderSpecBuilder(usEast1eProviderSpecBuilder.WithInstanceType("c5.xlarge")).WithName("master-4").Build()
+		machine := machineBuilder.WithProviderSpecBuilder(usEast1eProviderSpecBuilderAWS.WithInstanceType("c5.xlarge")).WithName("master-4").Build()
 
 		Expect(k8sClient.Create(ctx, machine)).To(Succeed())
 
@@ -444,7 +445,7 @@ var _ = Describe("controlplanemachinesetgenerator controller", func() {
 						By("Checking the Control Plane Machine Set has been created")
 						Eventually(komega.Get(cpms)).Should(Succeed())
 
-						Expect(cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.FailureDomains).To(Equal(cpms5FailureDomainsBuilder.BuildFailureDomains()))
+						Expect(cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.FailureDomains).To(Equal(cpms5FailureDomainsBuilderAWS.BuildFailureDomains()))
 					})
 				})
 			})
@@ -493,7 +494,7 @@ var _ = Describe("controlplanemachinesetgenerator controller", func() {
 					By("Checking the Control Plane Machine Set has been created")
 					Eventually(komega.Get(cpms)).Should(Succeed())
 
-					Expect(cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.FailureDomains).To(Equal(cpms3FailureDomainsBuilder.BuildFailureDomains()))
+					Expect(cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.FailureDomains).To(Equal(cpms3FailureDomainsBuilderAWS.BuildFailureDomains()))
 				})
 
 				Context("With additional Machines adding additional failure domains", func() {
@@ -507,7 +508,7 @@ var _ = Describe("controlplanemachinesetgenerator controller", func() {
 						By("Checking the Control Plane Machine Set has been created")
 						Eventually(komega.Get(cpms)).Should(Succeed())
 
-						Expect(cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.FailureDomains).To(Equal(cpms5FailureDomainsBuilder.BuildFailureDomains()))
+						Expect(cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.FailureDomains).To(Equal(cpms5FailureDomainsBuilderAWS.BuildFailureDomains()))
 					})
 				})
 			})
@@ -520,7 +521,7 @@ var _ = Describe("controlplanemachinesetgenerator controller", func() {
 			BeforeEach(func() {
 				By("Creating 1 Control Plane Machine")
 				machineBuilder := resourcebuilder.Machine().AsMaster().WithNamespace(namespaceName)
-				machine2 = machineBuilder.WithProviderSpecBuilder(usEast1cProviderSpecBuilder.WithInstanceType("c5.4xlarge")).WithName("master-2").Build()
+				machine2 = machineBuilder.WithProviderSpecBuilder(usEast1cProviderSpecBuilderAWS.WithInstanceType("c5.4xlarge")).WithName("master-2").Build()
 				Expect(k8sClient.Create(ctx, machine2)).To(Succeed())
 				machines := []machinev1beta1.Machine{*machine2}
 
@@ -594,7 +595,7 @@ var _ = Describe("controlplanemachinesetgenerator controller", func() {
 				By("Creating an outdated and Inactive Control Plane Machine Set")
 				// Create an Inactive ControlPlaneMachineSet with a Provider Spec that
 				// doesn't match the one of the youngest control plane machine (i.e. it's outdated).
-				cpms = cpmsInactive3FDsBuilder.WithNamespace(namespaceName).Build()
+				cpms = cpmsInactive3FDsBuilderAWS.WithNamespace(namespaceName).Build()
 				Expect(k8sClient.Create(ctx, cpms)).To(Succeed())
 			})
 
@@ -636,7 +637,7 @@ var _ = Describe("controlplanemachinesetgenerator controller", func() {
 				})
 
 				It("should update, but not duplicate the failure domains on the ControlPlaneMachineSet", func() {
-					Eventually(komega.Object(cpms)).Should(HaveField("Spec.Template.OpenShiftMachineV1Beta1Machine.FailureDomains", Equal(cpms5FailureDomainsBuilder.BuildFailureDomains())))
+					Eventually(komega.Object(cpms)).Should(HaveField("Spec.Template.OpenShiftMachineV1Beta1Machine.FailureDomains", Equal(cpms5FailureDomainsBuilderAWS.BuildFailureDomains())))
 				})
 			})
 		})
@@ -646,7 +647,7 @@ var _ = Describe("controlplanemachinesetgenerator controller", func() {
 				By("Creating an up to date and Inactive Control Plane Machine Set")
 				// Create an Inactive ControlPlaneMachineSet with a Provider Spec that
 				// match the youngest control plane machine (i.e. it's up to date).
-				cpms = cpmsInactive5FDsBuilder.WithNamespace(namespaceName).Build()
+				cpms = cpmsInactive5FDsBuilderAWS.WithNamespace(namespaceName).Build()
 				Expect(k8sClient.Create(ctx, cpms)).To(Succeed())
 			})
 
@@ -662,7 +663,7 @@ var _ = Describe("controlplanemachinesetgenerator controller", func() {
 				By("Creating an outdated and Active Control Plane Machine Set")
 				// Create an Active ControlPlaneMachineSet with a Provider Spec that
 				// doesn't match the one of the youngest control plane machine (i.e. it's outdated).
-				cpms = cpmsActiveOutdatedBuilder.WithNamespace(namespaceName).Build()
+				cpms = cpmsActiveOutdatedBuilderAWS.WithNamespace(namespaceName).Build()
 				Expect(k8sClient.Create(ctx, cpms)).To(Succeed())
 			})
 
@@ -677,7 +678,7 @@ var _ = Describe("controlplanemachinesetgenerator controller", func() {
 				By("Creating an up to date and Active Control Plane Machine Set")
 				// Create an Active ControlPlaneMachineSet with a Provider Spec that
 				// doesn't match the one of the youngest control plane machine (i.e. it's up to date).
-				cpms = cpmsActiveUpToDateBuilder.WithNamespace(namespaceName).Build()
+				cpms = cpmsActiveUpToDateBuilderAWS.WithNamespace(namespaceName).Build()
 				Expect(k8sClient.Create(ctx, cpms)).To(Succeed())
 			})
 
@@ -702,12 +703,12 @@ var _ = Describe("controlplanemachinesetgenerator controller", func() {
 				By("Creating an outdated and Inactive Control Plane Machine Set")
 				// Create an Inactive ControlPlaneMachineSet with a Provider Spec that
 				// doesn't match the failure domains configured.
-				cpms = cpmsInactive5FDsBuilder.WithNamespace(namespaceName).Build()
+				cpms = cpmsInactive5FDsBuilderAWS.WithNamespace(namespaceName).Build()
 				Expect(k8sClient.Create(ctx, cpms)).To(Succeed())
 			})
 
 			It("should update ControlPlaneMachineSet with the expected failure domains", func() {
-				Eventually(komega.Object(cpms)).Should(HaveField("Spec.Template.OpenShiftMachineV1Beta1Machine.FailureDomains", Equal(cpms3FailureDomainsBuilder.BuildFailureDomains())))
+				Eventually(komega.Object(cpms)).Should(HaveField("Spec.Template.OpenShiftMachineV1Beta1Machine.FailureDomains", Equal(cpms3FailureDomainsBuilderAWS.BuildFailureDomains())))
 			})
 
 			Context("With additional Machines adding additional failure domains", func() {
@@ -718,104 +719,105 @@ var _ = Describe("controlplanemachinesetgenerator controller", func() {
 				})
 
 				It("should include additional failure domains from Machines, not present in the Machine Sets", func() {
-					Eventually(komega.Object(cpms)).Should(HaveField("Spec.Template.OpenShiftMachineV1Beta1Machine.FailureDomains", Equal(cpms5FailureDomainsBuilder.BuildFailureDomains())))
+					Eventually(komega.Object(cpms)).Should(HaveField("Spec.Template.OpenShiftMachineV1Beta1Machine.FailureDomains", Equal(cpms5FailureDomainsBuilderAWS.BuildFailureDomains())))
 				})
 			})
 		})
 	})
 })
 
-var (
-	usEast1aFailureDomainBuilderAzure = resourcebuilder.AzureFailureDomain().WithZone("us-east-1a")
+var _ = Describe("controlplanemachinesetgenerator controller on Azure", func() {
 
-	usEast1bFailureDomainBuilderAzure = resourcebuilder.AzureFailureDomain().WithZone("us-east-1b")
+	var (
+		usEast1aFailureDomainBuilderAzure = resourcebuilder.AzureFailureDomain().WithZone("us-east-1a")
 
-	usEast1cFailureDomainBuilderAzure = resourcebuilder.AzureFailureDomain().WithZone("us-east-1c")
+		usEast1bFailureDomainBuilderAzure = resourcebuilder.AzureFailureDomain().WithZone("us-east-1b")
 
-	usEast1dFailureDomainBuilderAzure = resourcebuilder.AzureFailureDomain().WithZone("us-east-1d")
+		usEast1cFailureDomainBuilderAzure = resourcebuilder.AzureFailureDomain().WithZone("us-east-1c")
 
-	usEast1eFailureDomainBuilderAzure = resourcebuilder.AzureFailureDomain().WithZone("us-east-1e")
+		usEast1dFailureDomainBuilderAzure = resourcebuilder.AzureFailureDomain().WithZone("us-east-1d")
 
-	usEast1aProviderSpecBuilderAzure = resourcebuilder.AzureProviderSpec().WithZone("us-east-1a")
+		usEast1eFailureDomainBuilderAzure = resourcebuilder.AzureFailureDomain().WithZone("us-east-1e")
 
-	usEast1bProviderSpecBuilderAzure = resourcebuilder.AzureProviderSpec().WithZone("us-east-1b")
+		usEast1aProviderSpecBuilderAzure = resourcebuilder.AzureProviderSpec().WithZone("us-east-1a")
 
-	usEast1cProviderSpecBuilderAzure = resourcebuilder.AzureProviderSpec().WithZone("us-east-1c")
+		usEast1bProviderSpecBuilderAzure = resourcebuilder.AzureProviderSpec().WithZone("us-east-1b")
 
-	usEast1dProviderSpecBuilderAzure = resourcebuilder.AzureProviderSpec().WithZone("us-east-1d")
+		usEast1cProviderSpecBuilderAzure = resourcebuilder.AzureProviderSpec().WithZone("us-east-1c")
 
-	usEast1eProviderSpecBuilderAzure = resourcebuilder.AzureProviderSpec().WithZone("us-east-1e")
+		usEast1dProviderSpecBuilderAzure = resourcebuilder.AzureProviderSpec().WithZone("us-east-1d")
 
-	cpms3FailureDomainsBuilderAzure = resourcebuilder.AzureFailureDomains().WithFailureDomainBuilders(
-		usEast1aFailureDomainBuilderAzure,
-		usEast1bFailureDomainBuilderAzure,
-		usEast1cFailureDomainBuilderAzure,
+		usEast1eProviderSpecBuilderAzure = resourcebuilder.AzureProviderSpec().WithZone("us-east-1e")
+
+		cpms3FailureDomainsBuilderAzure = resourcebuilder.AzureFailureDomains().WithFailureDomainBuilders(
+			usEast1aFailureDomainBuilderAzure,
+			usEast1bFailureDomainBuilderAzure,
+			usEast1cFailureDomainBuilderAzure,
+		)
+
+		cpms5FailureDomainsBuilderAzure = resourcebuilder.AzureFailureDomains().WithFailureDomainBuilders(
+			usEast1aFailureDomainBuilderAzure,
+			usEast1bFailureDomainBuilderAzure,
+			usEast1cFailureDomainBuilderAzure,
+			usEast1dFailureDomainBuilderAzure,
+			usEast1eFailureDomainBuilderAzure,
+		)
+
+		cpmsInactive3FDsBuilderAzure = resourcebuilder.ControlPlaneMachineSet().
+						WithState(machinev1.ControlPlaneMachineSetStateInactive).
+						WithMachineTemplateBuilder(
+				resourcebuilder.OpenShiftMachineV1Beta1Template().
+					WithProviderSpecBuilder(
+						usEast1aProviderSpecBuilderAzure.WithZone("").WithVMSize("defaultinstancetype"),
+					).
+					WithFailureDomainsBuilder(resourcebuilder.AzureFailureDomains().WithFailureDomainBuilders(
+						usEast1aFailureDomainBuilderAzure,
+						usEast1bFailureDomainBuilderAzure,
+						usEast1cFailureDomainBuilderAzure,
+					)),
+			)
+
+		cpmsInactive5FDsBuilderAzure = resourcebuilder.ControlPlaneMachineSet().
+						WithState(machinev1.ControlPlaneMachineSetStateInactive).
+						WithMachineTemplateBuilder(
+				resourcebuilder.OpenShiftMachineV1Beta1Template().
+					WithProviderSpecBuilder(
+						usEast1aProviderSpecBuilderAzure.WithZone("").WithVMSize("defaultinstancetype"),
+					).
+					WithFailureDomainsBuilder(resourcebuilder.AzureFailureDomains().WithFailureDomainBuilders(
+						usEast1aFailureDomainBuilderAzure,
+						usEast1bFailureDomainBuilderAzure,
+						usEast1cFailureDomainBuilderAzure,
+						usEast1dFailureDomainBuilderAzure,
+						usEast1eFailureDomainBuilderAzure,
+					)),
+			)
+
+		cpmsActiveOutdatedBuilderAzure = resourcebuilder.ControlPlaneMachineSet().
+						WithState(machinev1.ControlPlaneMachineSetStateActive).
+						WithMachineTemplateBuilder(
+				resourcebuilder.OpenShiftMachineV1Beta1Template().
+					WithProviderSpecBuilder(
+						usEast1aProviderSpecBuilderAzure.WithZone("").WithVMSize("defaultinstancetype"),
+					).
+					WithFailureDomainsBuilder(resourcebuilder.AzureFailureDomains().WithFailureDomainBuilders(
+						usEast1aFailureDomainBuilderAzure,
+						usEast1bFailureDomainBuilderAzure,
+						usEast1cFailureDomainBuilderAzure,
+					)),
+			)
+
+		cpmsActiveUpToDateBuilderAzure = resourcebuilder.ControlPlaneMachineSet().
+						WithState(machinev1.ControlPlaneMachineSetStateActive).
+						WithMachineTemplateBuilder(
+				resourcebuilder.OpenShiftMachineV1Beta1Template().
+					WithProviderSpecBuilder(
+						usEast1aProviderSpecBuilderAzure.WithZone("").WithVMSize("defaultinstancetype"),
+					).
+					WithFailureDomainsBuilder(cpms5FailureDomainsBuilderAzure),
+			)
 	)
 
-	cpms5FailureDomainsBuilderAzure = resourcebuilder.AzureFailureDomains().WithFailureDomainBuilders(
-		usEast1aFailureDomainBuilderAzure,
-		usEast1bFailureDomainBuilderAzure,
-		usEast1cFailureDomainBuilderAzure,
-		usEast1dFailureDomainBuilderAzure,
-		usEast1eFailureDomainBuilderAzure,
-	)
-
-	cpmsInactive3FDsBuilderAzure = resourcebuilder.ControlPlaneMachineSet().
-					WithState(machinev1.ControlPlaneMachineSetStateInactive).
-					WithMachineTemplateBuilder(
-			resourcebuilder.OpenShiftMachineV1Beta1Template().
-				WithProviderSpecBuilder(
-					usEast1aProviderSpecBuilderAzure.WithZone("").WithVMSize("defaultinstancetype"),
-				).
-				WithFailureDomainsBuilder(resourcebuilder.AzureFailureDomains().WithFailureDomainBuilders(
-					usEast1aFailureDomainBuilderAzure,
-					usEast1bFailureDomainBuilderAzure,
-					usEast1cFailureDomainBuilderAzure,
-				)),
-		)
-
-	cpmsInactive5FDsBuilderAzure = resourcebuilder.ControlPlaneMachineSet().
-					WithState(machinev1.ControlPlaneMachineSetStateInactive).
-					WithMachineTemplateBuilder(
-			resourcebuilder.OpenShiftMachineV1Beta1Template().
-				WithProviderSpecBuilder(
-					usEast1aProviderSpecBuilderAzure.WithZone("").WithVMSize("defaultinstancetype"),
-				).
-				WithFailureDomainsBuilder(resourcebuilder.AzureFailureDomains().WithFailureDomainBuilders(
-					usEast1aFailureDomainBuilderAzure,
-					usEast1bFailureDomainBuilderAzure,
-					usEast1cFailureDomainBuilderAzure,
-					usEast1dFailureDomainBuilderAzure,
-					usEast1eFailureDomainBuilderAzure,
-				)),
-		)
-
-	cpmsActiveOutdatedBuilderAzure = resourcebuilder.ControlPlaneMachineSet().
-					WithState(machinev1.ControlPlaneMachineSetStateActive).
-					WithMachineTemplateBuilder(
-			resourcebuilder.OpenShiftMachineV1Beta1Template().
-				WithProviderSpecBuilder(
-					usEast1aProviderSpecBuilderAzure.WithZone("").WithVMSize("defaultinstancetype"),
-				).
-				WithFailureDomainsBuilder(resourcebuilder.AzureFailureDomains().WithFailureDomainBuilders(
-					usEast1aFailureDomainBuilderAzure,
-					usEast1bFailureDomainBuilderAzure,
-					usEast1cFailureDomainBuilderAzure,
-				)),
-		)
-
-	cpmsActiveUpToDateBuilderAzure = resourcebuilder.ControlPlaneMachineSet().
-					WithState(machinev1.ControlPlaneMachineSetStateActive).
-					WithMachineTemplateBuilder(
-			resourcebuilder.OpenShiftMachineV1Beta1Template().
-				WithProviderSpecBuilder(
-					usEast1aProviderSpecBuilderAzure.WithZone("").WithVMSize("defaultinstancetype"),
-				).
-				WithFailureDomainsBuilder(cpms5FailureDomainsBuilderAzure),
-		)
-)
-
-var _ = Describe("controlplanemachinesetgenerator controller", func() {
 	var mgrCancel context.CancelFunc
 	var mgrDone chan struct{}
 	var mgr manager.Manager
@@ -1091,7 +1093,7 @@ var _ = Describe("controlplanemachinesetgenerator controller", func() {
 			BeforeEach(func() {
 				By("Creating 1 Control Plane Machine")
 				machineBuilder := resourcebuilder.Machine().AsMaster().WithNamespace(namespaceName)
-				machine2 = machineBuilder.WithProviderSpecBuilder(usEast1cProviderSpecBuilder.WithInstanceType("c5.4xlarge")).WithName("master-2").Build()
+				machine2 = machineBuilder.WithProviderSpecBuilder(usEast1cProviderSpecBuilderAzure.WithVMSize("defaultinstancetype")).WithName("master-2").Build()
 				Expect(k8sClient.Create(ctx, machine2)).To(Succeed())
 				machines := []machinev1beta1.Machine{*machine2}
 

--- a/pkg/controllers/controlplanemachinesetgenerator/controller_test.go
+++ b/pkg/controllers/controlplanemachinesetgenerator/controller_test.go
@@ -724,3 +724,573 @@ var _ = Describe("controlplanemachinesetgenerator controller", func() {
 		})
 	})
 })
+
+var (
+	usEast1aFailureDomainBuilderAzure = resourcebuilder.AzureFailureDomain().WithZone("us-east-1a")
+
+	usEast1bFailureDomainBuilderAzure = resourcebuilder.AzureFailureDomain().WithZone("us-east-1b")
+
+	usEast1cFailureDomainBuilderAzure = resourcebuilder.AzureFailureDomain().WithZone("us-east-1c")
+
+	usEast1dFailureDomainBuilderAzure = resourcebuilder.AzureFailureDomain().WithZone("us-east-1d")
+
+	usEast1eFailureDomainBuilderAzure = resourcebuilder.AzureFailureDomain().WithZone("us-east-1e")
+
+	usEast1aProviderSpecBuilderAzure = resourcebuilder.AzureProviderSpec().WithZone("us-east-1a")
+
+	usEast1bProviderSpecBuilderAzure = resourcebuilder.AzureProviderSpec().WithZone("us-east-1b")
+
+	usEast1cProviderSpecBuilderAzure = resourcebuilder.AzureProviderSpec().WithZone("us-east-1c")
+
+	usEast1dProviderSpecBuilderAzure = resourcebuilder.AzureProviderSpec().WithZone("us-east-1d")
+
+	usEast1eProviderSpecBuilderAzure = resourcebuilder.AzureProviderSpec().WithZone("us-east-1e")
+
+	cpms3FailureDomainsBuilderAzure = resourcebuilder.AzureFailureDomains().WithFailureDomainBuilders(
+		usEast1aFailureDomainBuilderAzure,
+		usEast1bFailureDomainBuilderAzure,
+		usEast1cFailureDomainBuilderAzure,
+	)
+
+	cpms5FailureDomainsBuilderAzure = resourcebuilder.AzureFailureDomains().WithFailureDomainBuilders(
+		usEast1aFailureDomainBuilderAzure,
+		usEast1bFailureDomainBuilderAzure,
+		usEast1cFailureDomainBuilderAzure,
+		usEast1dFailureDomainBuilderAzure,
+		usEast1eFailureDomainBuilderAzure,
+	)
+
+	cpmsInactive3FDsBuilderAzure = resourcebuilder.ControlPlaneMachineSet().
+					WithState(machinev1.ControlPlaneMachineSetStateInactive).
+					WithMachineTemplateBuilder(
+			resourcebuilder.OpenShiftMachineV1Beta1Template().
+				WithProviderSpecBuilder(
+					usEast1aProviderSpecBuilderAzure.WithZone("").WithVMSize("defaultinstancetype"),
+				).
+				WithFailureDomainsBuilder(resourcebuilder.AzureFailureDomains().WithFailureDomainBuilders(
+					usEast1aFailureDomainBuilderAzure,
+					usEast1bFailureDomainBuilderAzure,
+					usEast1cFailureDomainBuilderAzure,
+				)),
+		)
+
+	cpmsInactive5FDsBuilderAzure = resourcebuilder.ControlPlaneMachineSet().
+					WithState(machinev1.ControlPlaneMachineSetStateInactive).
+					WithMachineTemplateBuilder(
+			resourcebuilder.OpenShiftMachineV1Beta1Template().
+				WithProviderSpecBuilder(
+					usEast1aProviderSpecBuilderAzure.WithZone("").WithVMSize("defaultinstancetype"),
+				).
+				WithFailureDomainsBuilder(resourcebuilder.AzureFailureDomains().WithFailureDomainBuilders(
+					usEast1aFailureDomainBuilderAzure,
+					usEast1bFailureDomainBuilderAzure,
+					usEast1cFailureDomainBuilderAzure,
+					usEast1dFailureDomainBuilderAzure,
+					usEast1eFailureDomainBuilderAzure,
+				)),
+		)
+
+	cpmsActiveOutdatedBuilderAzure = resourcebuilder.ControlPlaneMachineSet().
+					WithState(machinev1.ControlPlaneMachineSetStateActive).
+					WithMachineTemplateBuilder(
+			resourcebuilder.OpenShiftMachineV1Beta1Template().
+				WithProviderSpecBuilder(
+					usEast1aProviderSpecBuilderAzure.WithZone("").WithVMSize("defaultinstancetype"),
+				).
+				WithFailureDomainsBuilder(resourcebuilder.AzureFailureDomains().WithFailureDomainBuilders(
+					usEast1aFailureDomainBuilderAzure,
+					usEast1bFailureDomainBuilderAzure,
+					usEast1cFailureDomainBuilderAzure,
+				)),
+		)
+
+	cpmsActiveUpToDateBuilderAzure = resourcebuilder.ControlPlaneMachineSet().
+					WithState(machinev1.ControlPlaneMachineSetStateActive).
+					WithMachineTemplateBuilder(
+			resourcebuilder.OpenShiftMachineV1Beta1Template().
+				WithProviderSpecBuilder(
+					usEast1aProviderSpecBuilderAzure.WithZone("").WithVMSize("defaultinstancetype"),
+				).
+				WithFailureDomainsBuilder(cpms5FailureDomainsBuilderAzure),
+		)
+)
+
+var _ = Describe("controlplanemachinesetgenerator controller", func() {
+	var mgrCancel context.CancelFunc
+	var mgrDone chan struct{}
+	var mgr manager.Manager
+	var reconciler *ControlPlaneMachineSetGeneratorReconciler
+
+	var namespaceName string
+	var cpms *machinev1.ControlPlaneMachineSet
+	var machine0, machine1, machine2 *machinev1beta1.Machine
+	var machineSet0, machineSet1, machineSet2, machineSet3, machineSet4 *machinev1beta1.MachineSet
+
+	startManager := func(mgr *manager.Manager) (context.CancelFunc, chan struct{}) {
+		mgrCtx, mgrCancel := context.WithCancel(context.Background())
+		mgrDone := make(chan struct{})
+
+		go func() {
+			defer GinkgoRecover()
+			defer close(mgrDone)
+
+			Expect((*mgr).Start(mgrCtx)).To(Succeed())
+		}()
+
+		return mgrCancel, mgrDone
+	}
+
+	stopManager := func() {
+		mgrCancel()
+		// Wait for the mgrDone to be closed, which will happen once the mgr has stopped
+		<-mgrDone
+	}
+
+	create3MachineSets := func() {
+		machineSetBuilder := resourcebuilder.MachineSet().WithNamespace(namespaceName)
+		machineSet0 = machineSetBuilder.WithProviderSpecBuilder(usEast1aProviderSpecBuilderAzure).WithGenerateName("machineset-us-east-1a-").Build()
+		machineSet1 = machineSetBuilder.WithProviderSpecBuilder(usEast1bProviderSpecBuilderAzure).WithGenerateName("machineset-us-east-1b-").Build()
+		machineSet2 = machineSetBuilder.WithProviderSpecBuilder(usEast1cProviderSpecBuilderAzure).WithGenerateName("machineset-us-east-1c-").Build()
+
+		Expect(k8sClient.Create(ctx, machineSet0)).To(Succeed())
+		Expect(k8sClient.Create(ctx, machineSet1)).To(Succeed())
+		Expect(k8sClient.Create(ctx, machineSet2)).To(Succeed())
+	}
+
+	create5MachineSets := func() {
+		create3MachineSets()
+
+		machineSetBuilder := resourcebuilder.MachineSet().WithNamespace(namespaceName)
+		machineSet3 = machineSetBuilder.WithProviderSpecBuilder(usEast1dProviderSpecBuilderAzure).WithGenerateName("machineset-us-east-1d-").Build()
+		machineSet4 = machineSetBuilder.WithProviderSpecBuilder(usEast1eProviderSpecBuilderAzure).WithGenerateName("machineset-us-east-1e-").Build()
+
+		Expect(k8sClient.Create(ctx, machineSet3)).To(Succeed())
+		Expect(k8sClient.Create(ctx, machineSet4)).To(Succeed())
+	}
+
+	create3CPMachines := func() *[]machinev1beta1.Machine {
+		// Create 3 control plane machines with differing Provider Specs,
+		// so then we can reliably check which machine Provider Spec is picked for the ControlPlaneMachineSet.
+		machineBuilder := resourcebuilder.Machine().AsMaster().WithNamespace(namespaceName)
+		machine0 = machineBuilder.WithProviderSpecBuilder(usEast1aProviderSpecBuilderAzure.WithVMSize("defaultinstancetype")).WithName("master-0").Build()
+		machine1 = machineBuilder.WithProviderSpecBuilder(usEast1bProviderSpecBuilderAzure.WithVMSize("defaultinstancetype")).WithName("master-1").Build()
+		machine2 = machineBuilder.WithProviderSpecBuilder(usEast1cProviderSpecBuilderAzure.WithVMSize("defaultinstancetype")).WithName("master-2").Build()
+
+		// Create Machines with some wait time between them
+		// to achieve staggered CreationTimestamp(s).
+		Expect(k8sClient.Create(ctx, machine0)).To(Succeed())
+		Expect(k8sClient.Create(ctx, machine1)).To(Succeed())
+		Expect(k8sClient.Create(ctx, machine2)).To(Succeed())
+
+		return &[]machinev1beta1.Machine{*machine0, *machine1, *machine2}
+	}
+
+	createUsEast1dMachine := func() *machinev1beta1.Machine {
+		machineBuilder := resourcebuilder.Machine().AsMaster().WithNamespace(namespaceName)
+		machine := machineBuilder.WithProviderSpecBuilder(usEast1dProviderSpecBuilderAzure.WithVMSize("defaultinstancetype")).WithName("master-3").Build()
+
+		Expect(k8sClient.Create(ctx, machine)).To(Succeed())
+
+		return machine
+	}
+
+	createUsEast1eMachine := func() *machinev1beta1.Machine {
+		machineBuilder := resourcebuilder.Machine().AsMaster().WithNamespace(namespaceName)
+		machine := machineBuilder.WithProviderSpecBuilder(usEast1eProviderSpecBuilderAzure.WithVMSize("defaultinstancetype")).WithName("master-4").Build()
+
+		Expect(k8sClient.Create(ctx, machine)).To(Succeed())
+
+		return machine
+	}
+
+	BeforeEach(func() {
+
+		By("Setting up a namespace for the test")
+		ns := resourcebuilder.Namespace().WithGenerateName("control-plane-machine-set-controller-").Build()
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+		namespaceName = ns.GetName()
+
+		By("Setting up a new infrastructure for the test")
+		// Create infrastructure object.
+		infra := resourcebuilder.Infrastructure().WithName(infrastructureName).AsAzure("test").Build()
+		infraStatus := infra.Status.DeepCopy()
+		Expect(k8sClient.Create(ctx, infra)).To(Succeed())
+		// Update Infrastructure Status.
+		Eventually(komega.UpdateStatus(infra, func() {
+			infra.Status = *infraStatus
+		})).Should(Succeed())
+
+		By("Setting up a manager and controller")
+		var err error
+		mgr, err = ctrl.NewManager(cfg, ctrl.Options{
+			Scheme:             testScheme,
+			MetricsBindAddress: "0",
+			Port:               testEnv.WebhookInstallOptions.LocalServingPort,
+			Host:               testEnv.WebhookInstallOptions.LocalServingHost,
+			CertDir:            testEnv.WebhookInstallOptions.LocalServingCertDir,
+		})
+		Expect(err).ToNot(HaveOccurred(), "Manager should be able to be created")
+		reconciler = &ControlPlaneMachineSetGeneratorReconciler{
+			Client:    mgr.GetClient(),
+			Namespace: namespaceName,
+		}
+		Expect(reconciler.SetupWithManager(mgr)).To(Succeed(), "Reconciler should be able to setup with manager")
+
+	})
+
+	AfterEach(func() {
+		test.CleanupResources(Default, ctx, cfg, k8sClient, namespaceName,
+			&corev1.Node{},
+			&machinev1beta1.Machine{},
+			&configv1.Infrastructure{},
+			&machinev1beta1.MachineSet{},
+			&machinev1.ControlPlaneMachineSet{},
+		)
+	})
+
+	JustBeforeEach(func() {
+		By("Starting the manager")
+		mgrCancel, mgrDone = startManager(&mgr)
+	})
+
+	JustAfterEach(func() {
+		By("Stopping the manager")
+		stopManager()
+	})
+
+	Context("when a Control Plane Machine Set doesn't exist", func() {
+		BeforeEach(func() {
+			cpms = &machinev1.ControlPlaneMachineSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      clusterControlPlaneMachineSetName,
+					Namespace: namespaceName,
+				},
+			}
+		})
+
+		Context("with 5 Machine Sets", func() {
+			BeforeEach(func() {
+				By("Creating MachineSets")
+				create5MachineSets()
+			})
+
+			Context("with 3 existing control plane machines", func() {
+				BeforeEach(func() {
+					By("Creating Control Plane Machines")
+					create3CPMachines()
+				})
+
+				It("should create the ControlPlaneMachineSet with the expected fields", func() {
+					By("Checking the Control Plane Machine Set has been created")
+					Eventually(komega.Get(cpms)).Should(Succeed())
+					Expect(cpms.Spec.State).To(Equal(machinev1.ControlPlaneMachineSetStateInactive))
+					Expect(*cpms.Spec.Replicas).To(Equal(int32(3)))
+				})
+
+				It("should create the ControlPlaneMachineSet with the provider spec matching the youngest machine provider spec", func() {
+					By("Checking the Control Plane Machine Set has been created")
+					Eventually(komega.Get(cpms)).Should(Succeed())
+					// In this case expect the machine Provider Spec of the youngest machine to be used here.
+					// In this case it should be `machine-2` given that's the one we created last.
+					cpmsProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec)
+					Expect(err).To(BeNil())
+
+					machineProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(machine2.Spec)
+					Expect(err).To(BeNil())
+
+					// Remove from the machine Provider Spec the fields that won't be
+					// present on the ControlPlaneMachineSet Provider Spec.
+					azureMachineProviderConfig := machineProviderSpec.Azure().Config()
+					azureMachineProviderConfig.Zone = nil
+
+					Expect(cpmsProviderSpec.Azure().Config()).To(Equal(azureMachineProviderConfig))
+				})
+
+				Context("With additional MachineSets duplicating failure domains", func() {
+					BeforeEach(func() {
+						By("Creating additional MachineSets")
+						create3MachineSets()
+					})
+
+					It("should create the ControlPlaneMachineSet with only one copy of each failure domain", func() {
+						By("Checking the Control Plane Machine Set has been created")
+						Eventually(komega.Get(cpms)).Should(Succeed())
+
+						Expect(cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.FailureDomains).To(Equal(cpms5FailureDomainsBuilderAzure.BuildFailureDomains()))
+					})
+				})
+			})
+		})
+
+		Context("with 3 Machine Sets", func() {
+			BeforeEach(func() {
+				By("Creating MachineSets")
+				create3MachineSets()
+			})
+
+			Context("with 3 existing control plane machines", func() {
+				BeforeEach(func() {
+					By("Creating Control Plane Machines")
+					create3CPMachines()
+				})
+
+				It("should create the ControlPlaneMachineSet with the expected fields", func() {
+					By("Checking the Control Plane Machine Set has been created")
+					Eventually(komega.Get(cpms)).Should(Succeed())
+					Expect(cpms.Spec.State).To(Equal(machinev1.ControlPlaneMachineSetStateInactive))
+					Expect(*cpms.Spec.Replicas).To(Equal(int32(3)))
+				})
+
+				It("should create the ControlPlaneMachineSet with the provider spec matching the youngest machine provider spec", func() {
+					By("Checking the Control Plane Machine Set has been created")
+					Eventually(komega.Get(cpms)).Should(Succeed())
+					// In this case expect the machine Provider Spec of the youngest machine to be used here.
+					// In this case it should be `machine-2` given that's the one we created last.
+					cpmsProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec)
+					Expect(err).To(BeNil())
+
+					machineProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(machine2.Spec)
+					Expect(err).To(BeNil())
+
+					// Remove from the machine Provider Spec the fields that won't be
+					// present on the ControlPlaneMachineSet Provider Spec.
+					azureMachineProviderConfig := machineProviderSpec.Azure().Config()
+					azureMachineProviderConfig.Zone = nil
+
+					Expect(cpmsProviderSpec.Azure().Config()).To(Equal(azureMachineProviderConfig))
+				})
+
+				It("should create the ControlPlaneMachineSet with only one copy of each of the 3 failure domains", func() {
+					By("Checking the Control Plane Machine Set has been created")
+					Eventually(komega.Get(cpms)).Should(Succeed())
+
+					Expect(cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.FailureDomains).To(Equal(cpms3FailureDomainsBuilderAzure.BuildFailureDomains()))
+				})
+
+				Context("With additional Machines adding additional failure domains", func() {
+					BeforeEach(func() {
+						By("Creating additional Machines")
+						createUsEast1dMachine()
+						createUsEast1eMachine()
+					})
+
+					It("should create the ControlPlaneMachineSet with only one copy of each the 5 failure domains", func() {
+						By("Checking the Control Plane Machine Set has been created")
+						Eventually(komega.Get(cpms)).Should(Succeed())
+
+						Expect(cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.FailureDomains).To(Equal(cpms5FailureDomainsBuilderAzure.BuildFailureDomains()))
+					})
+				})
+			})
+		})
+
+		Context("with only 1 existing control plane machine", func() {
+			var logger test.TestLogger
+			isSupportedControlPlaneMachinesNumber := false
+
+			BeforeEach(func() {
+				By("Creating 1 Control Plane Machine")
+				machineBuilder := resourcebuilder.Machine().AsMaster().WithNamespace(namespaceName)
+				machine2 = machineBuilder.WithProviderSpecBuilder(usEast1cProviderSpecBuilder.WithInstanceType("c5.4xlarge")).WithName("master-2").Build()
+				Expect(k8sClient.Create(ctx, machine2)).To(Succeed())
+				machines := []machinev1beta1.Machine{*machine2}
+
+				By("Invoking the check on whether the number of control plane machines in the cluster is supported")
+				logger = test.NewTestLogger()
+				isSupportedControlPlaneMachinesNumber = reconciler.isSupportedControlPlaneMachinesNumber(logger.Logger(), machines)
+			})
+
+			It("should have not created the ControlPlaneMachineSet", func() {
+				Consistently(komega.Get(cpms)).Should(MatchError("controlplanemachinesets.machine.openshift.io \"" + clusterControlPlaneMachineSetName + "\" not found"))
+			})
+
+			It("should detect the cluster has an unsupported number of control plane machines", func() {
+				Expect(isSupportedControlPlaneMachinesNumber).To(BeFalse())
+			})
+
+			It("sets an appropriate log line", func() {
+				Eventually(logger.Entries()).Should(ConsistOf(
+					test.LogEntry{
+						Level:         1,
+						KeysAndValues: []interface{}{"count", 1},
+						Message:       unsupportedNumberOfControlPlaneMachines,
+					},
+				))
+			})
+
+		})
+
+		Context("with an unsupported platform", func() {
+			var logger test.TestLogger
+			BeforeEach(func() {
+				By("Creating MachineSets")
+				create5MachineSets()
+
+				By("Creating Control Plane Machines")
+				machines := create3CPMachines()
+
+				logger = test.NewTestLogger()
+				generatedCPMS, err := reconciler.generateControlPlaneMachineSet(logger.Logger(), configv1.NonePlatformType, *machines, nil)
+				Expect(generatedCPMS).To(BeNil())
+				Expect(err).To(MatchError(errUnsupportedPlatform))
+			})
+
+			It("should have not created the ControlPlaneMachineSet", func() {
+				Consistently(komega.Get(cpms)).Should(MatchError("controlplanemachinesets.machine.openshift.io \"" + clusterControlPlaneMachineSetName + "\" not found"))
+			})
+
+			It("sets an appropriate log line", func() {
+				Eventually(logger.Entries()).Should(ConsistOf(
+					test.LogEntry{
+						Level:         1,
+						KeysAndValues: []interface{}{"platform", configv1.NonePlatformType},
+						Message:       unsupportedPlatform,
+					},
+				))
+			})
+
+		})
+	})
+
+	Context("when a Control Plane Machine Set exists with 5 Machine Sets", func() {
+		BeforeEach(func() {
+			By("Creating MachineSets")
+			create5MachineSets()
+			By("Creating Control Plane Machines")
+			create3CPMachines()
+		})
+
+		Context("with state Inactive and outdated", func() {
+			BeforeEach(func() {
+				By("Creating an outdated and Inactive Control Plane Machine Set")
+				// Create an Inactive ControlPlaneMachineSet with a Provider Spec that
+				// doesn't match the one of the youngest control plane machine (i.e. it's outdated).
+				cpms = cpmsInactive3FDsBuilderAzure.WithNamespace(namespaceName).Build()
+				Expect(k8sClient.Create(ctx, cpms)).To(Succeed())
+			})
+
+			It("should recreate ControlPlaneMachineSet with the provider spec matching the youngest machine provider spec", func() {
+				// In this case expect the machine Provider Spec of the youngest machine to be used here.
+				// In this case it should be `machine-1` given that's the one we created last.
+				machineProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(machine2.Spec)
+				Expect(err).To(BeNil())
+
+				// Remove from the machine Provider Spec the fields that won't be
+				// present on the ControlPlaneMachineSet Provider Spec.
+				azureMachineProviderConfig := machineProviderSpec.Azure().Config()
+				azureMachineProviderConfig.Zone = nil
+
+				oldUID := cpms.UID
+
+				Eventually(komega.Object(cpms), time.Second*30).Should(
+					HaveField("Spec.Template.OpenShiftMachineV1Beta1Machine.Spec",
+						WithTransform(func(in machinev1beta1.MachineSpec) machinev1beta1.AzureMachineProviderSpec {
+							mPS, err := providerconfig.NewProviderConfigFromMachineSpec(in)
+							if err != nil {
+								return machinev1beta1.AzureMachineProviderSpec{}
+							}
+
+							return mPS.Azure().Config()
+						}, Equal(azureMachineProviderConfig))),
+					"The control plane machine provider spec should match the youngest machine's provider spec",
+				)
+
+				Expect(oldUID).NotTo(Equal(cpms.UID),
+					"The control plane machine set UID should differ with the old one, as it should've been deleted and recreated")
+			})
+
+			Context("With additional MachineSets duplicating failure domains", func() {
+				BeforeEach(func() {
+					By("Creating additional MachineSets")
+					create3MachineSets()
+				})
+
+				It("should update, but not duplicate the failure domains on the ControlPlaneMachineSet", func() {
+					Eventually(komega.Object(cpms)).Should(HaveField("Spec.Template.OpenShiftMachineV1Beta1Machine.FailureDomains", Equal(cpms5FailureDomainsBuilderAzure.BuildFailureDomains())))
+				})
+			})
+		})
+
+		Context("with state Inactive and up to date", func() {
+			BeforeEach(func() {
+				By("Creating an up to date and Inactive Control Plane Machine Set")
+				// Create an Inactive ControlPlaneMachineSet with a Provider Spec that
+				// match the youngest control plane machine (i.e. it's up to date).
+				cpms = cpmsInactive5FDsBuilderAzure.WithNamespace(namespaceName).Build()
+				Expect(k8sClient.Create(ctx, cpms)).To(Succeed())
+			})
+
+			It("should keep the ControlPlaneMachineSet up to date and not change it", func() {
+				cpmsVersion := cpms.ObjectMeta.ResourceVersion
+				Consistently(komega.Object(cpms)).Should(HaveField("ObjectMeta.ResourceVersion", cpmsVersion))
+			})
+
+		})
+
+		Context("with state Active and outdated", func() {
+			BeforeEach(func() {
+				By("Creating an outdated and Active Control Plane Machine Set")
+				// Create an Active ControlPlaneMachineSet with a Provider Spec that
+				// doesn't match the one of the youngest control plane machine (i.e. it's outdated).
+				cpms = cpmsActiveOutdatedBuilderAzure.WithNamespace(namespaceName).Build()
+				Expect(k8sClient.Create(ctx, cpms)).To(Succeed())
+			})
+
+			It("should keep the CPMS unchanged", func() {
+				cpmsVersion := cpms.ObjectMeta.ResourceVersion
+				Consistently(komega.Object(cpms)).Should(HaveField("ObjectMeta.ResourceVersion", cpmsVersion))
+			})
+		})
+
+		Context("with state Active and up to date", func() {
+			BeforeEach(func() {
+				By("Creating an up to date and Active Control Plane Machine Set")
+				// Create an Active ControlPlaneMachineSet with a Provider Spec that
+				// doesn't match the one of the youngest control plane machine (i.e. it's up to date).
+				cpms = cpmsActiveUpToDateBuilderAzure.WithNamespace(namespaceName).Build()
+				Expect(k8sClient.Create(ctx, cpms)).To(Succeed())
+			})
+
+			It("should keep the ControlPlaneMachineSet unchanged", func() {
+				cpmsVersion := cpms.ObjectMeta.ResourceVersion
+				Consistently(komega.Object(cpms)).Should(HaveField("ObjectMeta.ResourceVersion", cpmsVersion))
+			})
+
+		})
+	})
+
+	Context("when a Control Plane Machine Set exists with 3 Machine Sets", func() {
+		BeforeEach(func() {
+			By("Creating MachineSets")
+			create3MachineSets()
+			By("Creating Control Plane Machines")
+			create3CPMachines()
+		})
+
+		Context("with state Inactive and outdated", func() {
+			BeforeEach(func() {
+				By("Creating an outdated and Inactive Control Plane Machine Set")
+				// Create an Inactive ControlPlaneMachineSet with a Provider Spec that
+				// doesn't match the failure domains configured.
+				cpms = cpmsInactive5FDsBuilderAzure.WithNamespace(namespaceName).Build()
+				Expect(k8sClient.Create(ctx, cpms)).To(Succeed())
+			})
+
+			It("should update ControlPlaneMachineSet with the expected failure domains", func() {
+				Eventually(komega.Object(cpms)).Should(HaveField("Spec.Template.OpenShiftMachineV1Beta1Machine.FailureDomains", Equal(cpms3FailureDomainsBuilderAzure.BuildFailureDomains())))
+			})
+
+			Context("With additional Machines adding additional failure domains", func() {
+				BeforeEach(func() {
+					By("Creating additional MachineSets")
+					createUsEast1dMachine()
+					createUsEast1eMachine()
+				})
+
+				It("should include additional failure domains from Machines, not present in the Machine Sets", func() {
+					Eventually(komega.Object(cpms)).Should(HaveField("Spec.Template.OpenShiftMachineV1Beta1Machine.FailureDomains", Equal(cpms5FailureDomainsBuilderAzure.BuildFailureDomains())))
+				})
+			})
+		})
+	})
+})

--- a/pkg/controllers/controlplanemachinesetgenerator/utils_test.go
+++ b/pkg/controllers/controlplanemachinesetgenerator/utils_test.go
@@ -103,6 +103,39 @@ var _ = Describe("mergeMachineSlices tests", func() {
 })
 
 var _ = Describe("compareControlPlaneMachineSets tests", func() {
+
+	var (
+		usEast1aSubnetAWS = machinev1beta1.AWSResourceReference{
+			Filters: []machinev1beta1.Filter{
+				{
+					Name: "tag:Name",
+					Values: []string{
+						"subnet-us-east-1a",
+					},
+				},
+			},
+		}
+
+		usEast1bSubnetAWS = machinev1beta1.AWSResourceReference{
+			Filters: []machinev1beta1.Filter{
+				{
+					Name: "tag:Name",
+					Values: []string{
+						"subnet-us-east-1b",
+					},
+				},
+			},
+		}
+
+		usEast1aProviderSpecBuilderAWS = resourcebuilder.AWSProviderSpec().
+						WithAvailabilityZone("us-east-1a").
+						WithSubnet(usEast1aSubnetAWS)
+
+		usEast1bProviderSpecBuilderAWS = resourcebuilder.AWSProviderSpec().
+						WithAvailabilityZone("us-east-1b").
+						WithSubnet(usEast1bSubnetAWS)
+	)
+
 	type compareControlPlaneMachineSetsTableInput struct {
 		platformType  configv1.PlatformType
 		cpmsABuilder  resourcebuilder.ControlPlaneMachineSetInterface
@@ -110,14 +143,6 @@ var _ = Describe("compareControlPlaneMachineSets tests", func() {
 		expectedError error
 		expectedDiff  []string
 	}
-
-	usEast1aProviderSpecBuilder = resourcebuilder.AWSProviderSpec().
-		WithAvailabilityZone("us-east-1a").
-		WithSubnet(usEast1aSubnet)
-
-	usEast1bProviderSpecBuilder = resourcebuilder.AWSProviderSpec().
-		WithAvailabilityZone("us-east-1b").
-		WithSubnet(usEast1bSubnet)
 
 	DescribeTable("when comparing two ControlPlaneMachineSets",
 		func(in compareControlPlaneMachineSetsTableInput) {
@@ -140,11 +165,11 @@ var _ = Describe("compareControlPlaneMachineSets tests", func() {
 			platformType: configv1.AWSPlatformType,
 			cpmsABuilder: resourcebuilder.ControlPlaneMachineSet().WithMachineTemplateBuilder(resourcebuilder.OpenShiftMachineV1Beta1Template().
 				WithProviderSpecBuilder(
-					usEast1aProviderSpecBuilder,
+					usEast1aProviderSpecBuilderAWS,
 				)),
 			cpmsBBuilder: resourcebuilder.ControlPlaneMachineSet().WithMachineTemplateBuilder(resourcebuilder.OpenShiftMachineV1Beta1Template().
 				WithProviderSpecBuilder(
-					usEast1bProviderSpecBuilder,
+					usEast1bProviderSpecBuilderAWS,
 				)),
 			expectedError: nil,
 			expectedDiff: []string{
@@ -156,11 +181,11 @@ var _ = Describe("compareControlPlaneMachineSets tests", func() {
 			platformType: configv1.AWSPlatformType,
 			cpmsABuilder: resourcebuilder.ControlPlaneMachineSet().WithMachineTemplateBuilder(resourcebuilder.OpenShiftMachineV1Beta1Template().
 				WithProviderSpecBuilder(
-					usEast1aProviderSpecBuilder.WithInstanceType("c5.large"),
+					usEast1aProviderSpecBuilderAWS.WithInstanceType("c5.large"),
 				)),
 			cpmsBBuilder: resourcebuilder.ControlPlaneMachineSet().WithMachineTemplateBuilder(resourcebuilder.OpenShiftMachineV1Beta1Template().
 				WithProviderSpecBuilder(
-					usEast1aProviderSpecBuilder.WithInstanceType("c5.xlarge"),
+					usEast1aProviderSpecBuilderAWS.WithInstanceType("c5.xlarge"),
 				)),
 			expectedError: nil,
 			expectedDiff: []string{
@@ -175,7 +200,7 @@ var _ = Describe("compareControlPlaneMachineSets tests", func() {
 				)),
 			cpmsBBuilder: resourcebuilder.ControlPlaneMachineSet().WithMachineTemplateBuilder(resourcebuilder.OpenShiftMachineV1Beta1Template().
 				WithProviderSpecBuilder(
-					usEast1aProviderSpecBuilder.WithInstanceType("c5.xlarge"),
+					usEast1aProviderSpecBuilderAWS.WithInstanceType("c5.xlarge"),
 				)),
 			expectedError: fmt.Errorf("failed to extract providerSpec from MachineSpec: %w",
 				fmt.Errorf("could not determine platform type: %w", errNilProviderSpec)),
@@ -185,7 +210,7 @@ var _ = Describe("compareControlPlaneMachineSets tests", func() {
 			platformType: configv1.AWSPlatformType,
 			cpmsABuilder: resourcebuilder.ControlPlaneMachineSet().WithMachineTemplateBuilder(resourcebuilder.OpenShiftMachineV1Beta1Template().
 				WithProviderSpecBuilder(
-					usEast1aProviderSpecBuilder.WithInstanceType("c5.xlarge"),
+					usEast1aProviderSpecBuilderAWS.WithInstanceType("c5.xlarge"),
 				)),
 			cpmsBBuilder: resourcebuilder.ControlPlaneMachineSet().WithMachineTemplateBuilder(resourcebuilder.OpenShiftMachineV1Beta1Template().
 				WithProviderSpecBuilder(

--- a/pkg/test/resourcebuilder/infrastructure.go
+++ b/pkg/test/resourcebuilder/infrastructure.go
@@ -84,6 +84,30 @@ func (i InfrastructureBuilder) AsAWS(name string, region string) InfrastructureB
 	return i
 }
 
+// AsAzure sets the Status for the infrastructure builder.
+func (i InfrastructureBuilder) AsAzure(name string) InfrastructureBuilder {
+	i.spec = &configv1.InfrastructureSpec{
+		PlatformSpec: configv1.PlatformSpec{
+			Type:  "Azure",
+			Azure: &configv1.AzurePlatformSpec{},
+		},
+	}
+	i.status = &configv1.InfrastructureStatus{
+		InfrastructureName:     name,
+		APIServerURL:           "https://api.test-cluster.test-domain:6443",
+		APIServerInternalURL:   "https://api-int.test-cluster.test-domain:6443",
+		EtcdDiscoveryDomain:    "",
+		ControlPlaneTopology:   configv1.HighlyAvailableTopologyMode,
+		InfrastructureTopology: configv1.HighlyAvailableTopologyMode,
+		PlatformStatus: &configv1.PlatformStatus{
+			Type:  "Azure",
+			Azure: &configv1.AzurePlatformStatus{},
+		},
+	}
+
+	return i
+}
+
 // WithGenerateName sets the generateName for the infrastructure builder.
 func (i InfrastructureBuilder) WithGenerateName(generateName string) InfrastructureBuilder {
 	i.generateName = generateName


### PR DESCRIPTION
This PR adds support for clusters upgraded to 4.12+ a `ControlPlaneMachineSet` support for the Azure cloud provider. We used to not automatically create them, but now we generate the CPMS as `Inactive` in the same way we do for AWS.

This is a draft PR. Tests are yet to be implemented.