### PR TITLE
OCPBUGS-3320: Deduplicate Failure Domains for the CPMS

### DIFF
--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/failuredomain/set.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/failuredomain/set.go
@@ -28,11 +28,7 @@ type Set struct {
 // NewSet creates a new set from the given items.
 func NewSet(items ...FailureDomain) *Set {
 	s := Set{}
-
-	for _, item := range items {
-		fd := item
-		s.items = append(s.items, fd)
-	}
+	s.Insert(items...)
 
 	return &s
 }

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/failuredomain/set_test.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/failuredomain/set_test.go
@@ -65,90 +65,153 @@ var _ = Describe("Set suite", func() {
 
 			var set *Set
 
-			BeforeEach(func() {
-				By("creating a new set with 2 failure domains")
-				set = NewSet(usEast1aFailureDomain, usEast1cFailureDomain)
-			})
-
-			It("should have the initial failure domains", func() {
-				Expect(set.Has(usEast1aFailureDomain)).To(BeTrue(), "Set should contain the us-east-1a failure domain")
-				Expect(set.Has(usEast1cFailureDomain)).To(BeTrue(), "Set should contain the us-east-1c failure domain")
-			})
-
-			It("should not have other failure domains", func() {
-				Expect(set.Has(usEast1bFailureDomain)).ToNot(BeTrue(), "Set not should contain the us-east-1b failure domain")
-				Expect(set.Has(usEast1dFailureDomain)).ToNot(BeTrue(), "Set not should contain the us-east-1d failure domain")
-			})
-
-			It("should return a sorted list of the failure domains", func() {
-				Expect(set.List()).To(Equal([]FailureDomain{
-					usEast1aFailureDomain,
-					usEast1cFailureDomain,
-				}))
-			})
-
-			Context("when adding additional failure domains (separately)", func() {
-				Context("that are not already in the set", func() {
-					BeforeEach(func() {
-						set.Insert(usEast1bFailureDomain)
-						set.Insert(usEast1dFailureDomain)
-					})
-
-					It("should have the initial failure domains and the new failure domains", func() {
-						Expect(set.Has(usEast1aFailureDomain)).To(BeTrue(), "Set should contain the us-east-1a failure domain")
-						Expect(set.Has(usEast1bFailureDomain)).To(BeTrue(), "Set should contain the us-east-1b failure domain")
-						Expect(set.Has(usEast1cFailureDomain)).To(BeTrue(), "Set should contain the us-east-1c failure domain")
-						Expect(set.Has(usEast1dFailureDomain)).To(BeTrue(), "Set should contain the us-east-1d failure domain")
-					})
-
-					It("should return a sorted list of the failure domains without duplicates", func() {
-						Expect(set.List()).To(Equal([]FailureDomain{
-							usEast1aFailureDomain,
-							usEast1bFailureDomain,
-							usEast1cFailureDomain,
-							usEast1dFailureDomain,
-						}))
-					})
+			Context("with duplicate failure domains in the initial set", func() {
+				BeforeEach(func() {
+					By("creating a new set with 3 failure domains, where 2 are the same (duplicates)")
+					set = NewSet(usEast1aFailureDomain, usEast1aFailureDomain, usEast1bFailureDomain)
 				})
 
-				Context("that are not already in the set (together)", func() {
-					BeforeEach(func() {
-						set.Insert(usEast1bFailureDomain, usEast1dFailureDomain)
-					})
-
-					It("should have the initial failure domains and the new failure domains", func() {
-						Expect(set.Has(usEast1aFailureDomain)).To(BeTrue(), "Set should contain the us-east-1a failure domain")
-						Expect(set.Has(usEast1bFailureDomain)).To(BeTrue(), "Set should contain the us-east-1b failure domain")
-						Expect(set.Has(usEast1cFailureDomain)).To(BeTrue(), "Set should contain the us-east-1c failure domain")
-						Expect(set.Has(usEast1dFailureDomain)).To(BeTrue(), "Set should contain the us-east-1d failure domain")
-					})
-
-					It("should return a sorted list of the failure domains without duplicates", func() {
-						Expect(set.List()).To(Equal([]FailureDomain{
-							usEast1aFailureDomain,
-							usEast1bFailureDomain,
-							usEast1cFailureDomain,
-							usEast1dFailureDomain,
-						}))
-					})
+				It("should have the initial failure domains only once each", func() {
+					Expect(set.Has(usEast1aFailureDomain)).To(BeTrue(), "Set should contain the us-east-1a failure domain once")
+					Expect(set.Has(usEast1bFailureDomain)).To(BeTrue(), "Set should contain the us-east-1b failure domain once")
+					// We know that the set only contains us-east-1a and us-east-1b
+					Expect(len(set.List())).To(BeIdenticalTo(2))
 				})
 
-				Context("that are already in the set", func() {
-					BeforeEach(func() {
-						set.Insert(usEast1aFailureDomain)
-						set.Insert(usEast1cFailureDomain)
+				It("should not have other failure domains", func() {
+					Expect(set.Has(usEast1cFailureDomain)).ToNot(BeTrue(), "Set not should contain the us-east-1c failure domain")
+					Expect(set.Has(usEast1dFailureDomain)).ToNot(BeTrue(), "Set not should contain the us-east-1d failure domain")
+				})
+
+				Context("when adding other failure domains", func() {
+					Context("that are not yet in the set", func() {
+						BeforeEach(func() {
+							set.Insert(usEast1cFailureDomain)
+							set.Insert(usEast1dFailureDomain)
+						})
+
+						It("should have the initial failure domains and the new failure domains", func() {
+							Expect(set.Has(usEast1aFailureDomain)).To(BeTrue(), "Set should contain the us-east-1a failure domain")
+							Expect(set.Has(usEast1bFailureDomain)).To(BeTrue(), "Set should contain the us-east-1b failure domain")
+							Expect(set.Has(usEast1cFailureDomain)).To(BeTrue(), "Set should contain the us-east-1c failure domain")
+							Expect(set.Has(usEast1dFailureDomain)).To(BeTrue(), "Set should contain the us-east-1d failure domain")
+							Expect(len(set.List())).To(BeIdenticalTo(4))
+						})
+
+						It("should return a sorted list of the failure domains without duplicates", func() {
+							Expect(set.List()).To(Equal([]FailureDomain{
+								usEast1aFailureDomain,
+								usEast1bFailureDomain,
+								usEast1cFailureDomain,
+								usEast1dFailureDomain,
+							}))
+						})
 					})
 
-					It("should still have the initial failure domains", func() {
-						Expect(set.Has(usEast1aFailureDomain)).To(BeTrue(), "Set should contain the us-east-1a failure domain")
-						Expect(set.Has(usEast1cFailureDomain)).To(BeTrue(), "Set should contain the us-east-1c failure domain")
+					Context("that are already in the set", func() {
+						It("should still have the initial failure domains", func() {
+							Expect(set.Has(usEast1aFailureDomain)).To(BeTrue(), "Set should contain the us-east-1a failure domain")
+							Expect(set.Has(usEast1bFailureDomain)).To(BeTrue(), "Set should contain the us-east-1b failure domain")
+							// we know that the set will only contain eu-east-1a and eu-east-1b
+							Expect(len(set.List())).To(BeIdenticalTo(2))
+						})
+
+						It("should return a sorted list of the failure domains without duplicates", func() {
+							Expect(set.List()).To(Equal([]FailureDomain{
+								usEast1aFailureDomain,
+								usEast1bFailureDomain,
+							}))
+						})
+					})
+				})
+			})
+
+			Context("when having no initial duplicates in the set", func() {
+				BeforeEach(func() {
+					By("creating a new set with 2 failure domains")
+					set = NewSet(usEast1aFailureDomain, usEast1cFailureDomain)
+				})
+
+				It("should have the initial failure domains", func() {
+					Expect(set.Has(usEast1aFailureDomain)).To(BeTrue(), "Set should contain the us-east-1a failure domain")
+					Expect(set.Has(usEast1cFailureDomain)).To(BeTrue(), "Set should contain the us-east-1c failure domain")
+				})
+
+				It("should not have other failure domains", func() {
+					Expect(set.Has(usEast1bFailureDomain)).ToNot(BeTrue(), "Set not should contain the us-east-1b failure domain")
+					Expect(set.Has(usEast1dFailureDomain)).ToNot(BeTrue(), "Set not should contain the us-east-1d failure domain")
+				})
+
+				It("should return a sorted list of the failure domains", func() {
+					Expect(set.List()).To(Equal([]FailureDomain{
+						usEast1aFailureDomain,
+						usEast1cFailureDomain,
+					}))
+				})
+
+				Context("when adding additional failure domains (separately)", func() {
+					Context("that are not already in the set", func() {
+						BeforeEach(func() {
+							set.Insert(usEast1bFailureDomain)
+							set.Insert(usEast1dFailureDomain)
+						})
+
+						It("should have the initial failure domains and the new failure domains", func() {
+							Expect(set.Has(usEast1aFailureDomain)).To(BeTrue(), "Set should contain the us-east-1a failure domain")
+							Expect(set.Has(usEast1bFailureDomain)).To(BeTrue(), "Set should contain the us-east-1b failure domain")
+							Expect(set.Has(usEast1cFailureDomain)).To(BeTrue(), "Set should contain the us-east-1c failure domain")
+							Expect(set.Has(usEast1dFailureDomain)).To(BeTrue(), "Set should contain the us-east-1d failure domain")
+						})
+
+						It("should return a sorted list of the failure domains without duplicates", func() {
+							Expect(set.List()).To(Equal([]FailureDomain{
+								usEast1aFailureDomain,
+								usEast1bFailureDomain,
+								usEast1cFailureDomain,
+								usEast1dFailureDomain,
+							}))
+						})
 					})
 
-					It("should return a sorted list of the failure domains without duplicates", func() {
-						Expect(set.List()).To(Equal([]FailureDomain{
-							usEast1aFailureDomain,
-							usEast1cFailureDomain,
-						}))
+					Context("that are not already in the set (together)", func() {
+						BeforeEach(func() {
+							set.Insert(usEast1bFailureDomain, usEast1dFailureDomain)
+						})
+
+						It("should have the initial failure domains and the new failure domains", func() {
+							Expect(set.Has(usEast1aFailureDomain)).To(BeTrue(), "Set should contain the us-east-1a failure domain")
+							Expect(set.Has(usEast1bFailureDomain)).To(BeTrue(), "Set should contain the us-east-1b failure domain")
+							Expect(set.Has(usEast1cFailureDomain)).To(BeTrue(), "Set should contain the us-east-1c failure domain")
+							Expect(set.Has(usEast1dFailureDomain)).To(BeTrue(), "Set should contain the us-east-1d failure domain")
+						})
+
+						It("should return a sorted list of the failure domains without duplicates", func() {
+							Expect(set.List()).To(Equal([]FailureDomain{
+								usEast1aFailureDomain,
+								usEast1bFailureDomain,
+								usEast1cFailureDomain,
+								usEast1dFailureDomain,
+							}))
+						})
+					})
+
+					Context("that are already in the set", func() {
+						BeforeEach(func() {
+							set.Insert(usEast1aFailureDomain)
+							set.Insert(usEast1cFailureDomain)
+						})
+
+						It("should still have the initial failure domains", func() {
+							Expect(set.Has(usEast1aFailureDomain)).To(BeTrue(), "Set should contain the us-east-1a failure domain")
+							Expect(set.Has(usEast1cFailureDomain)).To(BeTrue(), "Set should contain the us-east-1c failure domain")
+						})
+
+						It("should return a sorted list of the failure domains without duplicates", func() {
+							Expect(set.List()).To(Equal([]FailureDomain{
+								usEast1aFailureDomain,
+								usEast1cFailureDomain,
+							}))
+						})
 					})
 				})
 			})

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/mapping.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/mapping.go
@@ -63,7 +63,9 @@ func mapMachineIndexesToFailureDomains(ctx context.Context, logger logr.Logger, 
 		return nil, fmt.Errorf("could not construct machine mapping: %w", err)
 	}
 
-	baseMapping, err := createBaseFailureDomainMapping(cpms, failureDomains, len(machineMapping))
+	failureDomainsSet := failuredomain.NewSet(failureDomains...)
+
+	baseMapping, err := createBaseFailureDomainMapping(cpms, failureDomainsSet.List(), len(machineMapping))
 	if err != nil {
 		return nil, fmt.Errorf("could not construct base failure domain mapping: %w", err)
 	}

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/mapping_test.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/mapping_test.go
@@ -588,6 +588,137 @@ var _ = Describe("Failure Domain Mapping", func() {
 					},
 				},
 			}),
+			Entry("with duplicate failure domains at the beginning of the Control Plane Machine Set", mappingMachineIndexesTableInput{
+				cpmsBuilder: cpmsBuilder,
+				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
+					usEast1aFailureDomainBuilder,
+					usEast1aFailureDomainBuilder,
+					usEast1bFailureDomainBuilder,
+					usEast1cFailureDomainBuilder,
+				).BuildFailureDomains(),
+				machines: []*machinev1beta1.Machine{
+					machineBuilder.WithName("machine-0").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-1").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-2").WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build(),
+				},
+				expectedMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+				},
+				expectedLogs: []test.LogEntry{
+					{
+						Level: 4,
+						KeysAndValues: []interface{}{
+							"mapping", fmt.Sprintf("%v", map[int32]failuredomain.FailureDomain{
+								0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+								1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+								2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+							}),
+						},
+						Message: "Mapped provided failure domains",
+					},
+				},
+			}),
+			Entry("with duplicate failure domains at the end of the Control Plane Machine Set", mappingMachineIndexesTableInput{
+				cpmsBuilder: cpmsBuilder,
+				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
+					usEast1aFailureDomainBuilder,
+					usEast1bFailureDomainBuilder,
+					usEast1cFailureDomainBuilder,
+					usEast1cFailureDomainBuilder,
+				).BuildFailureDomains(),
+				machines: []*machinev1beta1.Machine{
+					machineBuilder.WithName("machine-0").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-1").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-2").WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build(),
+				},
+				expectedMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+				},
+				expectedLogs: []test.LogEntry{
+					{
+						Level: 4,
+						KeysAndValues: []interface{}{
+							"mapping", fmt.Sprintf("%v", map[int32]failuredomain.FailureDomain{
+								0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+								1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+								2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+							}),
+						},
+						Message: "Mapped provided failure domains",
+					},
+				},
+			}),
+			Entry("with duplicate failure domains in the middle of the Control Plane Machine Set", mappingMachineIndexesTableInput{
+				cpmsBuilder: cpmsBuilder,
+				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
+					usEast1aFailureDomainBuilder,
+					usEast1bFailureDomainBuilder,
+					usEast1bFailureDomainBuilder,
+					usEast1cFailureDomainBuilder,
+				).BuildFailureDomains(),
+				machines: []*machinev1beta1.Machine{
+					machineBuilder.WithName("machine-0").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-1").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-2").WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build(),
+				},
+				expectedMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+				},
+				expectedLogs: []test.LogEntry{
+					{
+						Level: 4,
+						KeysAndValues: []interface{}{
+							"mapping", fmt.Sprintf("%v", map[int32]failuredomain.FailureDomain{
+								0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+								1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+								2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+							}),
+						},
+						Message: "Mapped provided failure domains",
+					},
+				},
+			}),
+			Entry("with multiple duplicate failure domains in the Control Plane Machine Set", mappingMachineIndexesTableInput{
+				cpmsBuilder: cpmsBuilder,
+				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
+					usEast1aFailureDomainBuilder,
+					usEast1aFailureDomainBuilder,
+					usEast1bFailureDomainBuilder,
+					usEast1bFailureDomainBuilder,
+					usEast1bFailureDomainBuilder,
+					usEast1cFailureDomainBuilder,
+					usEast1cFailureDomainBuilder,
+				).BuildFailureDomains(),
+				machines: []*machinev1beta1.Machine{
+					machineBuilder.WithName("machine-0").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-1").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build(),
+					machineBuilder.WithName("machine-2").WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build(),
+				},
+				expectedMapping: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+					1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+					2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+				},
+				expectedLogs: []test.LogEntry{
+					{
+						Level: 4,
+						KeysAndValues: []interface{}{
+							"mapping", fmt.Sprintf("%v", map[int32]failuredomain.FailureDomain{
+								0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomainBuilder.Build()),
+								1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomainBuilder.Build()),
+								2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomainBuilder.Build()),
+							}),
+						},
+						Message: "Mapped provided failure domains",
+					},
+				},
+			}),
 			Entry("when rebalancing indexes and an index only contains deleted machines", mappingMachineIndexesTableInput{
 				cpmsBuilder: cpmsBuilder,
 				failureDomains: resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(


### PR DESCRIPTION
This PR contains fix that prevents a new master node from getting spawned if we enter duplicate failure domains for CPMS.
I added just one simple case for AWS for now. If we need more, please let me know. I also think that the `set.go` file was wrong - we could have a multiset (a set, where the elements can be more than once) when using `NewSet()` - we could plug a slice that contained duplicates and it would just keep them.

Edit: Also yet to be tested it in the cluster.