### PR TITLE
[OCPCLOUD-1776]: Enable CPMS for GCP

### DIFF
--- a/pkg/test/resourcebuilder/gcp_provider_spec.go
+++ b/pkg/test/resourcebuilder/gcp_provider_spec.go
@@ -28,13 +28,15 @@ import (
 // GCPProviderSpec creates a new GCP machine config builder.
 func GCPProviderSpec() GCPProviderSpecBuilder {
 	return GCPProviderSpecBuilder{
-		zone: "us-central1-a",
+		zone:        "us-central1-a",
+		targetPools: []string{"target-pool-1", "target-pool-2"},
 	}
 }
 
 // GCPProviderSpecBuilder is used to build a GCP machine config object.
 type GCPProviderSpecBuilder struct {
-	zone string
+	zone        string
+	targetPools []string
 }
 
 // Build builds a new GCP machine config based on the configuration provided.
@@ -48,9 +50,7 @@ func (m GCPProviderSpecBuilder) Build() *machinev1beta1.GCPMachineProviderSpec {
 		UserDataSecret: &corev1.LocalObjectReference{
 			Name: "gcp-user-data-12345678",
 		},
-		TargetPools: []string{
-			"gcp-target-pool-12345678",
-		},
+		TargetPools:        m.targetPools,
 		DeletionProtection: false,
 		NetworkInterfaces: []*machinev1beta1.GCPNetworkInterface{{
 			Network:    "gcp-network-12345678",
@@ -104,5 +104,11 @@ func (m GCPProviderSpecBuilder) BuildRawExtension() *runtime.RawExtension {
 // WithZone sets the zone for the GCP machine config builder.
 func (m GCPProviderSpecBuilder) WithZone(zone string) GCPProviderSpecBuilder {
 	m.zone = zone
+	return m
+}
+
+// WithTargetPools sets the target pools for the GCP machine config builder.
+func (m GCPProviderSpecBuilder) WithTargetPools(targetPools []string) GCPProviderSpecBuilder {
+	m.targetPools = targetPools
 	return m
 }

--- a/pkg/webhooks/controlplanemachineset/webhooks.go
+++ b/pkg/webhooks/controlplanemachineset/webhooks.go
@@ -293,10 +293,16 @@ func validateOpenShiftAzureProviderConfig(parentPath *field.Path, providerConfig
 
 // validateOpenShiftGCPProviderConfig runs GCP specific checks on the provider config on the ControlPlaneMachineSet.
 // This ensure that the ControlPlaneMachineSet can safely replace GCP control plane machines.
-func validateOpenShiftGCPProviderConfig(parentPath *field.Path, _ providerconfig.GCPProviderConfig) []error {
-	// On GCP, we do not currently update the backend pools for the inernal load balancer.
-	// Until this is supported in Machine API Provider GCP, we cannot safely replace control plane machines.
-	return []error{field.Forbidden(parentPath, "automatic replacement of control plane machines on GCP is not currently supported")}
+func validateOpenShiftGCPProviderConfig(parentPath *field.Path, providerConfig providerconfig.GCPProviderConfig) []error {
+	errs := []error{}
+
+	config := providerConfig.Config()
+
+	if len(config.TargetPools) == 0 {
+		errs = append(errs, field.Required(parentPath.Child("targetPools"), "targetPools is required for control plane machines"))
+	}
+
+	return errs
 }
 
 // fetchControlPlaneMachines returns all control plane machines in the cluster.


### PR DESCRIPTION
This PR enables CPMS for GCP, which used to be forbidden before. We check, whether the `targetPools` for GCP aren't empty, if so we append an error accordingly. If everything is correct, then everything goes through just fine. Added some tests for this as well..

I have to test it manually. Will update the PR once I do that:-)