### PR TITLE
[OCPCLOUD-1781]: Ensure CPMS tests work on GCP

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -169,6 +169,8 @@ func (f *framework) IncreaseProviderSpecInstanceSize(rawProviderSpec *runtime.Ra
 		return increaseAWSInstanceSize(rawProviderSpec, providerConfig)
 	case configv1.AzurePlatformType:
 		return increaseAzureInstanceSize(rawProviderSpec, providerConfig)
+	case configv1.GCPPlatformType:
+		return increaseGCPInstanceSize(rawProviderSpec, providerConfig)
 	default:
 		return fmt.Errorf("%w: %s", errUnsupportedPlatform, f.platform)
 	}
@@ -233,6 +235,8 @@ func getPlatformSupportLevel(k8sClient runtimeclient.Client) (PlatformSupportLev
 	case configv1.AWSPlatformType:
 		return Full, platformType, nil
 	case configv1.AzurePlatformType:
+		return Manual, platformType, nil
+	case configv1.GCPPlatformType:
 		return Manual, platformType, nil
 	default:
 		return Unsupported, platformType, nil
@@ -348,6 +352,61 @@ func nextAzureVMSize(current string) (string, error) {
 	}
 
 	return fmt.Sprintf("Standard_%s%d%s%s", family, multiplier, subfamily, version), nil
+}
+
+// increaseGCPInstanceSize increases the instance size of the instance on the providerSpec for an GCP providerSpec.
+func increaseGCPInstanceSize(rawProviderSpec *runtime.RawExtension, providerConfig providerconfig.ProviderConfig) error {
+	cfg := providerConfig.GCP().Config()
+
+	var err error
+
+	cfg.MachineType, err = nextGCPMachineSize(cfg.MachineType)
+	if err != nil {
+		return fmt.Errorf("failed to get next instance size: %w", err)
+	}
+
+	if err := setProviderSpecValue(rawProviderSpec, cfg); err != nil {
+		return fmt.Errorf("failed to set provider spec value: %w", err)
+	}
+
+	return nil
+}
+
+// nextGCPVMSize returns the next GCP machine size in the series.
+// The Machine sizes being used are in format e2-standard-<number>,
+// where the number is a factor of 2 - from 2, up to 32.
+func nextGCPMachineSize(current string) (string, error) {
+	// Regex to match the GCP machine size string.
+	// e.g. e2-standard-2 --- e2-standard-32
+	re := regexp.MustCompile(`e2-standard-(?P<version>[0-9]+)`)
+
+	values := re.FindStringSubmatch(current)
+	if len(values) != 2 {
+		return "", fmt.Errorf("%w: %s", errInstanceTypeUnsupportedFormat, current)
+	}
+
+	multiplier, err := strconv.Atoi(values[1])
+	if err != nil {
+		// This is a panic because the multiplier should always be a number.
+		panic("failed to convert multiplier to int")
+	}
+
+	switch {
+	case multiplier == 2:
+		multiplier = 4
+	case multiplier == 4:
+		multiplier = 8
+	case multiplier == 8:
+		multiplier = 16
+	case multiplier == 16:
+		multiplier = 32
+	case multiplier >= 32:
+		return "", fmt.Errorf("%w: %s", errInstanceTypeNotSupported, current)
+	default:
+		multiplier *= 2
+	}
+
+	return fmt.Sprintf("e2-standard-%d", multiplier), nil
 }
 
 // setProviderSpecValue sets the value of the provider spec to the value that is passed.

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -376,7 +376,7 @@ func increaseGCPInstanceSize(rawProviderSpec *runtime.RawExtension, providerConf
 // The Machine sizes being used are in format <e2|n2|n1>-standard-<number>.
 func nextGCPMachineSize(current string) (string, error) {
 	// Regex to match the GCP machine size string.
-	re := regexp.MustCompile(`(?P<family>[0-9a-z]+)-standard-(?P<version>[0-9]+)`)
+	re := regexp.MustCompile(`(?P<family>[0-9a-z]+)-standard-(?P<multiplier>[0-9]+)`)
 
 	values := re.FindStringSubmatch(current)
 	if len(values) != 3 {
@@ -396,6 +396,8 @@ func nextGCPMachineSize(current string) (string, error) {
 
 // setNextGCPMachineSize returns the new GCP machine size in the series
 // according to the family supported (e2, n1, n2).
+//
+//nolint:cyclop
 func setNextGCPMachineSize(current, family string, multiplier int) (string, error) {
 	switch {
 	case multiplier >= 32 && family == "e2":

--- a/test/e2e/framework/framework_test.go
+++ b/test/e2e/framework/framework_test.go
@@ -124,5 +124,48 @@ var _ = Describe("Framwork", func() {
 				)
 			})
 		})
+
+		Context("On GCP", func() {
+			Context("NextGCPMachineSize", func() {
+				type nextInstanceSizeTableInput struct {
+					currentMachineSize string
+					expectedNextSize   string
+					expectedError      error
+				}
+
+				DescribeTable("should return the next VM size", func(in nextInstanceSizeTableInput) {
+					nextInstanceSize, err := nextGCPMachineSize(in.currentMachineSize)
+					if in.expectedError != nil {
+						Expect(err).To(MatchError(in.expectedError))
+					} else {
+						Expect(err).ToNot(HaveOccurred())
+					}
+
+					Expect(nextInstanceSize).To(Equal(in.expectedNextSize))
+				},
+					Entry("when the current Machine size is e2-standard-2", nextInstanceSizeTableInput{
+						currentMachineSize: "e2-standard-2",
+						expectedNextSize:   "e2-standard-4",
+					}),
+					Entry("when the current Machine size is e2-standard-4", nextInstanceSizeTableInput{
+						currentMachineSize: "e2-standard-4",
+						expectedNextSize:   "e2-standard-8",
+					}),
+					Entry("when the current Machine size is e2-standard-8", nextInstanceSizeTableInput{
+						currentMachineSize: "e2-standard-8",
+						expectedNextSize:   "e2-standard-16",
+					}),
+					Entry("when the current Machine size is e2-standard-16", nextInstanceSizeTableInput{
+						currentMachineSize: "e2-standard-16",
+						expectedNextSize:   "e2-standard-32",
+					}),
+					Entry("when the current Machine size is e2-standard-32", nextInstanceSizeTableInput{
+						currentMachineSize: "e2-standard-32",
+						expectedNextSize:   "",
+						expectedError:      fmt.Errorf("%w: e2-standard-32", errInstanceTypeNotSupported),
+					}),
+				)
+			})
+		})
 	})
 })

--- a/test/e2e/framework/framework_test.go
+++ b/test/e2e/framework/framework_test.go
@@ -143,6 +143,40 @@ var _ = Describe("Framwork", func() {
 
 					Expect(nextInstanceSize).To(Equal(in.expectedNextSize))
 				},
+					Entry("when the current Machine size is n1-standard-1", nextInstanceSizeTableInput{
+						currentMachineSize: "n1-standard-1",
+						expectedNextSize:   "n1-standard-2",
+					}),
+					Entry("when the current Machine size is n1-standard-2", nextInstanceSizeTableInput{
+						currentMachineSize: "n1-standard-2",
+						expectedNextSize:   "n1-standard-4",
+					}),
+					Entry("when the current Machine size is n1-standard-32", nextInstanceSizeTableInput{
+						currentMachineSize: "n1-standard-32",
+						expectedNextSize:   "n1-standard-64",
+					}),
+					Entry("when the current Machine size is n1-standard-64", nextInstanceSizeTableInput{
+						currentMachineSize: "n1-standard-64",
+						expectedNextSize:   "n1-standard-96",
+					}),
+					Entry("when the current Machine size is n1-standard-96", nextInstanceSizeTableInput{
+						currentMachineSize: "n1-standard-96",
+						expectedNextSize:   "",
+						expectedError:      fmt.Errorf("%w: n1-standard-96", errInstanceTypeNotSupported),
+					}),
+					Entry("when the current Machine size is n2-standard-64", nextInstanceSizeTableInput{
+						currentMachineSize: "n2-standard-64",
+						expectedNextSize:   "n2-standard-80",
+					}),
+					Entry("when the current Machine size is n2-standard-96", nextInstanceSizeTableInput{
+						currentMachineSize: "n2-standard-96",
+						expectedNextSize:   "n2-standard-128",
+					}),
+					Entry("when the current Machine size is n2-standard-128", nextInstanceSizeTableInput{
+						currentMachineSize: "n2-standard-128",
+						expectedNextSize:   "",
+						expectedError:      fmt.Errorf("%w: n2-standard-128", errInstanceTypeNotSupported),
+					}),
 					Entry("when the current Machine size is e2-standard-2", nextInstanceSizeTableInput{
 						currentMachineSize: "e2-standard-2",
 						expectedNextSize:   "e2-standard-4",


### PR DESCRIPTION
This PR adds unit tests for scaling the machine sizes on GCP cluster. Also checked whether the e2e presubmit test passes - OK, on a working GCP cluster with CPSM in `Active` state.