### PR TITLE
OCPCLOUD-1741: e2e presubmit tests: ControlPlaneMachineSet uninstall

### DIFF
--- a/test/e2e/common/machine.go
+++ b/test/e2e/common/machine.go
@@ -256,3 +256,45 @@ func waitForNewMachineRunning(ctx context.Context, oldMachine, newMachine *machi
 		},
 	)
 }
+
+// ExpectControlPlaneMachinesAllRunning checks that all the control plane machines
+// are in running phase.
+func ExpectControlPlaneMachinesAllRunning(testFramework framework.Framework) {
+	By("Checking the control plane machines are all in running phase")
+
+	machineSelector := runtimeclient.MatchingLabels(framework.ControlPlaneMachineSetSelectorLabels())
+
+	machineList := &machinev1beta1.MachineList{}
+
+	Eventually(komega.ObjectList(machineList, machineSelector)).Should(HaveField("Items",
+		HaveEach(HaveField("Status.Phase", HaveValue(Equal("Running")))),
+	), "expected all of the control plane machines to be in running phase")
+}
+
+// ExpectControlPlaneMachinesNotOwned checks that none of the control plane machines
+// have owner references.
+func ExpectControlPlaneMachinesNotOwned(testFramework framework.Framework) {
+	By("Checking that none of the control plane machines have owner references")
+
+	machineSelector := runtimeclient.MatchingLabels(framework.ControlPlaneMachineSetSelectorLabels())
+
+	machineList := &machinev1beta1.MachineList{}
+
+	Eventually(komega.ObjectList(machineList, machineSelector)).Should(HaveField("Items",
+		HaveEach(HaveField("ObjectMeta.OwnerReferences", HaveLen(0))),
+	), "expected none of the control plane machines to have owner references")
+}
+
+// ExpectControlPlaneMachinesWithoutDeletionTimestamp checks that none of the control plane machines
+// has a deletion timestamp.
+func ExpectControlPlaneMachinesWithoutDeletionTimestamp(testFramework framework.Framework) {
+	By("Checking that none of the control plane machines have a deletion timestamp")
+
+	machineSelector := runtimeclient.MatchingLabels(framework.ControlPlaneMachineSetSelectorLabels())
+
+	machineList := &machinev1beta1.MachineList{}
+
+	Eventually(komega.ObjectList(machineList, machineSelector)).Should(HaveField("Items",
+		HaveEach(HaveField("ObjectMeta.DeletionTimestamp", BeNil())),
+	), "expected none of the control plane machines to have a deletionTimestap")
+}

--- a/test/e2e/presubmit/presubmit.go
+++ b/test/e2e/presubmit/presubmit.go
@@ -174,3 +174,15 @@ func ItShouldNotOnDeleteReplaceTheOutdatedMachine(testFramework framework.Framew
 		))))
 	})
 }
+
+// ItShouldUninstallTheControlPlaneMachineSet checks that the control plane machine set is correctly uninstalled
+// when a deletion is triggered, without triggering control plane machines changes.
+func ItShouldUninstallTheControlPlaneMachineSet(testFramework framework.Framework) {
+	It("should uninstall the control plane machine set without control plane machine changes", func() {
+		common.ExpectControlPlaneMachineSetToBeInactiveOrNotFound(testFramework)
+		common.ExpectControlPlaneMachinesAllRunning(testFramework)
+		common.ExpectControlPlaneMachinesNotOwned(testFramework)
+		common.ExpectControlPlaneMachinesWithoutDeletionTimestamp(testFramework)
+		common.EventuallyClusterOperatorsShouldStabilise()
+	})
+}

--- a/test/e2e/presubmit_test.go
+++ b/test/e2e/presubmit_test.go
@@ -70,6 +70,25 @@ var _ = Describe("ControlPlaneMachineSet Operator", framework.PreSubmit(), func(
 				})
 
 				presubmit.ItShouldNotOnDeleteReplaceTheOutdatedMachine(testFramework, 2)
+
+			})
+		})
+
+		Context("and the ControlPlaneMachineSet is up to date", Ordered, func() {
+			BeforeEach(func() {
+				common.EnsureControlPlaneMachineSetUpdated(testFramework)
+			})
+
+			Context("and the ControlPlaneMachineSet is deleted", func() {
+				BeforeEach(func() {
+					common.EnsureControlPlaneMachineSetDeleted(testFramework)
+				})
+
+				AfterEach(func() {
+					common.EnsureActiveControlPlaneMachineSet(testFramework)
+				})
+
+				presubmit.ItShouldUninstallTheControlPlaneMachineSet(testFramework)
 			})
 		})
 	})


### PR DESCRIPTION
This adds a check to the E2E suite that confirms that, when the control plane machine set is deleted, it gets correctly uninstalled and the cluster is cleaned up as expected.