### PR TITLE
[OCPCLOUD-1749] Check on delete strategy correctly replaces machines

### DIFF
--- a/test/e2e/periodic/periodic.go
+++ b/test/e2e/periodic/periodic.go
@@ -100,15 +100,15 @@ func ItShouldPerformARollingUpdate(testFramework framework.Framework) {
 
 // checkRolloutProgress monitors the progress of each index in the rollout in turn.
 func checkRolloutProgress(testFramework framework.Framework, ctx context.Context) bool {
-	if ok := common.CheckRolloutForIndex(testFramework, ctx, 0); !ok {
+	if ok := common.CheckRolloutForIndex(testFramework, ctx, 0, machinev1.RollingUpdate); !ok {
 		return false
 	}
 
-	if ok := common.CheckRolloutForIndex(testFramework, ctx, 1); !ok {
+	if ok := common.CheckRolloutForIndex(testFramework, ctx, 1, machinev1.RollingUpdate); !ok {
 		return false
 	}
 
-	if ok := common.CheckRolloutForIndex(testFramework, ctx, 2); !ok {
+	if ok := common.CheckRolloutForIndex(testFramework, ctx, 2, machinev1.RollingUpdate); !ok {
 		return false
 	}
 

--- a/test/e2e/presubmit_test.go
+++ b/test/e2e/presubmit_test.go
@@ -32,12 +32,12 @@ import (
 var _ = Describe("ControlPlaneMachineSet Operator", framework.PreSubmit(), func() {
 	BeforeEach(func() {
 		common.EventuallyClusterOperatorsShouldStabilise(10*time.Minute, 10*time.Second)
-	})
+	}, OncePerOrdered)
 
 	Context("With an active ControlPlaneMachineSet", func() {
 		BeforeEach(func() {
 			common.EnsureActiveControlPlaneMachineSet(testFramework)
-		})
+		}, OncePerOrdered)
 
 		Context("and the instance type of index 1 is not as expected", func() {
 			BeforeEach(func() {
@@ -52,24 +52,26 @@ var _ = Describe("ControlPlaneMachineSet Operator", framework.PreSubmit(), func(
 
 			BeforeEach(func() {
 				originalStrategy = common.EnsureControlPlaneMachineSetUpdateStrategy(testFramework, machinev1.OnDelete)
-			})
+			}, OncePerOrdered)
 
 			AfterEach(func() {
 				common.EnsureControlPlaneMachineSetUpdateStrategy(testFramework, originalStrategy)
-			})
+			}, OncePerOrdered)
 
-			Context("and the instance type of index 2 is not as expected", func() {
+			Context("and the instance type of index 2 is not as expected", Ordered, func() {
 				var originalProviderSpec machinev1beta1.ProviderSpec
 
-				BeforeEach(func() {
+				BeforeAll(func() {
 					originalProviderSpec = presubmit.IncreaseControlPlaneMachineInstanceSize(testFramework, 2)
 				})
 
-				AfterEach(func() {
+				AfterAll(func() {
 					presubmit.UpdateControlPlaneMachineProviderSpec(testFramework, 2, originalProviderSpec)
 				})
 
 				presubmit.ItShouldNotOnDeleteReplaceTheOutdatedMachine(testFramework, 2)
+
+				presubmit.ItShouldOnDeleteReplaceTheOutDatedMachineWhenDeleted(testFramework, 2)
 
 			})
 		})


### PR DESCRIPTION
Currently based on #137, this PR extends the OnDelete strategy test to check that, when we delete a Machine, it gets replaced while the CPMS is configured with an OnDelete strategy. Changes for this PR are the second commit only.