### PR TITLE
OCPCLOUD-1742: e2e presubmit tests: generated ControlPlaneMachineSet replicas updated

### DIFF
--- a/test/e2e/presubmit/presubmit.go
+++ b/test/e2e/presubmit/presubmit.go
@@ -186,3 +186,27 @@ func ItShouldUninstallTheControlPlaneMachineSet(testFramework framework.Framewor
 		common.EventuallyClusterOperatorsShouldStabilise()
 	})
 }
+
+// ItShouldHaveTheControlPlaneMachineSetReplicasUpdated checks that the control plane machine set replicas are updated.
+func ItShouldHaveTheControlPlaneMachineSetReplicasUpdated(testFramework framework.Framework) {
+	It("should have the control plane machine set replicas up to date", func() {
+		By("Checking the control plane machine set replicas are up to date")
+
+		Expect(testFramework).ToNot(BeNil(), "test framework should not be nil")
+		k8sClient := testFramework.GetClient()
+
+		cpms := &machinev1.ControlPlaneMachineSet{}
+		Expect(k8sClient.Get(testFramework.GetContext(), framework.ControlPlaneMachineSetKey(), cpms)).To(Succeed(), "control plane machine set should exist")
+
+		Expect(cpms.Spec.Replicas).ToNot(BeNil(), "replicas should always be set")
+
+		desiredReplicas := *cpms.Spec.Replicas
+
+		Expect(cpms).To(SatisfyAll(
+			HaveField("Status.Replicas", Equal(desiredReplicas)),
+			HaveField("Status.UpdatedReplicas", Equal(desiredReplicas)),
+			HaveField("Status.ReadyReplicas", Equal(desiredReplicas)),
+			HaveField("Status.UnavailableReplicas", Equal(int32(0))),
+		), "control plane machine set replicas should be up to date")
+	})
+}

--- a/test/e2e/presubmit_test.go
+++ b/test/e2e/presubmit_test.go
@@ -89,6 +89,7 @@ var _ = Describe("ControlPlaneMachineSet Operator", framework.PreSubmit(), func(
 				})
 
 				presubmit.ItShouldUninstallTheControlPlaneMachineSet(testFramework)
+				presubmit.ItShouldHaveTheControlPlaneMachineSetReplicasUpdated(testFramework)
 			})
 		})
 	})


### PR DESCRIPTION
This adds a check to the E2E suite that confirms that, when the control plane machine set is recreated after its deletion, all the replicas (control plane machines) are up to date as expected.

This PR is based on https://github.com/openshift/cluster-control-plane-machine-set-operator/pull/138 only the last commit is relevant to this one.