### PR TITLE
Ensure stable output from RunCheckUntil

### DIFF
--- a/test/e2e/framework/utils.go
+++ b/test/e2e/framework/utils.go
@@ -126,6 +126,10 @@ func RunCheckUntil(ctx context.Context, check, condition func(context.Context, G
 		case conditionErr == nil:
 			// The until finally succeeded.
 			return nil
+		case errors.Is(conditionErr, errContextCancelled) || errors.Is(checkErr, errContextCancelled):
+			// The context was cancelled.
+			// Return the context cancelled error so that the Eventually will fail with a consistent error.
+			return errContextCancelled
 		case checkErr != nil:
 			// The check failed but the until has not completed.
 			// Abort the check.
@@ -133,7 +137,7 @@ func RunCheckUntil(ctx context.Context, check, condition func(context.Context, G
 		default:
 			return conditionErr
 		}
-	}).WithContext(ctx).Should(gomega.Succeed())
+	}).WithContext(ctx).Should(gomega.Succeed(), "check failed or condition did not succeed before the context was cancelled")
 }
 
 // runAssertion runs the assertion function and returns an error if the assertion failed.

--- a/test/e2e/framework/utils_test.go
+++ b/test/e2e/framework/utils_test.go
@@ -168,6 +168,7 @@ var _ = Describe("Async utils", func() {
 			// we intercept it, only the eventually error is reported.
 			Expect(errs).To(ConsistOf(MatchError(SatisfyAll(
 				ContainSubstring("Context was cancelled"),
+				ContainSubstring("check failed or condition did not succeed before the context was cancelled"),
 				ContainSubstring("Expected success, but got an error"),
 			))))
 		})


### PR DESCRIPTION
This test has been flaking because there was an unstable output in the case the context was cancelled before the timeout was reached.

Either the `Eventually` would catch the timeout in which case the test passed, or, the `checkErr` would be `errContextCancelled` in which case the `StopTrying` returned and the test failed.

By intercepting `errContextCancelled` and returning it plainly, the `Eventually` is always the one catching the context timeout, meaning we now have stable errors.

I also added some context to the `Eventually` so that when it fails it includes the message `check failed or condition did not succeed before the context was cancelled`