### PR TITLE
OCPCLOUD-1746: e2e presubmit test: activating ControlPlaneMachineSet doesn't cause rollout

### DIFF
--- a/test/e2e/presubmit_test.go
+++ b/test/e2e/presubmit_test.go
@@ -90,6 +90,15 @@ var _ = Describe("ControlPlaneMachineSet Operator", framework.PreSubmit(), func(
 
 				presubmit.ItShouldUninstallTheControlPlaneMachineSet(testFramework)
 				presubmit.ItShouldHaveTheControlPlaneMachineSetReplicasUpdated(testFramework)
+
+				Context("and the ControlPlaneMachineSet is reactivated", func() {
+					BeforeEach(func() {
+						common.EnsureControlPlaneMachineSetUpdated(testFramework)
+						common.EnsureActiveControlPlaneMachineSet(testFramework)
+					})
+
+					presubmit.ItShouldNotCauseARollout(testFramework)
+				})
 			})
 		})
 	})


### PR DESCRIPTION
This adds a check to the E2E suite that confirms that, when the machines are updated and the control plane machine set is activated, no rollout is triggered.