### PR TITLE
OCPCLOUD-1750: e2e presubmit test: activating ControlPlaneMachineSet adds owner references

### DIFF
--- a/test/e2e/helpers/cases.go
+++ b/test/e2e/helpers/cases.go
@@ -286,3 +286,19 @@ func ItShouldNotCauseARollout(testFramework framework.Framework) {
 		EventuallyClusterOperatorsShouldStabilise()
 	})
 }
+
+// ItShouldCheckAllControlPlaneMachinesHaveCorrectOwnerReferences checks that all the control plane machines
+// have the correct owner references set.
+func ItShouldCheckAllControlPlaneMachinesHaveCorrectOwnerReferences(testFramework framework.Framework) {
+	It("should find all control plane machines to have owner references set", func() {
+		// Check that all the control plane machines are owned.
+		ExpectControlPlaneMachinesOwned(testFramework)
+
+		// Check that no control plane machine is garbage collected (being deleted),
+		// as this may happen if incorrect owner references are added.
+		ConsistentlyControlPlaneMachinesWithoutDeletionTimestamp(testFramework)
+
+		// Check that the operators are stable.
+		EventuallyClusterOperatorsShouldStabilise()
+	})
+}

--- a/test/e2e/helpers/machine.go
+++ b/test/e2e/helpers/machine.go
@@ -338,6 +338,34 @@ func ExpectControlPlaneMachinesWithoutDeletionTimestamp(testFramework framework.
 	), "expected none of the control plane machines to have a deletionTimestap")
 }
 
+// ConsistentlyControlPlaneMachinesWithoutDeletionTimestamp checks that none of the control plane machines
+// have a deletion timestamp, consistently.
+func ConsistentlyControlPlaneMachinesWithoutDeletionTimestamp(testFramework framework.Framework) {
+	By("Checking that none of the control plane machines have a deletion timestamp")
+
+	machineSelector := runtimeclient.MatchingLabels(framework.ControlPlaneMachineSetSelectorLabels())
+
+	machineList := &machinev1beta1.MachineList{}
+
+	Consistently(komega.ObjectList(machineList, machineSelector)).Should(HaveField("Items",
+		HaveEach(HaveField("ObjectMeta.DeletionTimestamp", BeNil())),
+	), "expected none of the control plane machines to have a deletionTimestap")
+}
+
+// ExpectControlPlaneMachinesOwned checks that all of the control plane machines
+// have owner references.
+func ExpectControlPlaneMachinesOwned(testFramework framework.Framework) {
+	By("Checking that all of the control plane machines have owner references")
+
+	machineSelector := runtimeclient.MatchingLabels(framework.ControlPlaneMachineSetSelectorLabels())
+
+	machineList := &machinev1beta1.MachineList{}
+
+	Eventually(komega.ObjectList(machineList, machineSelector)).Should(HaveField("Items",
+		Not(ContainElement(HaveField("ObjectMeta.OwnerReferences", BeEmpty()))),
+	), "expected none of the control plane machines to not have an owner reference")
+}
+
 // IncreaseControlPlaneMachineInstanceSize increases the instance size of the control plane machine
 // in the given index. This should trigger the control plane machine set to update the machine in
 // this index based on the update strategy.

--- a/test/e2e/presubmit_test.go
+++ b/test/e2e/presubmit_test.go
@@ -98,6 +98,7 @@ var _ = Describe("ControlPlaneMachineSet Operator", framework.PreSubmit(), func(
 					})
 
 					helpers.ItShouldNotCauseARollout(testFramework)
+					helpers.ItShouldCheckAllControlPlaneMachinesHaveCorrectOwnerReferences(testFramework)
 				})
 			})
 		})


### PR DESCRIPTION
This adds a check to the E2E suite that confirms that, when the machines are up to date and the control plane machine set is activated, the correct owner references are added.