### PR TITLE
OCPCLOUD-1744: e2e presubmit: update to newest machine triggers inactive ControlPlaneMachineSet regeneration

### DIFF
--- a/pkg/controllers/controlplanemachineset/controller_test.go
+++ b/pkg/controllers/controlplanemachineset/controller_test.go
@@ -1026,7 +1026,7 @@ var _ = Describe("With a running controller", func() {
 		})
 
 		Context("and the instance size is changed", func() {
-			var testOptions helpers.TestOptions
+			var testOptions helpers.RollingUpdatePeriodicTestOptions
 
 			BeforeEach(func() {
 				// The CPMS is configured for AWS so use the AWS Platform Type.

--- a/test/e2e/helpers/cases.go
+++ b/test/e2e/helpers/cases.go
@@ -39,9 +39,8 @@ func ItShouldHaveAnActiveControlPlaneMachineSet(testFramework framework.Framewor
 	})
 }
 
-// TestOptions allow the test cases to be configured with a test framework and
-// optional timeouts.
-type TestOptions struct {
+// RollingUpdatePeriodicTestOptions allow the test cases to be configured.
+type RollingUpdatePeriodicTestOptions struct {
 	TestFramework        framework.Framework
 	RolloutTimeout       time.Duration
 	StabilisationTimeout time.Duration
@@ -49,7 +48,7 @@ type TestOptions struct {
 
 // ItShouldPerformARollingUpdate checks that the control plane machine set performs a rolling update
 // in the manner desired.
-func ItShouldPerformARollingUpdate(opts *TestOptions) {
+func ItShouldPerformARollingUpdate(opts *RollingUpdatePeriodicTestOptions) {
 	It("should perform a rolling update", Offset(1), func() {
 		Expect(opts).ToNot(BeNil(), "test options are required")
 		Expect(opts.TestFramework).ToNot(BeNil(), "testFramework is required")

--- a/test/e2e/periodic_test.go
+++ b/test/e2e/periodic_test.go
@@ -40,7 +40,7 @@ var _ = Describe("ControlPlaneMachineSet Operator", framework.Periodic(), func()
 				helpers.IncreaseControlPlaneMachineSetInstanceSize(testFramework)
 			})
 
-			helpers.ItShouldPerformARollingUpdate(&helpers.TestOptions{
+			helpers.ItShouldPerformARollingUpdate(&helpers.RollingUpdatePeriodicTestOptions{
 				TestFramework: testFramework,
 			})
 		})


### PR DESCRIPTION
This adds a check to the E2E suite that confirms that, when the reference machine (newest, alphabetically latest) provider spec is updated, and the `ControlPlaneMachineSet` is `Inactive`, the `ControlPlaneMachineSet` is regenerated by the `control-plane-machine-set-generator` controller.