### PR TITLE
OCPBUGS-4297: Fix stale cache issue on createMachine

### DIFF
--- a/pkg/controllers/controlplanemachineset/cluster_operator_test.go
+++ b/pkg/controllers/controlplanemachineset/cluster_operator_test.go
@@ -73,9 +73,10 @@ var _ = Describe("Cluster Operator Status with a running controller", func() {
 		Expect(err).ToNot(HaveOccurred(), "Manager should be able to be created")
 
 		reconciler := &ControlPlaneMachineSetReconciler{
-			Client:       k8sClient,
-			Namespace:    namespaceName,
-			OperatorName: operatorName,
+			Client:         k8sClient,
+			UncachedClient: k8sClient,
+			Namespace:      namespaceName,
+			OperatorName:   operatorName,
 		}
 		Expect(reconciler.SetupWithManager(mgr)).To(Succeed(), "Reconciler should be able to setup with manager")
 
@@ -196,9 +197,10 @@ var _ = Describe("Cluster Operator Status", func() {
 		cpmsBuilder = resourcebuilder.ControlPlaneMachineSet().WithName(clusterControlPlaneMachineSetName).WithNamespace(namespaceName)
 
 		reconciler = &ControlPlaneMachineSetReconciler{
-			Client:       k8sClient,
-			Namespace:    namespaceName,
-			OperatorName: operatorName,
+			Client:         k8sClient,
+			UncachedClient: k8sClient,
+			Namespace:      namespaceName,
+			OperatorName:   operatorName,
 		}
 
 		// CVO will create a blank cluster operator for us before the operator starts.

--- a/pkg/controllers/controlplanemachineset/controller.go
+++ b/pkg/controllers/controlplanemachineset/controller.go
@@ -79,8 +79,9 @@ var (
 // ControlPlaneMachineSetReconciler reconciles a ControlPlaneMachineSet object.
 type ControlPlaneMachineSetReconciler struct {
 	client.Client
-	Scheme     *runtime.Scheme
-	RESTMapper meta.RESTMapper
+	Scheme         *runtime.Scheme
+	RESTMapper     meta.RESTMapper
+	UncachedClient client.Client
 
 	// Namespace is the namespace in which the ControlPlaneMachineSet controller should operate.
 	// Any ControlPlaneMachineSet not in this namespace should be ignored.

--- a/pkg/controllers/controlplanemachineset/controller_test.go
+++ b/pkg/controllers/controlplanemachineset/controller_test.go
@@ -166,9 +166,10 @@ var _ = Describe("With a running controller", func() {
 		Expect(err).ToNot(HaveOccurred(), "Manager should be able to be created")
 
 		reconciler := &ControlPlaneMachineSetReconciler{
-			Client:       mgr.GetClient(),
-			Namespace:    namespaceName,
-			OperatorName: operatorName,
+			Client:         mgr.GetClient(),
+			UncachedClient: mgr.GetClient(),
+			Namespace:      namespaceName,
+			OperatorName:   operatorName,
 		}
 		Expect(reconciler.SetupWithManager(mgr)).To(Succeed(), "Reconciler should be able to setup with manager")
 
@@ -1267,9 +1268,10 @@ var _ = Describe("ensureFinalizer", func() {
 		namespaceName = ns.GetName()
 
 		reconciler = &ControlPlaneMachineSetReconciler{
-			Client:    k8sClient,
-			Scheme:    testScheme,
-			Namespace: namespaceName,
+			Client:         k8sClient,
+			UncachedClient: k8sClient,
+			Scheme:         testScheme,
+			Namespace:      namespaceName,
 		}
 
 		// The ControlPlaneMachineSet should already exist by the time we get here.
@@ -1410,10 +1412,11 @@ var _ = Describe("ensureOwnerRefrences", func() {
 		namespaceName = ns.GetName()
 
 		reconciler = &ControlPlaneMachineSetReconciler{
-			Client:     k8sClient,
-			Scheme:     testScheme,
-			RESTMapper: testRESTMapper,
-			Namespace:  namespaceName,
+			Client:         k8sClient,
+			UncachedClient: k8sClient,
+			Scheme:         testScheme,
+			RESTMapper:     testRESTMapper,
+			Namespace:      namespaceName,
 		}
 
 		// The ControlPlaneMachineSet should already exist by the time we get here.
@@ -1917,8 +1920,9 @@ var _ = Describe("validateClusterState", func() {
 		}
 
 		reconciler := &ControlPlaneMachineSetReconciler{
-			Client:    k8sClient,
-			Namespace: namespaceName,
+			Client:         k8sClient,
+			UncachedClient: k8sClient,
+			Namespace:      namespaceName,
 		}
 
 		cpms := in.cpmsBuilder.Build()

--- a/pkg/controllers/controlplanemachineset/status_test.go
+++ b/pkg/controllers/controlplanemachineset/status_test.go
@@ -49,9 +49,10 @@ var _ = Describe("Status", func() {
 			By("Setting up the reconciler")
 			logger = test.NewTestLogger()
 			reconciler = &ControlPlaneMachineSetReconciler{
-				Namespace: namespaceName,
-				Scheme:    testScheme,
-				Client:    k8sClient,
+				Namespace:      namespaceName,
+				Scheme:         testScheme,
+				Client:         k8sClient,
+				UncachedClient: k8sClient,
 			}
 
 			By("Setting up supporting resources")

--- a/pkg/machineproviders/mock/zz_generated_machine_provider_mock.go
+++ b/pkg/machineproviders/mock/zz_generated_machine_provider_mock.go
@@ -11,6 +11,7 @@ import (
 	logr "github.com/go-logr/logr"
 	gomock "github.com/golang/mock/gomock"
 	machineproviders "github.com/openshift/cluster-control-plane-machine-set-operator/pkg/machineproviders"
+	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // MockMachineProvider is a mock of MachineProvider interface.
@@ -77,4 +78,18 @@ func (m *MockMachineProvider) GetMachineInfos(arg0 context.Context, arg1 logr.Lo
 func (mr *MockMachineProviderMockRecorder) GetMachineInfos(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMachineInfos", reflect.TypeOf((*MockMachineProvider)(nil).GetMachineInfos), arg0, arg1)
+}
+
+// WithClient mocks base method.
+func (m *MockMachineProvider) WithClient(arg0 client.Client) machineproviders.MachineProvider {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WithClient", arg0)
+	ret0, _ := ret[0].(machineproviders.MachineProvider)
+	return ret0
+}
+
+// WithClient indicates an expected call of WithClient.
+func (mr *MockMachineProviderMockRecorder) WithClient(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithClient", reflect.TypeOf((*MockMachineProvider)(nil).WithClient), arg0)
 }

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/provider.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/provider.go
@@ -167,6 +167,17 @@ type openshiftMachineProvider struct {
 	machineAPIScheme *apimachineryruntime.Scheme
 }
 
+// WithClient sets the desired client to the Machine Provider.
+func (m *openshiftMachineProvider) WithClient(client client.Client) machineproviders.MachineProvider {
+	// Take a shallow copy, this should be sufficient for the usage of the provider.
+	o := &openshiftMachineProvider{}
+	*o = *m
+
+	o.client = client
+
+	return o
+}
+
 // GetMachineInfos inspects the current state of the Machines matched by the selector
 // and returns information about the Machines in the form of a MachineInfo.
 // For each Machine, it identifies the following:

--- a/pkg/machineproviders/types.go
+++ b/pkg/machineproviders/types.go
@@ -22,6 +22,7 @@ import (
 	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // MachineInfo collates information about a Control Plane Machine and Node.
@@ -70,6 +71,11 @@ type MachineProvider interface {
 	// GetMachineInfos is used to collect information about the Control Plane Machines and Nodes that currently exist
 	// within the Cluster, as referred to by the ControlPlaneMachineSet.
 	GetMachineInfos(context.Context, logr.Logger) ([]MachineInfo, error)
+
+	// WithClient is used to set API client for the Machine Provider.
+	// It should not mutate the state of the existing provider but return
+	// a copy of the provider with the new client.
+	WithClient(client client.Client) MachineProvider
 
 	// CreateMachine is used to instruct the Machine Provider to create a new Machine. The only input is the index for
 	// the new Machine. During construction of the MachineProvider, it should map indexes to failure domains so that it


### PR DESCRIPTION
Fixes issue OCPBUGS-4297, where a stale cache of MachineInfos can lead to the controller not detecting an already existing replacement being present and as such, triggering a subsequent replacement machine creation.

It fixes the issue by introducing an uncached API client which is later used to create an uncached machine provider that checks, right before replacement machine creation (for performance reasons, as we don't want to always use the expensive uncached client), if a replacement already exists, avoiding the double replacement problem.