### PR TITLE
OCPCLOUD-1740: e2e periodic test: machine replacement with cluster wide proxy

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -9,7 +9,7 @@ REPO_ROOT=$(dirname "${BASH_SOURCE}")/..
 OPENSHIFT_CI=${OPENSHIFT_CI:-""}
 ARTIFACT_DIR=${ARTIFACT_DIR:-""}
 GINKGO=${GINKGO:-"go run ${REPO_ROOT}/vendor/github.com/onsi/ginkgo/v2/ginkgo"}
-GINKGO_ARGS=${GINKGO_ARGS:-"-r -v --fail-fast --trace --timeout=2h"}
+GINKGO_ARGS=${GINKGO_ARGS:-"-r -v --fail-fast --trace --timeout=3h"}
 GINKGO_EXTRA_ARGS=${GINKGO_EXTRA_ARGS:-""}
 
 if [ "$OPENSHIFT_CI" == "true" ] && [ -n "$ARTIFACT_DIR" ] && [ -d "$ARTIFACT_DIR" ]; then # detect ci environment there

--- a/pkg/controllers/controlplanemachineset/controller_test.go
+++ b/pkg/controllers/controlplanemachineset/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 Red Hat, Inc.
+Copyright 2023 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/test/resourcebuilder/configmap.go
+++ b/pkg/test/resourcebuilder/configmap.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcebuilder
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ConfigMap creates a new ConfigMap builder.
+func ConfigMap() ConfigMapBuilder {
+	return ConfigMapBuilder{}
+}
+
+// ConfigMapBuilder is used to build out a ConfigMap object.
+type ConfigMapBuilder struct {
+	generateName string
+	name         string
+	namespace    string
+	labels       map[string]string
+	data         map[string]string
+}
+
+// Build builds a new ConfigMap based on the configuration provided.
+func (m ConfigMapBuilder) Build() *corev1.ConfigMap {
+	ConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: m.generateName,
+			Name:         m.name,
+			Namespace:    m.namespace,
+			Labels:       m.labels,
+		},
+		Data: m.data,
+	}
+
+	return ConfigMap
+}
+
+// WithData sets the data for the ConfigMap builder.
+func (m ConfigMapBuilder) WithData(data map[string]string) ConfigMapBuilder {
+	m.data = data
+	return m
+}
+
+// WithGenerateName sets the generateName for the ConfigMap builder.
+func (m ConfigMapBuilder) WithGenerateName(generateName string) ConfigMapBuilder {
+	m.generateName = generateName
+	return m
+}
+
+// WithLabel sets the labels for the ConfigMap builder.
+func (m ConfigMapBuilder) WithLabel(key, value string) ConfigMapBuilder {
+	if m.labels == nil {
+		m.labels = make(map[string]string)
+	}
+
+	m.labels[key] = value
+
+	return m
+}
+
+// WithLabels sets the labels for the ConfigMap builder.
+func (m ConfigMapBuilder) WithLabels(labels map[string]string) ConfigMapBuilder {
+	m.labels = labels
+	return m
+}
+
+// WithName sets the name for the ConfigMap builder.
+func (m ConfigMapBuilder) WithName(name string) ConfigMapBuilder {
+	m.name = name
+	return m
+}
+
+// WithNamespace sets the namespace for the ConfigMap builder.
+func (m ConfigMapBuilder) WithNamespace(namespace string) ConfigMapBuilder {
+	m.namespace = namespace
+	return m
+}

--- a/pkg/test/resourcebuilder/daemonset.go
+++ b/pkg/test/resourcebuilder/daemonset.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcebuilder
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// DaemonSet creates a new DaemonSet builder.
+func DaemonSet() DaemonSetBuilder {
+	return DaemonSetBuilder{}
+}
+
+// DaemonSetBuilder is used to build out a DaemonSet object.
+type DaemonSetBuilder struct {
+	generateName string
+	name         string
+	namespace    string
+	labels       map[string]string
+	volumes      []corev1.Volume
+	containers   []corev1.Container
+}
+
+// Build builds a new DaemonSet based on the configuration provided.
+func (m DaemonSetBuilder) Build() *appsv1.DaemonSet {
+	DaemonSet := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: m.generateName,
+			Name:         m.name,
+			Namespace:    m.namespace,
+			Labels:       m.labels,
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: m.labels,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      m.name,
+					Namespace: m.namespace,
+					Labels:    m.labels,
+				},
+				Spec: corev1.PodSpec{
+					Volumes:    m.volumes,
+					Containers: m.containers,
+				},
+			},
+		},
+	}
+
+	return DaemonSet
+}
+
+// WithContainers sets the containers for the DaemonSet builder.
+func (m DaemonSetBuilder) WithContainers(containers []corev1.Container) DaemonSetBuilder {
+	m.containers = containers
+	return m
+}
+
+// WithGenerateName sets the generateName for the DaemonSet builder.
+func (m DaemonSetBuilder) WithGenerateName(generateName string) DaemonSetBuilder {
+	m.generateName = generateName
+	return m
+}
+
+// WithLabel sets the labels for the DaemonSet builder.
+func (m DaemonSetBuilder) WithLabel(key, value string) DaemonSetBuilder {
+	if m.labels == nil {
+		m.labels = make(map[string]string)
+	}
+
+	m.labels[key] = value
+
+	return m
+}
+
+// WithLabels sets the labels for the DaemonSet builder.
+func (m DaemonSetBuilder) WithLabels(labels map[string]string) DaemonSetBuilder {
+	m.labels = labels
+	return m
+}
+
+// WithName sets the name for the DaemonSet builder.
+func (m DaemonSetBuilder) WithName(name string) DaemonSetBuilder {
+	m.name = name
+	return m
+}
+
+// WithNamespace sets the namespace for the DaemonSet builder.
+func (m DaemonSetBuilder) WithNamespace(namespace string) DaemonSetBuilder {
+	m.namespace = namespace
+	return m
+}
+
+// WithVolumes sets the volumes for the DaemonSet builder.
+func (m DaemonSetBuilder) WithVolumes(volumes []corev1.Volume) DaemonSetBuilder {
+	m.volumes = volumes
+	return m
+}

--- a/pkg/test/resourcebuilder/secret.go
+++ b/pkg/test/resourcebuilder/secret.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcebuilder
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Secret creates a new Secret builder.
+func Secret() SecretBuilder {
+	return SecretBuilder{}
+}
+
+// SecretBuilder is used to build out a Secret object.
+type SecretBuilder struct {
+	generateName string
+	name         string
+	namespace    string
+	labels       map[string]string
+	data         map[string][]byte
+}
+
+// Build builds a new Secret based on the configuration provided.
+func (m SecretBuilder) Build() *corev1.Secret {
+	Secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: m.generateName,
+			Name:         m.name,
+			Namespace:    m.namespace,
+			Labels:       m.labels,
+		},
+		Data: m.data,
+	}
+
+	return Secret
+}
+
+// WithData sets the data for the Secret builder.
+func (m SecretBuilder) WithData(data map[string][]byte) SecretBuilder {
+	m.data = data
+	return m
+}
+
+// WithGenerateName sets the generateName for the Secret builder.
+func (m SecretBuilder) WithGenerateName(generateName string) SecretBuilder {
+	m.generateName = generateName
+	return m
+}
+
+// WithLabel sets the labels for the Secret builder.
+func (m SecretBuilder) WithLabel(key, value string) SecretBuilder {
+	if m.labels == nil {
+		m.labels = make(map[string]string)
+	}
+
+	m.labels[key] = value
+
+	return m
+}
+
+// WithLabels sets the labels for the Secret builder.
+func (m SecretBuilder) WithLabels(labels map[string]string) SecretBuilder {
+	m.labels = labels
+	return m
+}
+
+// WithName sets the name for the Secret builder.
+func (m SecretBuilder) WithName(name string) SecretBuilder {
+	m.name = name
+	return m
+}
+
+// WithNamespace sets the namespace for the Secret builder.
+func (m SecretBuilder) WithNamespace(namespace string) SecretBuilder {
+	m.namespace = namespace
+	return m
+}

--- a/pkg/test/resourcebuilder/service.go
+++ b/pkg/test/resourcebuilder/service.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcebuilder
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Service creates a new Service builder.
+func Service() ServiceBuilder {
+	return ServiceBuilder{}
+}
+
+// ServiceBuilder is used to build out a Service object.
+type ServiceBuilder struct {
+	generateName string
+	name         string
+	namespace    string
+	labels       map[string]string
+	selector     map[string]string
+	ports        []corev1.ServicePort
+}
+
+// Build builds a new Service based on the configuration provided.
+func (m ServiceBuilder) Build() *corev1.Service {
+	Service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: m.generateName,
+			Name:         m.name,
+			Namespace:    m.namespace,
+			Labels:       m.labels,
+		},
+		Spec: corev1.ServiceSpec{
+			Ports:    m.ports,
+			Selector: m.selector,
+		},
+	}
+
+	return Service
+}
+
+// WithGenerateName sets the generateName for the Service builder.
+func (m ServiceBuilder) WithGenerateName(generateName string) ServiceBuilder {
+	m.generateName = generateName
+	return m
+}
+
+// WithLabel sets the labels for the Service builder.
+func (m ServiceBuilder) WithLabel(key, value string) ServiceBuilder {
+	if m.labels == nil {
+		m.labels = make(map[string]string)
+	}
+
+	m.labels[key] = value
+
+	return m
+}
+
+// WithLabels sets the labels for the Service builder.
+func (m ServiceBuilder) WithLabels(labels map[string]string) ServiceBuilder {
+	m.labels = labels
+	return m
+}
+
+// WithName sets the name for the Service builder.
+func (m ServiceBuilder) WithName(name string) ServiceBuilder {
+	m.name = name
+	return m
+}
+
+// WithNamespace sets the namespace for the Service builder.
+func (m ServiceBuilder) WithNamespace(namespace string) ServiceBuilder {
+	m.namespace = namespace
+	return m
+}
+
+// WithPorts sets the ports for the Service builder.
+func (m ServiceBuilder) WithPorts(ports []corev1.ServicePort) ServiceBuilder {
+	m.ports = ports
+	return m
+}
+
+// WithSelector sets the selector for the Service builder.
+func (m ServiceBuilder) WithSelector(selector map[string]string) ServiceBuilder {
+	m.selector = selector
+	return m
+}

--- a/test/e2e/helpers/proxy.go
+++ b/test/e2e/helpers/proxy.go
@@ -1,0 +1,391 @@
+/*
+Copyright 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helpers
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	apitypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	client "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/cluster-control-plane-machine-set-operator/pkg/test/resourcebuilder"
+	"github.com/openshift/cluster-control-plane-machine-set-operator/test/e2e/framework"
+)
+
+const (
+	mapiControllersDeploymentName         = "machine-api-controllers"
+	machineControllerContainerName string = "machine-controller"
+	proxyName                             = "mitm-proxy"
+	mitmSignerName                        = "mitm-signer"
+	mitmBootstrapName                     = "mitm-bootstrap"
+	mitmCustomPKIName                     = "mitm-custom-pki"
+	mitmCustomPKINamespace                = "openshift-config"
+	mitmDaemonsetName                     = proxyName
+	mitmServiceName                       = proxyName
+)
+
+const proxySetup = `
+cd /.mitmproxy
+cat /root/certs/tls.key /root/certs/tls.crt > /.mitmproxy/mitmproxy-ca.pem
+curl -O https://snapshots.mitmproxy.org/5.3.0/mitmproxy-5.3.0-linux.tar.gz
+tar xvf mitmproxy-5.3.0-linux.tar.gz
+HOME=/.mitmproxy ./mitmdump --ssl-insecure
+`
+
+// DeployProxy deploys a MITM Proxy to the cluster.
+func DeployProxy(testFramework framework.Framework, gomegaArgs ...interface{}) {
+	proxyNamespace := testFramework.ControlPlaneMachineSetKey().Namespace
+	proxyLabels := map[string]string{
+		"app": proxyName,
+	}
+
+	// Generate an RSA private key and its corresponding X.509 certificate,
+	// for the MITM proxy.
+	certBytes, keyBytes, err := generateCert()
+	Expect(err).NotTo(HaveOccurred())
+
+	mitmSignerKey := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: keyBytes})
+	mitmSignerCert := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certBytes})
+
+	mitmSignerSecret := resourcebuilder.Secret().WithName(mitmSignerName).WithNamespace(proxyNamespace).WithLabels(proxyLabels).
+		WithData(map[string][]byte{"tls.crt": mitmSignerCert, "tls.key": mitmSignerKey}).Build()
+
+	mitmBootstrapConfigMap := resourcebuilder.ConfigMap().WithName(mitmBootstrapName).WithNamespace(proxyNamespace).WithLabels(proxyLabels).
+		WithData(map[string]string{"startup.sh": proxySetup}).Build()
+
+	mitmCustomPkiConfigMap := resourcebuilder.ConfigMap().WithName(mitmCustomPKIName).WithNamespace(mitmCustomPKINamespace).
+		WithData(map[string]string{"ca-bundle.crt": string(mitmSignerCert)}).Build()
+
+	mitmDaemonset := resourcebuilder.DaemonSet().WithName(proxyName).WithNamespace(proxyNamespace).WithLabels(proxyLabels).
+		WithVolumes(buildDaemonSetVolumes()).WithContainers(buildDaemonSetContainers()).Build()
+
+	mitmService := resourcebuilder.Service().WithNamespace(proxyNamespace).WithName(proxyName).
+		WithLabels(proxyLabels).WithSelector(proxyLabels).WithPorts(buildServicePorts()).Build()
+
+	k8sClient := testFramework.GetClient()
+	ctx := testFramework.GetContext()
+
+	By("Creating the MITM proxy Secret")
+	Eventually(k8sClient.Create(ctx, mitmSignerSecret)).Should(Succeed())
+
+	By("Creating the MITM proxy ConfigMaps")
+	Eventually(k8sClient.Create(ctx, mitmBootstrapConfigMap)).Should(Succeed())
+	Eventually(k8sClient.Create(ctx, mitmCustomPkiConfigMap)).Should(Succeed())
+
+	By("Creating the MITM proxy DaemonSet")
+	Eventually(k8sClient.Create(ctx, mitmDaemonset)).Should(Succeed())
+
+	By("Waiting for the MITM proxy DaemonSet to be available")
+	Eventually(komega.Object(mitmDaemonset), time.Minute*1).Should(
+		HaveField("Status.NumberAvailable", Not(BeZero())),
+	)
+
+	By("Creating the MITM proxy Service")
+	Eventually(k8sClient.Create(ctx, mitmService)).Should(Succeed())
+
+	By("Waiting for the MITM proxy Service to be available")
+	Eventually(komega.Object(mitmService), time.Minute*1).Should(
+		HaveField("Spec.ClusterIP", Not(Equal(""))),
+	)
+}
+
+// ConfigureClusterWideProxy configures the Cluster-Wide Proxy to use the MITM Proxy.
+func ConfigureClusterWideProxy(testFramework framework.Framework, gomegaArgs ...interface{}) {
+	k8sClient := testFramework.GetClient()
+	ctx := testFramework.GetContext()
+	proxyNamespace := testFramework.ControlPlaneMachineSetKey().Namespace
+
+	By("Configuring cluster-wide proxy")
+
+	services := &corev1.ServiceList{}
+	Eventually(k8sClient.List(ctx, services, client.MatchingLabels(map[string]string{"app": "mitm-proxy"}))).Should(Succeed())
+
+	proxy := &configv1.Proxy{}
+	Eventually(k8sClient.Get(ctx, client.ObjectKey{Name: "cluster"}, proxy)).Should(Succeed())
+
+	updateProxyArgs := append([]interface{}{komega.Update(proxy, func() {
+		proxy.Spec.HTTPProxy = "http://" + services.Items[0].Spec.ClusterIP + ":8080"
+		proxy.Spec.HTTPSProxy = "http://" + services.Items[0].Spec.ClusterIP + ":8080"
+		proxy.Spec.NoProxy = ".org,.com,.net,quay.io,registry.redhat.io"
+		proxy.Spec.TrustedCA = configv1.ConfigMapNameReference{
+			Name: mitmCustomPKIName,
+		}
+	})}, gomegaArgs...)
+	Eventually(updateProxyArgs...).Should(Succeed(), "cluster wide proxy set be able to be updated")
+
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      mapiControllersDeploymentName,
+			Namespace: proxyNamespace,
+		},
+	}
+
+	By("Waiting for machine-api-controller deployment to reflect configured cluster-wide proxy")
+
+	Eventually(komega.Object(deploy), time.Minute*5).Should(
+		HaveField("Spec.Template.Spec.Containers", ContainElement(SatisfyAll(
+			HaveField("Name", Equal(machineControllerContainerName)),
+			HaveField("Env", SatisfyAll(
+				ContainElement(SatisfyAll(
+					HaveField("Name", "NO_PROXY"),
+					HaveField("Value", Not(BeEmpty())),
+				)),
+				ContainElement(SatisfyAll(
+					HaveField("Name", "HTTPS_PROXY"),
+					HaveField("Value", Not(BeEmpty())),
+				)),
+				ContainElement(SatisfyAll(
+					HaveField("Name", "HTTP_PROXY"),
+					HaveField("Value", Not(BeEmpty())),
+				)),
+			)),
+		))),
+	)
+}
+
+// UnconfigureClusterWideProxy configures the Cluster-Wide Proxy to stop using the MITM Proxy.
+func UnconfigureClusterWideProxy(testFramework framework.Framework, gomegaArgs ...interface{}) {
+	k8sClient := testFramework.GetClient()
+	ctx := testFramework.GetContext()
+	proxyNamespace := testFramework.ControlPlaneMachineSetKey().Namespace
+
+	proxy := &configv1.Proxy{}
+	Eventually(k8sClient.Get(ctx, client.ObjectKey{Name: "cluster"}, proxy)).Should(Succeed())
+
+	By("Unconfiguring cluster-wide proxy")
+	Eventually(k8sClient.Patch(context.Background(), proxy, client.RawPatch(apitypes.JSONPatchType, []byte(`[
+		{"op": "remove", "path": "/spec/httpProxy"},
+		{"op": "remove", "path": "/spec/httpsProxy"},
+		{"op": "remove", "path": "/spec/noProxy"},
+		{"op": "remove", "path": "/spec/trustedCA"}
+	]`)))).Should(Succeed())
+
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      mapiControllersDeploymentName,
+			Namespace: proxyNamespace,
+		},
+	}
+
+	By("Waiting for machine-api-controller deployment to reflect unconfigured cluster-wide proxy")
+	Eventually(komega.Object(deploy), time.Minute*5).Should(
+		HaveField("Spec.Template.Spec.Containers", ContainElement(SatisfyAll(
+			HaveField("Name", Equal(machineControllerContainerName)),
+			HaveField("Env", SatisfyAll(
+				Not(ContainElement(SatisfyAll(
+					HaveField("Name", "NO_PROXY"),
+				))),
+				Not(ContainElement(SatisfyAll(
+					HaveField("Name", "HTTPS_PROXY"),
+				))),
+				Not(ContainElement(SatisfyAll(
+					HaveField("Name", "HTTP_PROXY"),
+				))),
+			)),
+		))),
+	)
+}
+
+// DeleteProxy delete the MITM Proxy from the cluster.
+func DeleteProxy(testFramework framework.Framework, gomegaArgs ...interface{}) {
+	k8sClient := testFramework.GetClient()
+	ctx := testFramework.GetContext()
+	proxyNamespace := testFramework.ControlPlaneMachineSetKey().Namespace
+	mitmSignerSecret := resourcebuilder.Secret().WithName(mitmSignerName).WithNamespace(proxyNamespace).Build()
+	mitmBootstrapConfigMap := resourcebuilder.ConfigMap().WithName(mitmBootstrapName).WithNamespace(proxyNamespace).Build()
+	mitmCustomPkiConfigMap := resourcebuilder.ConfigMap().WithName(mitmCustomPKIName).WithNamespace(mitmCustomPKINamespace).Build()
+	mitmDaemonset := resourcebuilder.DaemonSet().WithName(mitmDaemonsetName).WithNamespace(proxyNamespace).Build()
+	mitmService := resourcebuilder.Service().WithName(mitmServiceName).WithNamespace(proxyNamespace).Build()
+
+	By("Deleting the MITM proxy Secret")
+	Eventually(k8sClient.Delete(ctx, mitmSignerSecret)).Should(Succeed())
+
+	By("Deleting the MITM proxy ConfigMaps")
+	Eventually(k8sClient.Delete(ctx, mitmBootstrapConfigMap)).Should(Succeed())
+	Eventually(k8sClient.Delete(ctx, mitmCustomPkiConfigMap)).Should(Succeed())
+
+	By("Deleting the MITM proxy DaemonSet")
+	Eventually(k8sClient.Delete(ctx, mitmDaemonset)).Should(Succeed())
+
+	By("Deleting the MITM proxy Service")
+	Eventually(k8sClient.Delete(ctx, mitmService)).Should(Succeed())
+
+	By("Checking that the MITM proxy components are removed from the cluster")
+
+	Eventually(komega.Get(mitmSignerSecret)).
+		Should(MatchError(ContainSubstring("not found")), "expected MITM proxy Secret to be removed from the cluster")
+
+	Eventually(komega.Get(mitmBootstrapConfigMap)).
+		Should(MatchError(ContainSubstring("not found")), "expected MITM proxy Bootstrap ConfigMap to be removed from the cluster")
+
+	Eventually(komega.Get(mitmCustomPkiConfigMap)).
+		Should(MatchError(ContainSubstring("not found")), "expected MITM proxy PKI ConfigMap to be removed from the cluster")
+
+	Eventually(komega.Get(mitmDaemonset)).
+		Should(MatchError(ContainSubstring("not found")), "expected MITM proxy DaemonSet to be removed from the cluster")
+
+	Eventually(komega.Get(mitmService)).
+		Should(MatchError(ContainSubstring("not found")), "expected MITM proxy Service to be removed from the cluster")
+}
+
+func buildDaemonSetVolumes() []corev1.Volume {
+	mitmBootstrapPerms := int32(511)
+
+	return []corev1.Volume{
+		{
+			Name: "mitm-bootstrap",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: mitmBootstrapName,
+					},
+					DefaultMode: &mitmBootstrapPerms,
+				},
+			},
+		},
+		{
+			Name: mitmSignerName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: mitmSignerName,
+				},
+			},
+		},
+		{
+			Name: "mitm-workdir",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+	}
+}
+
+func buildDaemonSetContainers() []corev1.Container {
+	return []corev1.Container{{
+		Name:            "proxy",
+		Image:           "registry.redhat.io/ubi8/ubi",
+		ImagePullPolicy: corev1.PullIfNotPresent,
+		Command:         []string{"/bin/sh", "-c", "/root/startup.sh"},
+		Ports: []corev1.ContainerPort{
+			{
+				ContainerPort: 80,
+			},
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      mitmBootstrapName,
+				ReadOnly:  false,
+				MountPath: "/root/startup.sh",
+				SubPath:   "startup.sh",
+			},
+			{
+				Name:      mitmSignerName,
+				ReadOnly:  false,
+				MountPath: "/root/certs",
+			},
+			{
+				Name:      "mitm-workdir",
+				ReadOnly:  false,
+				MountPath: "/.mitmproxy",
+			},
+		},
+	}}
+}
+
+func buildServicePorts() []corev1.ServicePort {
+	return []corev1.ServicePort{
+		{
+			Protocol: "TCP",
+			Port:     8080,
+			TargetPort: intstr.IntOrString{
+				IntVal: 8080,
+			},
+		},
+	}
+}
+
+// generateCert generates an RSA private key and its corresponding X.509 certificate.
+// https://golang.org/src/crypto/tls/generate_cert.go as a function
+func generateCert() ([]byte, []byte, error) {
+	var err error
+
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate rsa key: %w", err)
+	}
+
+	keyBytes, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		return nil, keyBytes, fmt.Errorf("failed to marshal private key: %w", err)
+	}
+
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, keyBytes, fmt.Errorf("failed to generate random serial number: %w", err)
+	}
+
+	keyID, err := func() ([]byte, error) {
+		bytes := make([]byte, 20)
+		if _, err := rand.Read(bytes); err != nil {
+			return nil, fmt.Errorf("failed to generate random bytes: %w", err)
+		}
+
+		return bytes, nil
+	}()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate x509 certificate key ID: %w", err)
+	}
+
+	notBefore := time.Now()
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			CommonName: "mitm-proxy-ca",
+		},
+		NotBefore:             notBefore,
+		NotAfter:              notBefore.Add(time.Hour),
+		SubjectKeyId:          keyID,
+		AuthorityKeyId:        keyID,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	certBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate X.509 certificate: %w", err)
+	}
+
+	return certBytes, keyBytes, nil
+}

--- a/test/e2e/presubmit_test.go
+++ b/test/e2e/presubmit_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 Red Hat, Inc.
+Copyright 2023 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
This adds a periodic check to the E2E suite that confirms that, when a cluster wide proxy is configured, the CPMSO is able to create machine replacements, and control plane machines are correctly provisioned by MAPI.