### PR TITLE
golangci-lint: fix header year linting

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -63,8 +63,11 @@ linters:
     - wsl
 linters-settings:
   goheader:
+    values:
+      regexp:
+        license-year: (202[2-9]|20[3-9][0-9])
     template: |-
-      Copyright {{YEAR}} Red Hat, Inc.
+      Copyright {{license-year}} Red Hat, Inc.
 
       Licensed under the Apache License, Version 2.0 (the "License");
       you may not use this file except in compliance with the License.


### PR DESCRIPTION
With the year changing the linter wants us to change the file header's year of all the files touched in a pull request.
With this change we'll accept all years in the file header from 2022 onwards.