### PR TITLE
OCPBUGS-6760: webhooks: disable mandatory TargetPools validation on GCP

### DIFF
--- a/pkg/webhooks/controlplanemachineset/webhooks.go
+++ b/pkg/webhooks/controlplanemachineset/webhooks.go
@@ -294,15 +294,7 @@ func validateOpenShiftAzureProviderConfig(parentPath *field.Path, providerConfig
 // validateOpenShiftGCPProviderConfig runs GCP specific checks on the provider config on the ControlPlaneMachineSet.
 // This ensure that the ControlPlaneMachineSet can safely replace GCP control plane machines.
 func validateOpenShiftGCPProviderConfig(parentPath *field.Path, providerConfig providerconfig.GCPProviderConfig) []error {
-	errs := []error{}
-
-	config := providerConfig.Config()
-
-	if len(config.TargetPools) == 0 {
-		errs = append(errs, field.Required(parentPath.Child("targetPools"), "targetPools is required for control plane machines"))
-	}
-
-	return errs
+	return []error{}
 }
 
 // fetchControlPlaneMachines returns all control plane machines in the cluster.

--- a/pkg/webhooks/controlplanemachineset/webhooks_test.go
+++ b/pkg/webhooks/controlplanemachineset/webhooks_test.go
@@ -943,16 +943,6 @@ var _ = Describe("Webhooks", func() {
 					cpms.Spec.Selector.MatchLabels["new"] = dummyValue
 				})()).Should(MatchError(ContainSubstring("ControlPlaneMachineSet.machine.openshift.io \"cluster\" is invalid: spec.selector: Invalid value: \"object\": selector is immutable")), "The selector should be immutable")
 			})
-
-			It("when removing the target pools", func() {
-				// Change the providerSpec, expect the update to be successful
-				var emptySliceTargetPools []string
-				rawProviderSpec := resourcebuilder.GCPProviderSpec().WithTargetPools(emptySliceTargetPools).BuildRawExtension()
-
-				Expect(komega.Update(cpms, func() {
-					cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec.ProviderSpec.Value = rawProviderSpec
-				})()).Should(MatchError(ContainSubstring("spec.template.machines_v1beta1_machine_openshift_io.spec.providerSpec.value.targetPools: Required value: targetPools is required for control plane machines")))
-			})
 		})
 	})
 })


### PR DESCRIPTION
This causes issue for private GCP clusters.
We will re-add this check as a warning in the future, when [webhook warnings
are supported by controller-runtime](https://github.com/kubernetes-sigs/controller-runtime/pull/2014). See: https://issues.redhat.com/browse/OCPCLOUD-1894