### PR TITLE
OCPCLOUD-1990: Update supported platforms in docs

### DIFF
--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -42,7 +42,7 @@ The control plane machine set can balance machines across multiple failure domai
 fault tolerance within the control plane when issues arise within the infrastructure provider.
 
 Failure domains are configured within the machine template of the control plane machine set and are currently supported
-on Amazon Web Services (AWS) and Microsoft Azure only. Other platforms will be added over time.
+by all the [supported platforms](./README.md#supported-platforms) unless otherwise specified in the support matrix. Other platforms will be added over time.
 
 The control plane machine set will balance the machines across the failure domains provided, weighting towards the
 alphabetically first failure domains when a failure domain must be re-used.
@@ -91,8 +91,9 @@ The matrix shows in detail the support for each specific combination.
 | Platform \ OpenShift version |      <=4.11    |      4.12           |      4.13           |
 |------------------------------|:---------------|:--------------------|:--------------------|
 | AWS                          |  Not Supported | Full                | Full                |
-| Azure                        |  Not Supported | Manual              | Manual              |
-| VSphere                      |  Not Supported | Manual (Single Zone)| Manual (Signle Zone)|
+| Azure                        |  Not Supported | Manual              | Full                |
+| GCP                          |  Not Supported | Not Supported       | Full                |
+| VSphere                      |  Not Supported | Manual (Single Zone)| Manual (Single Zone)|
 | Other Platforms              |  Not Supported | Not Supported       | Not Supported       |
 
 > Note: Google Cloud Platform and OpenStack are planned for inclusion from OpenShift version 4.13 onwards.

--- a/docs/user/installation.md
+++ b/docs/user/installation.md
@@ -211,3 +211,30 @@ failureDomains:
 
 > Note: The `internalLoadBalancer` field may not be set on the Azure providerSpec. This field is required for control
 plane machines and you should populate this on both the Machine and the ControlPlaneMachineSet resource specs.
+
+#### Configuring a control plane machine set on Google Cloud Platform (GCP)
+
+Currently the only field supported by the GCP failure domain is the `zone`.
+Gather the existing control plane machines and note the value of the `zone` of each.
+Aside from the `zone` field, the remaining in spec the machines should be identical.
+
+Copy the value from one of the machines into the `providerSpec.value` (6) on the example above.
+Remove the `zone` field from the `providerSpec.value` once you have done that.
+
+For each `zone` you have in the cluster (normally 3), configure a failure domain like below:
+```yaml
+- zone: "<zone>"
+```
+
+With these zones, the complete `failureDomains` (3 and 4) on the example above should look something like below:
+```yaml
+failureDomains:
+  platform: GCP
+  gcp:
+  - zone: us-central1-a
+  - zone: us-central1-b
+  - zone: us-central1-c
+```
+
+> Note: The `targetPools` field may not be set on the GCP providerSpec. This field is required for control
+plane machines and you should populate this on both the Machine and the ControlPlaneMachineSet resource specs.


### PR DESCRIPTION
For the OCP 4.13 release we are moving the Azure and GCP platforms to "Full" support.
Hence this PRs updates the support matrix and the install steps for these platforms 