### PR TITLE
OCPBUGS-2960: Check ProviderSpec before generating MachineInfo

### DIFF
--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/provider.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/provider.go
@@ -100,7 +100,7 @@ func NewMachineProvider(ctx context.Context, logger logr.Logger, cl client.Clien
 		return nil, errEmptyConfig
 	}
 
-	providerConfig, err := providerconfig.NewProviderConfigFromMachineTemplate(*cpms.Spec.Template.OpenShiftMachineV1Beta1Machine)
+	providerConfig, err := buildValidProviderConfig(ctx, cl, cpms)
 	if err != nil {
 		return nil, fmt.Errorf("error building a valid provider config: %w", err)
 	}
@@ -134,6 +134,43 @@ func NewMachineProvider(ctx context.Context, logger logr.Logger, cl client.Clien
 		namespace:            cpms.Namespace,
 		machineAPIScheme:     machineAPIScheme,
 	}, nil
+}
+
+// buildValidProviderConfig makes sure that the provider config is valid by dry-run creating a machine.
+func buildValidProviderConfig(ctx context.Context, cl client.Client, cpms *machinev1.ControlPlaneMachineSet) (providerconfig.ProviderConfig, error) {
+	machine := &machinev1beta1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "tmp-machine-dry-run",
+			Namespace:    cpms.Namespace,
+			Annotations:  cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.ObjectMeta.Annotations,
+			Labels:       cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.ObjectMeta.Labels,
+		},
+		Spec: cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec,
+	}
+
+	providerConfig, err := providerconfig.NewProviderConfigFromMachineTemplate(*cpms.Spec.Template.OpenShiftMachineV1Beta1Machine)
+	if err != nil {
+		return nil, fmt.Errorf("could not create a new provider config from machine template: %w", err)
+	}
+
+	rawConfig, err := providerConfig.RawConfig()
+	if err != nil {
+		return nil, fmt.Errorf("could not fetch raw config from provider config: %w", err)
+	}
+
+	machine.Spec.ProviderSpec.Value.Raw = rawConfig
+
+	dryRunClient := client.NewDryRunClient(cl)
+	if err := dryRunClient.Create(ctx, machine); err != nil {
+		return nil, fmt.Errorf("could not dry-run create the machine: %w", err)
+	}
+
+	machineProviderConfig, err := providerconfig.NewProviderConfigFromMachineSpec(machine.Spec)
+	if err != nil {
+		return nil, fmt.Errorf("could not get provider config for machine: %w", err)
+	}
+
+	return machineProviderConfig, nil
 }
 
 // openshiftMachineProvider holds the implementation of the MachineProvider interface.
@@ -201,10 +238,6 @@ func (m *openshiftMachineProvider) GetMachineInfos(ctx context.Context, logger l
 	}
 
 	for _, machine := range machineList.Items {
-		if err := m.ensureValidProviderConfig(ctx); err != nil {
-			return nil, fmt.Errorf("could not ensure the validity of a provider config: %w", err)
-		}
-
 		machineInfo, err := m.generateMachineInfo(ctx, logger, machine)
 		if err != nil {
 			return nil, fmt.Errorf("could not generate machine info for machine %s: %w", machine.Name, err)
@@ -284,40 +317,6 @@ func (m *openshiftMachineProvider) generateMachineInfo(ctx context.Context, logg
 		Index:        machineIndex,
 		ErrorMessage: pointer.StringDeref(machine.Status.ErrorMessage, ""),
 	}, nil
-}
-
-// ensureValidProviderConfig makes sure that the provider config is valid by dry-run creating a machine.
-func (m *openshiftMachineProvider) ensureValidProviderConfig(ctx context.Context) error {
-	machine := &machinev1beta1.Machine{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        "tmp-machine-dry-run",
-			Namespace:   m.namespace,
-			Annotations: m.machineTemplate.ObjectMeta.Annotations,
-			Labels:      m.machineTemplate.ObjectMeta.Labels,
-		},
-		Spec: m.machineTemplate.Spec,
-	}
-
-	rawConfig, err := m.providerConfig.RawConfig()
-	if err != nil {
-		return fmt.Errorf("could not fetch raw config from provider config: %w", err)
-	}
-
-	machine.Spec.ProviderSpec.Value.Raw = rawConfig
-
-	dryRunClient := client.NewDryRunClient(m.client)
-	if err := dryRunClient.Create(ctx, machine); err != nil {
-		return fmt.Errorf("could not dry-run create the machine: %w", err)
-	}
-
-	providerConfig, err := providerconfig.NewProviderConfigFromMachineSpec(machine.Spec)
-	if err != nil {
-		return fmt.Errorf("could not get provider config for machine: %w", err)
-	}
-
-	m.providerConfig = providerConfig
-
-	return nil
 }
 
 func (m *openshiftMachineProvider) getMachineIndex(logger logr.Logger, machine machinev1beta1.Machine) (int32, error) {

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/provider_test.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/provider_test.go
@@ -226,6 +226,7 @@ var _ = Describe("MachineProvider", func() {
 				machineSelector:      cpms.Spec.Selector,
 				machineTemplate:      *template,
 				providerConfig:       providerConfig,
+				namespace:            namespaceName,
 			}
 
 			machineInfos, err := provider.GetMachineInfos(ctx, logger.Logger())
@@ -1576,6 +1577,7 @@ var _ = Describe("MachineProvider", func() {
 					UID: types.UID(ownerUID),
 				},
 				providerConfig: providerConfig,
+				namespace:      namespaceName,
 			}
 
 			machineBuilder := machinev1beta1resourcebuilder.Machine().AsMaster().

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -88,6 +88,9 @@ type Framework interface {
 	// ConvertToControlPlaneMachineSetProviderSpec converts a control plane machine provider spec
 	// to a control plane machine set suitable provider spec.
 	ConvertToControlPlaneMachineSetProviderSpec(providerSpec machinev1beta1.ProviderSpec) (*runtime.RawExtension, error)
+
+	// RemoveDefaultedValueFromCPMS removes a value that is defaulted by the defaulting webhook in the MAO
+	RemoveDefaultedValueFromCPMS(rawProviderSpec *runtime.RawExtension) (*runtime.RawExtension, error)
 }
 
 // PlatformSupportLevel is used to identify which tests should run
@@ -222,6 +225,75 @@ func (f *framework) IncreaseProviderSpecInstanceSize(rawProviderSpec *runtime.Ra
 	default:
 		return fmt.Errorf("%w: %s", errUnsupportedPlatform, f.platform)
 	}
+}
+
+// RemoveDefaultedValueFromCPMS removes a defaulted value from the ControlPlaneMachineSet
+// for either AWS, Azure or GCP.
+func (f *framework) RemoveDefaultedValueFromCPMS(rawProviderSpec *runtime.RawExtension) (*runtime.RawExtension, error) {
+	providerConfig, err := providerconfig.NewProviderConfigFromMachineSpec(machinev1beta1.MachineSpec{
+		ProviderSpec: machinev1beta1.ProviderSpec{
+			Value: rawProviderSpec,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get provider config: %w", err)
+	}
+
+	switch f.platform {
+	case configv1.AzurePlatformType:
+		return removeCredentialsSecretNameAzure(providerConfig)
+	case configv1.AWSPlatformType:
+		return removeCredentialsSecretNameAWS(providerConfig)
+	case configv1.GCPPlatformType:
+		return removeCredentialsSecretNameGCP(providerConfig)
+	default:
+		return nil, fmt.Errorf("%w: %s", errUnsupportedPlatform, f.platform)
+	}
+}
+
+// removeVMSize remove the credentialSecret.Name field from the ControlPlaneMachineSet.
+func removeCredentialsSecretNameAzure(providerConfig providerconfig.ProviderConfig) (*runtime.RawExtension, error) {
+	cfg := providerConfig.Azure().Config()
+	cfg.CredentialsSecret.Name = ""
+
+	rawBytes, err := json.Marshal(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling aws providerSpec: %w", err)
+	}
+
+	return &runtime.RawExtension{
+		Raw: rawBytes,
+	}, nil
+}
+
+// removeInstanceType remove the credentialSecret.Name field from the ControlPlaneMachineSet.
+func removeCredentialsSecretNameAWS(providerConfig providerconfig.ProviderConfig) (*runtime.RawExtension, error) {
+	cfg := providerConfig.AWS().Config()
+	cfg.CredentialsSecret.Name = ""
+
+	rawBytes, err := json.Marshal(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling aws providerSpec: %w", err)
+	}
+
+	return &runtime.RawExtension{
+		Raw: rawBytes,
+	}, nil
+}
+
+// removeMachineType remove the credentialSecret.Name field from the ControlPlaneMachineSet.
+func removeCredentialsSecretNameGCP(providerConfig providerconfig.ProviderConfig) (*runtime.RawExtension, error) {
+	cfg := providerConfig.GCP().Config()
+	cfg.CredentialsSecret.Name = ""
+
+	rawBytes, err := json.Marshal(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling aws providerSpec: %w", err)
+	}
+
+	return &runtime.RawExtension{
+		Raw: rawBytes,
+	}, nil
 }
 
 // ConvertToControlPlaneMachineSetProviderSpec converts a control plane machine provider spec

--- a/test/e2e/helpers/controlplanemachineset.go
+++ b/test/e2e/helpers/controlplanemachineset.go
@@ -329,9 +329,11 @@ func GetControlPlaneMachineSetUID(testFramework framework.Framework) types.UID {
 	return cpms.ObjectMeta.UID
 }
 
-// MakeControlPlaneMachineSetProviderConfigInvalid makes the current ControlPlaneMachineSet's providerSpec invalid
-// by removing a defaulted value.
-func MakeControlPlaneMachineSetProviderConfigInvalid(testFramework framework.Framework, gomegaArgs ...interface{}) machinev1beta1.ProviderSpec {
+// UpdateDefaultedValueFromControlPlaneMachineSetProviderConfig updates a defaulted field value from the Control Plane Machine Set's
+// provider config to test defaulting on such value.
+func UpdateDefaultedValueFromControlPlaneMachineSetProviderConfig(testFramework framework.Framework, set bool, gomegaArgs ...interface{}) machinev1beta1.ProviderSpec {
+	Expect(testFramework).ToNot(BeNil(), "test framework should not be nil")
+
 	cpms := testFramework.NewEmptyControlPlaneMachineSet()
 
 	Eventually(komega.Get(cpms), gomegaArgs...).Should(Succeed(), "control plane machine set should exist")
@@ -339,7 +341,7 @@ func MakeControlPlaneMachineSetProviderConfigInvalid(testFramework framework.Fra
 	originalProviderSpec := cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec.ProviderSpec
 
 	updatedProviderSpec := originalProviderSpec.DeepCopy()
-	rawExtension, err := testFramework.RemoveDefaultedValueFromCPMS(updatedProviderSpec.Value)
+	rawExtension, err := testFramework.UpdateDefaultedValueFromCPMS(updatedProviderSpec.Value, set)
 	Expect(err).NotTo(HaveOccurred())
 
 	updatedProviderSpec.Value = rawExtension

--- a/test/e2e/helpers/controlplanemachineset.go
+++ b/test/e2e/helpers/controlplanemachineset.go
@@ -331,7 +331,7 @@ func GetControlPlaneMachineSetUID(testFramework framework.Framework) types.UID {
 
 // UpdateDefaultedValueFromControlPlaneMachineSetProviderConfig updates a defaulted field value from the Control Plane Machine Set's
 // provider config to test defaulting on such value.
-func UpdateDefaultedValueFromControlPlaneMachineSetProviderConfig(testFramework framework.Framework, set bool, gomegaArgs ...interface{}) machinev1beta1.ProviderSpec {
+func UpdateDefaultedValueFromControlPlaneMachineSetProviderConfig(testFramework framework.Framework, gomegaArgs ...interface{}) machinev1beta1.ProviderSpec {
 	Expect(testFramework).ToNot(BeNil(), "test framework should not be nil")
 
 	cpms := testFramework.NewEmptyControlPlaneMachineSet()
@@ -341,7 +341,7 @@ func UpdateDefaultedValueFromControlPlaneMachineSetProviderConfig(testFramework 
 	originalProviderSpec := cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec.ProviderSpec
 
 	updatedProviderSpec := originalProviderSpec.DeepCopy()
-	rawExtension, err := testFramework.UpdateDefaultedValueFromCPMS(updatedProviderSpec.Value, set)
+	rawExtension, err := testFramework.UpdateDefaultedValueFromCPMS(updatedProviderSpec.Value)
 	Expect(err).NotTo(HaveOccurred())
 
 	updatedProviderSpec.Value = rawExtension
@@ -353,4 +353,19 @@ func UpdateDefaultedValueFromControlPlaneMachineSetProviderConfig(testFramework 
 	}), gomegaArgs...).Should(Succeed(), "control plane machine set should be able to be updated")
 
 	return originalProviderSpec
+}
+
+// UpdateControlPlaneMachineSetProviderSpec updates the provider spec of the control plane machine set to match the provider spec given.
+func UpdateControlPlaneMachineSetProviderSpec(testFramework framework.Framework, updatedProviderSpec machinev1beta1.ProviderSpec, gomegaArgs ...interface{}) {
+	By("Updating the provider spec of the control plane machine set")
+
+	Expect(testFramework).ToNot(BeNil(), "test framework should not be nil")
+
+	cpms := testFramework.NewEmptyControlPlaneMachineSet()
+
+	Eventually(komega.Get(cpms), gomegaArgs...).Should(Succeed(), "control plane machine set should exist")
+
+	Eventually(komega.Update(cpms, func() {
+		cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec.ProviderSpec = updatedProviderSpec
+	}), gomegaArgs...).Should(Succeed(), "control plane machine should be able to be updated")
 }

--- a/test/e2e/helpers/controlplanemachineset.go
+++ b/test/e2e/helpers/controlplanemachineset.go
@@ -328,3 +328,27 @@ func GetControlPlaneMachineSetUID(testFramework framework.Framework) types.UID {
 
 	return cpms.ObjectMeta.UID
 }
+
+// MakeControlPlaneMachineSetProviderConfigInvalid makes the current ControlPlaneMachineSet's providerSpec invalid
+// by removing a defaulted value.
+func MakeControlPlaneMachineSetProviderConfigInvalid(testFramework framework.Framework, gomegaArgs ...interface{}) machinev1beta1.ProviderSpec {
+	cpms := testFramework.NewEmptyControlPlaneMachineSet()
+
+	Eventually(komega.Get(cpms), gomegaArgs...).Should(Succeed(), "control plane machine set should exist")
+
+	originalProviderSpec := cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec.ProviderSpec
+
+	updatedProviderSpec := originalProviderSpec.DeepCopy()
+	rawExtension, err := testFramework.RemoveDefaultedValueFromCPMS(updatedProviderSpec.Value)
+	Expect(err).NotTo(HaveOccurred())
+
+	updatedProviderSpec.Value = rawExtension
+
+	By("Removing the defaulted field from the control plane machine set")
+
+	Eventually(komega.Update(cpms, func() {
+		cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec.ProviderSpec = *updatedProviderSpec
+	}), gomegaArgs...).Should(Succeed(), "control plane machine set should be able to be updated")
+
+	return originalProviderSpec
+}

--- a/test/e2e/presubmit_test.go
+++ b/test/e2e/presubmit_test.go
@@ -104,16 +104,15 @@ var _ = Describe("ControlPlaneMachineSet Operator", framework.PreSubmit(), func(
 		})
 
 		Context("and a defaulted value is deleted from the ControlPlaneMachineSet", func() {
+			var originalProviderSpec machinev1beta1.ProviderSpec
 			BeforeEach(func() {
 				_ = helpers.EnsureControlPlaneMachineSetUpdateStrategy(testFramework, machinev1.RollingUpdate)
-				// Unset the defaulted field
-				helpers.UpdateDefaultedValueFromControlPlaneMachineSetProviderConfig(testFramework, false)
+				originalProviderSpec = helpers.UpdateDefaultedValueFromControlPlaneMachineSetProviderConfig(testFramework)
 			})
 
 			AfterEach(func() {
 				helpers.EnsureActiveControlPlaneMachineSet(testFramework)
-				// Set the defaulted field back
-				helpers.UpdateDefaultedValueFromControlPlaneMachineSetProviderConfig(testFramework, true)
+				helpers.UpdateControlPlaneMachineSetProviderSpec(testFramework, originalProviderSpec)
 			})
 
 			helpers.ItShouldNotCauseARollout(testFramework)

--- a/test/e2e/presubmit_test.go
+++ b/test/e2e/presubmit_test.go
@@ -38,19 +38,6 @@ var _ = Describe("ControlPlaneMachineSet Operator", framework.PreSubmit(), func(
 			helpers.EnsureActiveControlPlaneMachineSet(testFramework)
 		}, OncePerOrdered)
 
-		Context("and the defaulted value delete from the ControlPlaneMachineSet", func() {
-			BeforeEach(func() {
-				_ = helpers.EnsureControlPlaneMachineSetUpdateStrategy(testFramework, machinev1.RollingUpdate)
-				helpers.MakeControlPlaneMachineSetProviderConfigInvalid(testFramework)
-			})
-
-			AfterEach(func() {
-				helpers.EnsureActiveControlPlaneMachineSet(testFramework)
-			})
-
-			helpers.ItShouldNotCauseARollout(testFramework)
-		})
-
 		Context("and the instance type of index 1 is not as expected", func() {
 			BeforeEach(func() {
 				helpers.IncreaseControlPlaneMachineInstanceSize(testFramework, 1)
@@ -114,6 +101,22 @@ var _ = Describe("ControlPlaneMachineSet Operator", framework.PreSubmit(), func(
 					helpers.ItShouldCheckAllControlPlaneMachinesHaveCorrectOwnerReferences(testFramework)
 				})
 			})
+		})
+
+		Context("and a defaulted value is deleted from the ControlPlaneMachineSet", func() {
+			BeforeEach(func() {
+				_ = helpers.EnsureControlPlaneMachineSetUpdateStrategy(testFramework, machinev1.RollingUpdate)
+				// Unset the defaulted field
+				helpers.UpdateDefaultedValueFromControlPlaneMachineSetProviderConfig(testFramework, false)
+			})
+
+			AfterEach(func() {
+				helpers.EnsureActiveControlPlaneMachineSet(testFramework)
+				// Set the defaulted field back
+				helpers.UpdateDefaultedValueFromControlPlaneMachineSetProviderConfig(testFramework, true)
+			})
+
+			helpers.ItShouldNotCauseARollout(testFramework)
 		})
 	})
 

--- a/test/e2e/presubmit_test.go
+++ b/test/e2e/presubmit_test.go
@@ -38,6 +38,19 @@ var _ = Describe("ControlPlaneMachineSet Operator", framework.PreSubmit(), func(
 			helpers.EnsureActiveControlPlaneMachineSet(testFramework)
 		}, OncePerOrdered)
 
+		Context("and the defaulted value delete from the ControlPlaneMachineSet", func() {
+			BeforeEach(func() {
+				_ = helpers.EnsureControlPlaneMachineSetUpdateStrategy(testFramework, machinev1.RollingUpdate)
+				helpers.MakeControlPlaneMachineSetProviderConfigInvalid(testFramework)
+			})
+
+			AfterEach(func() {
+				helpers.EnsureActiveControlPlaneMachineSet(testFramework)
+			})
+
+			helpers.ItShouldNotCauseARollout(testFramework)
+		})
+
 		Context("and the instance type of index 1 is not as expected", func() {
 			BeforeEach(func() {
 				helpers.IncreaseControlPlaneMachineInstanceSize(testFramework, 1)


### PR DESCRIPTION
If we remove the `vmSize` field from the CPMS ProviderSpec on Azure, the master machine gets stuck in a loop of provisiong/deleting states.
We try to fix this by adding a defaulting webhook for Azure's ProviderSpec, specifically for the `vmSize` field. If we see that this field is empty, we provide the ProviderSpec with a default value for that field.

- [x] Propose a solution
- [ ] Come up with reasonable pre-submit E2E test covering this
- [x] Test this on a running Azure cluster