### PR TITLE
OCPBUGS-11142: controlplanemachineset: start watching control plane nodes

### DIFF
--- a/cmd/control-plane-machine-set-operator/main.go
+++ b/cmd/control-plane-machine-set-operator/main.go
@@ -20,6 +20,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/spf13/pflag"
@@ -79,6 +80,9 @@ func main() { //nolint:funlen,cyclop
 			LeaderElect:  true,
 			ResourceName: defaultLeaderElectionID,
 		}
+
+		// defaultSyncPeriod is the default period after which to trigger controller's cache resync.
+		defaultSyncPeriod = 30 * time.Minute
 	)
 
 	pflag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
@@ -114,6 +118,8 @@ func main() { //nolint:funlen,cyclop
 		RetryPeriod:             &le.RetryPeriod.Duration,
 		RenewDeadline:           &le.RenewDeadline.Duration,
 		Namespace:               managedNamespace,
+		// Do a full resync to catch up in case of missing events.
+		SyncPeriod: &defaultSyncPeriod,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -24,7 +24,7 @@ fi
 
 # Exclude the specific E2E package as this is not a unit test.
 # This regex should allow packages under the e2e dir to still be tested.
-TEST_PACKAGES=$(go list -f "{{ .Dir }}" ./... | grep -v cluster-control-plane-machine-set-operator/test/e2e$)
+TEST_PACKAGES=${TEST_PACKAGES:-$(go list -f "{{ .Dir }}" ./... | grep -v cluster-control-plane-machine-set-operator/test/e2e$)}
 
 # Print the command we are going to run as Make would.
 echo ${GINKGO} ${GINKGO_ARGS} ${GINKGO_EXTRA_ARGS} "<omitted>"

--- a/pkg/controllers/controlplanemachineset/controller.go
+++ b/pkg/controllers/controlplanemachineset/controller.go
@@ -124,6 +124,11 @@ func (r *ControlPlaneMachineSetReconciler) SetupWithManager(mgr ctrl.Manager) er
 			builder.WithPredicates(util.FilterControlPlaneMachines(r.Namespace)),
 		).
 		Watches(
+			&source.Kind{Type: &corev1.Node{}},
+			handler.EnqueueRequestsFromMapFunc(util.ObjToControlPlaneMachineSet(clusterControlPlaneMachineSetName, r.Namespace)),
+			builder.WithPredicates(util.FilterControlPlaneNodes()),
+		).
+		Watches(
 			&source.Kind{Type: &configv1.ClusterOperator{}},
 			handler.EnqueueRequestsFromMapFunc(util.ObjToControlPlaneMachineSet(clusterControlPlaneMachineSetName, r.Namespace)),
 			builder.WithPredicates(util.FilterClusterOperator(r.OperatorName)),

--- a/pkg/util/suite_test.go
+++ b/pkg/util/suite_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	configv1 "github.com/openshift/api/config/v1"
+	machinev1 "github.com/openshift/api/machine/v1"
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	//+kubebuilder:scaffold:imports
+)
+
+var cfg *rest.Config
+var k8sClient client.Client
+var testEnv *envtest.Environment
+var testScheme *runtime.Scheme
+var ctx = context.Background()
+
+func TestUtil(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Util Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "vendor", "github.com", "openshift", "api", "machine", "v1"),
+			filepath.Join("..", "..", "vendor", "github.com", "openshift", "api", "machine", "v1beta1"),
+			filepath.Join("..", "..", "vendor", "github.com", "openshift", "api", "config", "v1"),
+		},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	var err error
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	testScheme = scheme.Scheme
+	Expect(machinev1.Install(testScheme)).To(Succeed())
+	Expect(machinev1beta1.Install(testScheme)).To(Succeed())
+	Expect(configv1.Install(testScheme)).To(Succeed())
+
+	//+kubebuilder:scaffold:scheme
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: testScheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+	komega.SetClient(k8sClient)
+	komega.SetContext(ctx)
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/pkg/util/watch_filters.go
+++ b/pkg/util/watch_filters.go
@@ -22,8 +22,12 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	machinev1 "github.com/openshift/api/machine/v1"
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+
+	corev1 "k8s.io/api/core/v1"
+
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -34,6 +38,12 @@ const (
 
 	// machineTypeLabelName is the label used to identify the type of a machine.
 	machineTypeLabelName = "machine.openshift.io/cluster-api-machine-type"
+
+	// nodeRoleMasterLabelName is the label used to identify the role of the node.
+	nodeRoleMasterLabelName = "node-role.kubernetes.io/master"
+
+	// nodeRoleControlPlaneLabelName is the label used to identify the role of the node.
+	nodeRoleControlPlaneLabelName = "node-role.kubernetes.io/control-plane"
 
 	// machineMasterRoleLabelName is the label value to identify the role of a control plane machine.
 	machineMasterRoleLabelName = "master"
@@ -119,4 +129,85 @@ func FilterControlPlaneMachines(namespace string) predicate.Predicate {
 			(labels[machineTypeLabelName] == machineMasterTypeLabelName ||
 				labels[machineTypeLabelName] == machineControlPlaneTypeLabelName)
 	})
+}
+
+// FilterControlPlaneNodes filters nodes requests to just the nodes that present as control plane nodes
+// and that have had a transition in the NodeReady condition.
+func FilterControlPlaneNodes() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			node, ok := e.Object.(*corev1.Node)
+			if !ok {
+				panic(fmt.Sprintf("expected to get an of object of type corev1.Node: got type %T", e.Object))
+			}
+
+			return isControlPlaneNode(node)
+		},
+		UpdateFunc: updateFuncFilterControlPlaneNodes,
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			node, ok := e.Object.(*corev1.Node)
+			if !ok {
+				panic(fmt.Sprintf("expected to get an of object of type corev1.Node: got type %T", e.Object))
+			}
+
+			return isControlPlaneNode(node)
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			if _, ok := e.Object.(*corev1.Node); !ok {
+				panic(fmt.Sprintf("expected to get an of object of type corev1.Node: got type %T", e.Object))
+			}
+
+			// We are only interested in events that can change a Node status,
+			// so we ignore generic events.
+			return false
+		},
+	}
+}
+
+// isControlPlaneNode checks whether the provided node is a control plane one.
+func isControlPlaneNode(node *corev1.Node) bool {
+	// Ensuring that this is a master machine by checking required labels.
+	labels := node.GetLabels()
+	_, hasMasterLabel := labels[nodeRoleMasterLabelName]
+	_, hasControlPlaneLabel := labels[nodeRoleControlPlaneLabelName]
+
+	// Only consider if Node is a control plane.
+	return hasMasterLabel || hasControlPlaneLabel
+}
+
+// updateFuncFilterControlPlaneNodes filters an event based on whether the node is a control plane
+// or not and if it has recently transitioned in its readiness status.
+func updateFuncFilterControlPlaneNodes(e event.UpdateEvent) bool {
+	node, ok := e.ObjectNew.(*corev1.Node)
+	if !ok {
+		panic(fmt.Sprintf("expected to get an of object of type corev1.Node: got type %T", e.ObjectNew))
+	}
+
+	oldNode, ok := e.ObjectOld.(*corev1.Node)
+	if !ok && oldNode != nil {
+		panic(fmt.Sprintf("expected to get an of object of type corev1.Node: got type %T", e.ObjectOld))
+	}
+
+	if !isControlPlaneNode(node) {
+		return false
+	}
+
+	var wasNodeReady, isNodeReady corev1.ConditionStatus
+
+	for _, c := range oldNode.Status.Conditions {
+		if c.Type == corev1.NodeReady {
+			wasNodeReady = c.Status
+			break
+		}
+	}
+
+	for _, c := range node.Status.Conditions {
+		if c.Type == corev1.NodeReady {
+			isNodeReady = c.Status
+			break
+		}
+	}
+
+	// Only consider if the node has changed in its readiness.
+	return wasNodeReady != isNodeReady
 }

--- a/pkg/util/watch_filters_test.go
+++ b/pkg/util/watch_filters_test.go
@@ -20,9 +20,11 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	configv1resourcebuilder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/config/v1"
+	corev1resourcebuilder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/core/v1"
 	machinev1resourcebuilder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/machine/v1"
 	machinev1beta1resourcebuilder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/machine/v1beta1"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -72,6 +74,14 @@ var _ = Describe("Watch Filters", func() {
 	updateEvent := func(obj client.Object) event.UpdateEvent {
 		return event.UpdateEvent{
 			ObjectNew: obj,
+		}
+	}
+
+	// updateEventFull is used to pass objects to the predicate Update function.
+	updateEventFull := func(objOld client.Object, objNew client.Object) event.UpdateEvent {
+		return event.UpdateEvent{
+			ObjectNew: objNew,
+			ObjectOld: objOld,
 		}
 	}
 
@@ -296,6 +306,140 @@ var _ = Describe("Watch Filters", func() {
 			Expect(machinePredicate.Update(updateEvent(machine))).To(BeTrue())
 			Expect(machinePredicate.Delete(deleteEvent(machine))).To(BeTrue())
 			Expect(machinePredicate.Generic(genericEvent(machine))).To(BeTrue())
+		})
+	})
+
+	Context("filterControlPlaneNodes", func() {
+		var nodesPredicate predicate.Predicate
+
+		BeforeEach(func() {
+			nodesPredicate = FilterControlPlaneNodes()
+		})
+
+		It("Panics with the wrong object kind", func() {
+			expectedMessage := "expected to get an of object of type corev1.Node: got type *v1.ControlPlaneMachineSet"
+			cpms := machinev1resourcebuilder.ControlPlaneMachineSet().Build()
+
+			Expect(func() {
+				nodesPredicate.Create(createEvent(cpms))
+			}).To(PanicWith(expectedMessage), "A programming error occurs when passing the wrong object, the function should panic")
+
+			Expect(func() {
+				nodesPredicate.Update(updateEventFull(cpms, cpms))
+			}).To(PanicWith(expectedMessage), "A programming error occurs when passing the wrong object, the function should panic")
+
+			Expect(func() {
+				nodesPredicate.Delete(deleteEvent(cpms))
+			}).To(PanicWith(expectedMessage), "A programming error occurs when passing the wrong object, the function should panic")
+
+			Expect(func() {
+				nodesPredicate.Generic(genericEvent(cpms))
+			}).To(PanicWith(expectedMessage), "A programming error occurs when passing the wrong object, the function should panic")
+		})
+
+		It("Returns false with worker node", func() {
+			node := corev1resourcebuilder.Node().AsWorker().Build()
+
+			Expect(nodesPredicate.Create(createEvent(node))).To(BeFalse())
+			Expect(nodesPredicate.Update(updateEvent(node))).To(BeFalse())
+			Expect(nodesPredicate.Delete(deleteEvent(node))).To(BeFalse())
+			Expect(nodesPredicate.Generic(genericEvent(node))).To(BeFalse())
+		})
+
+		It("Returns true with master node transitioned from NotReady to Ready", func() {
+			oldNode := corev1resourcebuilder.Node().WithConditions(
+				[]corev1.NodeCondition{
+					{
+						Type:   corev1.NodeReady,
+						Status: corev1.ConditionFalse,
+					},
+				},
+			).AsMaster().Build()
+			node := corev1resourcebuilder.Node().WithConditions(
+				[]corev1.NodeCondition{
+					{
+						Type:   corev1.NodeReady,
+						Status: corev1.ConditionTrue,
+					},
+				},
+			).AsMaster().Build()
+
+			Expect(nodesPredicate.Create(createEvent(node))).To(BeTrue())
+			Expect(nodesPredicate.Update(updateEventFull(oldNode, node))).To(BeTrue())
+			Expect(nodesPredicate.Delete(deleteEvent(node))).To(BeTrue())
+			Expect(nodesPredicate.Generic(genericEvent(node))).To(BeFalse())
+		})
+
+		It("Returns true with master node transitioned from Ready to NotReady", func() {
+			oldNode := corev1resourcebuilder.Node().WithConditions(
+				[]corev1.NodeCondition{
+					{
+						Type:   corev1.NodeReady,
+						Status: corev1.ConditionTrue,
+					},
+				},
+			).AsMaster().Build()
+			node := corev1resourcebuilder.Node().WithConditions(
+				[]corev1.NodeCondition{
+					{
+						Type:   corev1.NodeReady,
+						Status: corev1.ConditionFalse,
+					},
+				},
+			).AsMaster().Build()
+
+			Expect(nodesPredicate.Create(createEvent(node))).To(BeTrue())
+			Expect(nodesPredicate.Update(updateEventFull(oldNode, node))).To(BeTrue())
+			Expect(nodesPredicate.Delete(deleteEvent(node))).To(BeTrue())
+			Expect(nodesPredicate.Generic(genericEvent(node))).To(BeFalse())
+		})
+
+		It("Returns false with master node stayed in Ready", func() {
+			oldNode := corev1resourcebuilder.Node().WithConditions(
+				[]corev1.NodeCondition{
+					{
+						Type:   corev1.NodeReady,
+						Status: corev1.ConditionTrue,
+					},
+				},
+			).AsMaster().Build()
+			node := corev1resourcebuilder.Node().WithConditions(
+				[]corev1.NodeCondition{
+					{
+						Type:   corev1.NodeReady,
+						Status: corev1.ConditionTrue,
+					},
+				},
+			).AsMaster().Build()
+
+			Expect(nodesPredicate.Create(createEvent(node))).To(BeTrue())
+			Expect(nodesPredicate.Update(updateEventFull(oldNode, node))).To(BeFalse())
+			Expect(nodesPredicate.Delete(deleteEvent(node))).To(BeTrue())
+			Expect(nodesPredicate.Generic(genericEvent(node))).To(BeFalse())
+		})
+
+		It("Returns false with master node stayed in NotReady", func() {
+			oldNode := corev1resourcebuilder.Node().WithConditions(
+				[]corev1.NodeCondition{
+					{
+						Type:   corev1.NodeReady,
+						Status: corev1.ConditionFalse,
+					},
+				},
+			).AsMaster().Build()
+			node := corev1resourcebuilder.Node().WithConditions(
+				[]corev1.NodeCondition{
+					{
+						Type:   corev1.NodeReady,
+						Status: corev1.ConditionFalse,
+					},
+				},
+			).AsMaster().Build()
+
+			Expect(nodesPredicate.Create(createEvent(node))).To(BeTrue())
+			Expect(nodesPredicate.Update(updateEventFull(oldNode, node))).To(BeFalse())
+			Expect(nodesPredicate.Delete(deleteEvent(node))).To(BeTrue())
+			Expect(nodesPredicate.Generic(genericEvent(node))).To(BeFalse())
 		})
 	})
 })


### PR DESCRIPTION
With the recent update in the logic for considering a CPMS replica Ready
only when both the backing Machine is running and the backing Node is
Ready: https://github.com/openshift/cluster-control-plane-machine-set-operator/pull/171, 
we now need to watch nodes at all times to detect nodes
transitioning in readiness.

Also set the SyncPeriod for all the controllers. This way if we miss any transitioning event
we will catch them anyway after the SyncPeriod.

Ancillary changes:
- pkg/util: add test suite
- hack: allow setting TEST_PACKAGES on make invocations
  `make unit TEST_PACKAGES="pkg/util <other> <other>"`
