### PR TITLE
OCPBUGS-11389: Use PlatformStatus instead of PlatformSpec to determine platform

### DIFF
--- a/pkg/controllers/controlplanemachinesetgenerator/controller.go
+++ b/pkg/controllers/controlplanemachinesetgenerator/controller.go
@@ -177,7 +177,7 @@ func (r *ControlPlaneMachineSetGeneratorReconciler) reconcile(ctx context.Contex
 	}
 
 	// generate an up to date ControlPlaneMachineSet based on the current cluster state.
-	generatedCPMS, err := r.generateControlPlaneMachineSet(logger, infrastructure.Spec.PlatformSpec.Type, machines, machineSets)
+	generatedCPMS, err := r.generateControlPlaneMachineSet(logger, infrastructure.Status.PlatformStatus.Type, machines, machineSets)
 	if errors.Is(err, errUnsupportedPlatform) {
 		// Do not requeue if the platform is not supported.
 		// Nothing to do in this case.


### PR DESCRIPTION
When determining the current platform, we should use PlatformStatus instead of PlatformSpec.