### PR TITLE
[release-4.12] OCPBUGS-8503: machine's node must be ready for CPMS machine to be ready + fixes

### DIFF
--- a/cmd/control-plane-machine-set-operator/main.go
+++ b/cmd/control-plane-machine-set-operator/main.go
@@ -20,6 +20,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/spf13/pflag"
@@ -79,6 +80,9 @@ func main() { //nolint:funlen,cyclop
 			LeaderElect:  true,
 			ResourceName: defaultLeaderElectionID,
 		}
+
+		// defaultSyncPeriod is the default period after which to trigger controller's cache resync.
+		defaultSyncPeriod = 30 * time.Minute
 	)
 
 	pflag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
@@ -114,6 +118,8 @@ func main() { //nolint:funlen,cyclop
 		RetryPeriod:             &le.RetryPeriod.Duration,
 		RenewDeadline:           &le.RenewDeadline.Duration,
 		Namespace:               managedNamespace,
+		// Do a full resync to catch up in case of missing events.
+		SyncPeriod: &defaultSyncPeriod,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -24,7 +24,7 @@ fi
 
 # Exclude the specific E2E package as this is not a unit test.
 # This regex should allow packages under the e2e dir to still be tested.
-TEST_PACKAGES=$(go list -f "{{ .Dir }}" ./... | grep -v cluster-control-plane-machine-set-operator/test/e2e$)
+TEST_PACKAGES=${TEST_PACKAGES:-$(go list -f "{{ .Dir }}" ./... | grep -v cluster-control-plane-machine-set-operator/test/e2e$)}
 
 # Print the command we are going to run as Make would.
 echo ${GINKGO} ${GINKGO_ARGS} ${GINKGO_EXTRA_ARGS} "<omitted>"

--- a/pkg/controllers/controlplanemachineset/controller.go
+++ b/pkg/controllers/controlplanemachineset/controller.go
@@ -124,6 +124,11 @@ func (r *ControlPlaneMachineSetReconciler) SetupWithManager(mgr ctrl.Manager) er
 			builder.WithPredicates(util.FilterControlPlaneMachines(r.Namespace)),
 		).
 		Watches(
+			&source.Kind{Type: &corev1.Node{}},
+			handler.EnqueueRequestsFromMapFunc(util.ObjToControlPlaneMachineSet(clusterControlPlaneMachineSetName, r.Namespace)),
+			builder.WithPredicates(util.FilterControlPlaneNodes()),
+		).
+		Watches(
 			&source.Kind{Type: &configv1.ClusterOperator{}},
 			handler.EnqueueRequestsFromMapFunc(util.ObjToControlPlaneMachineSet(clusterControlPlaneMachineSetName, r.Namespace)),
 			builder.WithPredicates(util.FilterClusterOperator(r.OperatorName)),

--- a/pkg/controllers/controlplanemachineset/controller_test.go
+++ b/pkg/controllers/controlplanemachineset/controller_test.go
@@ -145,6 +145,8 @@ var _ = Describe("With a running controller", func() {
 		)).
 		WithProviderSpecBuilder(resourcebuilder.AWSProviderSpec())
 
+	masterNodeBuilder := resourcebuilder.Node().AsMaster()
+
 	// Running phase for setting machines to running.
 	running := "Running"
 
@@ -225,19 +227,24 @@ var _ = Describe("With a running controller", func() {
 				By("Creating Machines owned by the ControlPlaneMachineSet")
 				machineBuilder := resourcebuilder.Machine().AsMaster().WithGenerateName("state-test-").WithNamespace(namespaceName)
 
-				Expect(k8sClient.Create(ctx, machineBuilder.WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build())).To(Succeed())
-				Expect(k8sClient.Create(ctx, machineBuilder.WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build())).To(Succeed())
-				Expect(k8sClient.Create(ctx, machineBuilder.WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build())).To(Succeed())
+				machines := map[int]resourcebuilder.MachineBuilder{
+					0: machineBuilder.WithProviderSpecBuilder(usEast1aProviderSpecBuilder),
+					1: machineBuilder.WithProviderSpecBuilder(usEast1bProviderSpecBuilder),
+					2: machineBuilder.WithProviderSpecBuilder(usEast1cProviderSpecBuilder),
+				}
 
-				By("Ensuring Machines are Running")
-				machines := &machinev1beta1.MachineList{}
-				Expect(k8sClient.List(ctx, machines)).To(Succeed())
+				for i := range machines {
+					nodeName := fmt.Sprintf("node-%d", i)
+					machineName := fmt.Sprintf("master-%d", i)
 
-				for _, machine := range machines.Items {
-					m := machine.DeepCopy()
+					machine := machines[i].WithName(machineName).Build()
 
-					Eventually(komega.UpdateStatus(m, func() {
-						m.Status.Phase = &running
+					Expect(k8sClient.Create(ctx, machine)).To(Succeed())
+					Expect(k8sClient.Create(ctx, masterNodeBuilder.WithName(nodeName).AsReady().Build())).To(Succeed())
+
+					Eventually(komega.UpdateStatus(machine, func() {
+						machine.Status.Phase = &running
+						machine.Status.NodeRef = &corev1.ObjectReference{Name: nodeName}
 					})).Should(Succeed())
 				}
 			})
@@ -261,20 +268,24 @@ var _ = Describe("With a running controller", func() {
 			BeforeEach(func() {
 				By("Creating Machines owned by the ControlPlaneMachineSet")
 				machineBuilder := resourcebuilder.Machine().AsMaster().WithNamespace(namespaceName)
+				machines := map[int]resourcebuilder.MachineBuilder{
+					0: machineBuilder.WithProviderSpecBuilder(usEast1aProviderSpecBuilder),
+					1: machineBuilder.WithProviderSpecBuilder(usEast1bProviderSpecBuilder),
+					2: machineBuilder.WithProviderSpecBuilder(usEast1cProviderSpecBuilder),
+				}
 
-				Expect(k8sClient.Create(ctx, machineBuilder.WithName("master-0").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build())).To(Succeed())
-				Expect(k8sClient.Create(ctx, machineBuilder.WithName("master-1").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build())).To(Succeed())
-				Expect(k8sClient.Create(ctx, machineBuilder.WithName("master-2").WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build())).To(Succeed())
+				for i := range machines {
+					nodeName := fmt.Sprintf("node-%d", i)
+					machineName := fmt.Sprintf("master-%d", i)
 
-				By("Ensuring Machines are Running")
-				machines := &machinev1beta1.MachineList{}
-				Expect(k8sClient.List(ctx, machines)).To(Succeed())
+					machine := machines[i].WithName(machineName).Build()
 
-				for _, machine := range machines.Items {
-					m := machine.DeepCopy()
+					Expect(k8sClient.Create(ctx, machine)).To(Succeed())
+					Expect(k8sClient.Create(ctx, masterNodeBuilder.WithName(nodeName).AsReady().Build())).To(Succeed())
 
-					Eventually(komega.UpdateStatus(m, func() {
-						m.Status.Phase = &running
+					Eventually(komega.UpdateStatus(machine, func() {
+						machine.Status.Phase = &running
+						machine.Status.NodeRef = &corev1.ObjectReference{Name: nodeName}
 					})).Should(Succeed())
 				}
 			})
@@ -299,19 +310,24 @@ var _ = Describe("With a running controller", func() {
 				By("Creating Machines owned by the ControlPlaneMachineSet")
 				machineBuilder := resourcebuilder.Machine().AsMaster().WithNamespace(namespaceName)
 
-				Expect(k8sClient.Create(ctx, machineBuilder.WithName("master-4").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build())).To(Succeed())
-				Expect(k8sClient.Create(ctx, machineBuilder.WithName("master-0").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build())).To(Succeed())
-				Expect(k8sClient.Create(ctx, machineBuilder.WithName("master-2").WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build())).To(Succeed())
+				machines := map[int]resourcebuilder.MachineBuilder{
+					4: machineBuilder.WithProviderSpecBuilder(usEast1aProviderSpecBuilder),
+					0: machineBuilder.WithProviderSpecBuilder(usEast1bProviderSpecBuilder),
+					2: machineBuilder.WithProviderSpecBuilder(usEast1cProviderSpecBuilder),
+				}
 
-				By("Ensuring Machines are Running")
-				machines := &machinev1beta1.MachineList{}
-				Expect(k8sClient.List(ctx, machines)).To(Succeed())
+				for i := range machines {
+					nodeName := fmt.Sprintf("node-%d", i)
+					machineName := fmt.Sprintf("master-%d", i)
 
-				for _, machine := range machines.Items {
-					m := machine.DeepCopy()
+					machine := machines[i].WithName(machineName).Build()
 
-					Eventually(komega.UpdateStatus(m, func() {
-						m.Status.Phase = &running
+					Expect(k8sClient.Create(ctx, machine)).To(Succeed())
+					Expect(k8sClient.Create(ctx, masterNodeBuilder.WithName(nodeName).AsReady().Build())).To(Succeed())
+
+					Eventually(komega.UpdateStatus(machine, func() {
+						machine.Status.Phase = &running
+						machine.Status.NodeRef = &corev1.ObjectReference{Name: nodeName}
 					})).Should(Succeed())
 				}
 			})
@@ -336,19 +352,24 @@ var _ = Describe("With a running controller", func() {
 				By("Creating Machines owned by the ControlPlaneMachineSet")
 				machineBuilder := resourcebuilder.Machine().AsMaster().WithNamespace(namespaceName)
 
-				Expect(k8sClient.Create(ctx, machineBuilder.WithName("master-3").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build())).To(Succeed())
-				Expect(k8sClient.Create(ctx, machineBuilder.WithName("master-4").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build())).To(Succeed())
-				Expect(k8sClient.Create(ctx, machineBuilder.WithName("master-5").WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build())).To(Succeed())
+				machines := map[int]resourcebuilder.MachineBuilder{
+					3: machineBuilder.WithProviderSpecBuilder(usEast1aProviderSpecBuilder),
+					4: machineBuilder.WithProviderSpecBuilder(usEast1bProviderSpecBuilder),
+					5: machineBuilder.WithProviderSpecBuilder(usEast1cProviderSpecBuilder),
+				}
 
-				By("Ensuring Machines are Running")
-				machines := &machinev1beta1.MachineList{}
-				Expect(k8sClient.List(ctx, machines)).To(Succeed())
+				for i := range machines {
+					nodeName := fmt.Sprintf("node-%d", i)
+					machineName := fmt.Sprintf("master-%d", i)
 
-				for _, machine := range machines.Items {
-					m := machine.DeepCopy()
+					machine := machines[i].WithName(machineName).Build()
 
-					Eventually(komega.UpdateStatus(m, func() {
-						m.Status.Phase = &running
+					Expect(k8sClient.Create(ctx, machine)).To(Succeed())
+					Expect(k8sClient.Create(ctx, masterNodeBuilder.WithName(nodeName).AsReady().Build())).To(Succeed())
+
+					Eventually(komega.UpdateStatus(machine, func() {
+						machine.Status.Phase = &running
+						machine.Status.NodeRef = &corev1.ObjectReference{Name: nodeName}
 					})).Should(Succeed())
 				}
 			})
@@ -373,19 +394,24 @@ var _ = Describe("With a running controller", func() {
 				By("Creating Machines owned by the ControlPlaneMachineSet")
 				machineBuilder := resourcebuilder.Machine().AsMaster().WithGenerateName("state-test-").WithNamespace(namespaceName)
 
-				Expect(k8sClient.Create(ctx, machineBuilder.WithProviderSpecBuilder(usEast1aProviderSpecBuilder.WithInstanceType("different")).Build())).To(Succeed())
-				Expect(k8sClient.Create(ctx, machineBuilder.WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build())).To(Succeed())
-				Expect(k8sClient.Create(ctx, machineBuilder.WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build())).To(Succeed())
+				machines := map[int]resourcebuilder.MachineBuilder{
+					0: machineBuilder.WithProviderSpecBuilder(usEast1aProviderSpecBuilder.WithInstanceType("different")),
+					1: machineBuilder.WithProviderSpecBuilder(usEast1bProviderSpecBuilder),
+					2: machineBuilder.WithProviderSpecBuilder(usEast1cProviderSpecBuilder),
+				}
 
-				By("Ensuring Machines are Running")
-				machines := &machinev1beta1.MachineList{}
-				Expect(k8sClient.List(ctx, machines)).To(Succeed())
+				for i := range machines {
+					nodeName := fmt.Sprintf("node-%d", i)
+					machineName := fmt.Sprintf("master-%d", i)
 
-				for _, machine := range machines.Items {
-					m := machine.DeepCopy()
+					machine := machines[i].WithName(machineName).Build()
 
-					Eventually(komega.UpdateStatus(m, func() {
-						m.Status.Phase = &running
+					Expect(k8sClient.Create(ctx, machine)).To(Succeed())
+					Expect(k8sClient.Create(ctx, masterNodeBuilder.WithName(nodeName).AsReady().Build())).To(Succeed())
+
+					Eventually(komega.UpdateStatus(machine, func() {
+						machine.Status.Phase = &running
+						machine.Status.NodeRef = &corev1.ObjectReference{Name: nodeName}
 					})).Should(Succeed())
 				}
 			})
@@ -494,19 +520,24 @@ var _ = Describe("With a running controller", func() {
 				By("Creating Machines owned by the ControlPlaneMachineSet")
 				machineBuilder := resourcebuilder.Machine().AsMaster().WithGenerateName("state-test-").WithNamespace(namespaceName)
 
-				Expect(k8sClient.Create(ctx, machineBuilder.WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build())).To(Succeed())
-				Expect(k8sClient.Create(ctx, machineBuilder.WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build())).To(Succeed())
-				Expect(k8sClient.Create(ctx, machineBuilder.WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build())).To(Succeed())
+				machines := map[int]resourcebuilder.MachineBuilder{
+					0: machineBuilder.WithProviderSpecBuilder(usEast1aProviderSpecBuilder),
+					1: machineBuilder.WithProviderSpecBuilder(usEast1bProviderSpecBuilder),
+					2: machineBuilder.WithProviderSpecBuilder(usEast1cProviderSpecBuilder),
+				}
 
-				By("Ensuring Machines are Running")
-				machines := &machinev1beta1.MachineList{}
-				Expect(k8sClient.List(ctx, machines)).To(Succeed())
+				for i := range machines {
+					nodeName := fmt.Sprintf("node-%d", i)
+					machineName := fmt.Sprintf("master-%d", i)
 
-				for _, machine := range machines.Items {
-					m := machine.DeepCopy()
+					machine := machines[i].WithName(machineName).Build()
 
-					Eventually(komega.UpdateStatus(m, func() {
-						m.Status.Phase = &running
+					Expect(k8sClient.Create(ctx, machine)).To(Succeed())
+					Expect(k8sClient.Create(ctx, masterNodeBuilder.WithName(nodeName).AsReady().Build())).To(Succeed())
+
+					Eventually(komega.UpdateStatus(machine, func() {
+						machine.Status.Phase = &running
+						machine.Status.NodeRef = &corev1.ObjectReference{Name: nodeName}
 					})).Should(Succeed())
 				}
 			})
@@ -531,19 +562,24 @@ var _ = Describe("With a running controller", func() {
 				By("Creating Machines owned by the ControlPlaneMachineSet")
 				machineBuilder := resourcebuilder.Machine().AsMaster().WithNamespace(namespaceName)
 
-				Expect(k8sClient.Create(ctx, machineBuilder.WithName("master-0").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build())).To(Succeed())
-				Expect(k8sClient.Create(ctx, machineBuilder.WithName("master-1").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build())).To(Succeed())
-				Expect(k8sClient.Create(ctx, machineBuilder.WithName("master-2").WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build())).To(Succeed())
+				machines := map[int]resourcebuilder.MachineBuilder{
+					0: machineBuilder.WithProviderSpecBuilder(usEast1aProviderSpecBuilder),
+					1: machineBuilder.WithProviderSpecBuilder(usEast1bProviderSpecBuilder),
+					2: machineBuilder.WithProviderSpecBuilder(usEast1cProviderSpecBuilder),
+				}
 
-				By("Ensuring Machines are Running")
-				machines := &machinev1beta1.MachineList{}
-				Expect(k8sClient.List(ctx, machines)).To(Succeed())
+				for i := range machines {
+					nodeName := fmt.Sprintf("node-%d", i)
+					machineName := fmt.Sprintf("master-%d", i)
 
-				for _, machine := range machines.Items {
-					m := machine.DeepCopy()
+					machine := machines[i].WithName(machineName).Build()
 
-					Eventually(komega.UpdateStatus(m, func() {
-						m.Status.Phase = &running
+					Expect(k8sClient.Create(ctx, machine)).To(Succeed())
+					Expect(k8sClient.Create(ctx, masterNodeBuilder.WithName(nodeName).AsReady().Build())).To(Succeed())
+
+					Eventually(komega.UpdateStatus(machine, func() {
+						machine.Status.Phase = &running
+						machine.Status.NodeRef = &corev1.ObjectReference{Name: nodeName}
 					})).Should(Succeed())
 				}
 			})
@@ -568,19 +604,24 @@ var _ = Describe("With a running controller", func() {
 				By("Creating Machines owned by the ControlPlaneMachineSet")
 				machineBuilder := resourcebuilder.Machine().AsMaster().WithNamespace(namespaceName)
 
-				Expect(k8sClient.Create(ctx, machineBuilder.WithName("master-4").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build())).To(Succeed())
-				Expect(k8sClient.Create(ctx, machineBuilder.WithName("master-0").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build())).To(Succeed())
-				Expect(k8sClient.Create(ctx, machineBuilder.WithName("master-2").WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build())).To(Succeed())
+				machines := map[int]resourcebuilder.MachineBuilder{
+					4: machineBuilder.WithProviderSpecBuilder(usEast1aProviderSpecBuilder),
+					0: machineBuilder.WithProviderSpecBuilder(usEast1bProviderSpecBuilder),
+					2: machineBuilder.WithProviderSpecBuilder(usEast1cProviderSpecBuilder),
+				}
 
-				By("Ensuring Machines are Running")
-				machines := &machinev1beta1.MachineList{}
-				Expect(k8sClient.List(ctx, machines)).To(Succeed())
+				for i := range machines {
+					nodeName := fmt.Sprintf("node-%d", i)
+					machineName := fmt.Sprintf("master-%d", i)
 
-				for _, machine := range machines.Items {
-					m := machine.DeepCopy()
+					machine := machines[i].WithName(machineName).Build()
 
-					Eventually(komega.UpdateStatus(m, func() {
-						m.Status.Phase = &running
+					Expect(k8sClient.Create(ctx, machine)).To(Succeed())
+					Expect(k8sClient.Create(ctx, masterNodeBuilder.WithName(nodeName).AsReady().Build())).To(Succeed())
+
+					Eventually(komega.UpdateStatus(machine, func() {
+						machine.Status.Phase = &running
+						machine.Status.NodeRef = &corev1.ObjectReference{Name: nodeName}
 					})).Should(Succeed())
 				}
 			})
@@ -601,27 +642,32 @@ var _ = Describe("With a running controller", func() {
 		})
 
 		Context("with machines indexed 3, 4, 5", func() {
-			var toDeleteMachine *machinev1beta1.Machine
+			var toDeleteMachineBuilder resourcebuilder.MachineBuilder
 
 			BeforeEach(func() {
 				By("Creating Machines owned by the ControlPlaneMachineSet")
 				machineBuilder := resourcebuilder.Machine().AsMaster().WithNamespace(namespaceName)
 
-				Expect(k8sClient.Create(ctx, machineBuilder.WithName("master-3").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build())).To(Succeed())
+				toDeleteMachineBuilder = machineBuilder.WithName("master-4").WithProviderSpecBuilder(usEast1bProviderSpecBuilder)
 
-				toDeleteMachine = machineBuilder.WithName("master-4").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build()
-				Expect(k8sClient.Create(ctx, toDeleteMachine)).To(Succeed())
-				Expect(k8sClient.Create(ctx, machineBuilder.WithName("master-5").WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build())).To(Succeed())
+				machines := map[int]resourcebuilder.MachineBuilder{
+					3: machineBuilder.WithProviderSpecBuilder(usEast1aProviderSpecBuilder),
+					4: toDeleteMachineBuilder,
+					5: machineBuilder.WithProviderSpecBuilder(usEast1cProviderSpecBuilder),
+				}
 
-				By("Ensuring Machines are Running")
-				machines := &machinev1beta1.MachineList{}
-				Expect(k8sClient.List(ctx, machines)).To(Succeed())
+				for i := range machines {
+					nodeName := fmt.Sprintf("node-%d", i)
+					machineName := fmt.Sprintf("master-%d", i)
 
-				for _, machine := range machines.Items {
-					m := machine.DeepCopy()
+					machine := machines[i].WithName(machineName).Build()
 
-					Eventually(komega.UpdateStatus(m, func() {
-						m.Status.Phase = &running
+					Expect(k8sClient.Create(ctx, machine)).To(Succeed())
+					Expect(k8sClient.Create(ctx, masterNodeBuilder.WithName(nodeName).AsReady().Build())).To(Succeed())
+
+					Eventually(komega.UpdateStatus(machine, func() {
+						machine.Status.Phase = &running
+						machine.Status.NodeRef = &corev1.ObjectReference{Name: nodeName}
 					})).Should(Succeed())
 				}
 			})
@@ -642,6 +688,7 @@ var _ = Describe("With a running controller", func() {
 
 			Context("and a machine is deleted", func() {
 				BeforeEach(func() {
+					toDeleteMachine := toDeleteMachineBuilder.Build()
 					Eventually(komega.Update(toDeleteMachine, func() {
 						toDeleteMachine.SetFinalizers([]string{"machine.openshift.io/machine"})
 					})).Should(Succeed())
@@ -665,27 +712,30 @@ var _ = Describe("With a running controller", func() {
 		})
 
 		Context("with a machine needing an update", func() {
-			var differentMachine *machinev1beta1.Machine
+			var differentMachineBuilder resourcebuilder.MachineBuilder
 
 			BeforeEach(func() {
 				By("Creating Machines owned by the ControlPlaneMachineSet")
 				machineBuilder := resourcebuilder.Machine().AsMaster().WithGenerateName("state-test-").WithNamespace(namespaceName)
 
-				differentMachine = machineBuilder.WithProviderSpecBuilder(usEast1aProviderSpecBuilder.WithInstanceType("different")).Build()
-				Expect(k8sClient.Create(ctx, differentMachine)).To(Succeed())
+				differentMachineBuilder = machineBuilder.WithProviderSpecBuilder(usEast1aProviderSpecBuilder.WithInstanceType("different")).WithName("master-0")
+				machines := map[int]resourcebuilder.MachineBuilder{
+					0: differentMachineBuilder,
+					1: machineBuilder.WithProviderSpecBuilder(usEast1bProviderSpecBuilder),
+					2: machineBuilder.WithProviderSpecBuilder(usEast1cProviderSpecBuilder),
+				}
 
-				Expect(k8sClient.Create(ctx, machineBuilder.WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build())).To(Succeed())
-				Expect(k8sClient.Create(ctx, machineBuilder.WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build())).To(Succeed())
+				for i := range machines {
+					nodeName := fmt.Sprintf("node-%d", i)
 
-				By("Ensuring Machines are Running")
-				machines := &machinev1beta1.MachineList{}
-				Expect(k8sClient.List(ctx, machines)).To(Succeed())
+					machine := machines[i].Build()
 
-				for _, machine := range machines.Items {
-					m := machine.DeepCopy()
+					Expect(k8sClient.Create(ctx, machine)).To(Succeed())
+					Expect(k8sClient.Create(ctx, masterNodeBuilder.WithName(nodeName).AsReady().Build())).To(Succeed())
 
-					Eventually(komega.UpdateStatus(m, func() {
-						m.Status.Phase = &running
+					Eventually(komega.UpdateStatus(machine, func() {
+						machine.Status.Phase = &running
+						machine.Status.NodeRef = &corev1.ObjectReference{Name: nodeName}
 					})).Should(Succeed())
 				}
 			})
@@ -709,6 +759,8 @@ var _ = Describe("With a running controller", func() {
 
 			Context("and the machine is deleted", func() {
 				BeforeEach(func() {
+					differentMachine := differentMachineBuilder.Build()
+
 					Eventually(komega.Update(differentMachine, func() {
 						differentMachine.SetFinalizers([]string{"machine.openshift.io/machine"})
 					})).Should(Succeed())
@@ -817,19 +869,24 @@ var _ = Describe("With a running controller", func() {
 				By("Creating Machines owned by the ControlPlaneMachineSet")
 				machineBuilder := resourcebuilder.Machine().AsMaster().WithGenerateName("state-test-").WithNamespace(namespaceName)
 
-				Expect(k8sClient.Create(ctx, machineBuilder.WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build())).To(Succeed())
-				Expect(k8sClient.Create(ctx, machineBuilder.WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build())).To(Succeed())
-				Expect(k8sClient.Create(ctx, machineBuilder.WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build())).To(Succeed())
+				machines := map[int]resourcebuilder.MachineBuilder{
+					0: machineBuilder.WithProviderSpecBuilder(usEast1aProviderSpecBuilder),
+					1: machineBuilder.WithProviderSpecBuilder(usEast1bProviderSpecBuilder),
+					2: machineBuilder.WithProviderSpecBuilder(usEast1cProviderSpecBuilder),
+				}
 
-				By("Ensuring Machines are Running")
-				machines := &machinev1beta1.MachineList{}
-				Expect(k8sClient.List(ctx, machines)).To(Succeed())
+				for i := range machines {
+					nodeName := fmt.Sprintf("node-%d", i)
+					machineName := fmt.Sprintf("master-%d", i)
 
-				for _, machine := range machines.Items {
-					m := machine.DeepCopy()
+					machine := machines[i].WithName(machineName).Build()
 
-					Eventually(komega.UpdateStatus(m, func() {
-						m.Status.Phase = &running
+					Expect(k8sClient.Create(ctx, machine)).To(Succeed())
+					Expect(k8sClient.Create(ctx, masterNodeBuilder.WithName(nodeName).AsReady().Build())).To(Succeed())
+
+					Eventually(komega.UpdateStatus(machine, func() {
+						machine.Status.Phase = &running
+						machine.Status.NodeRef = &corev1.ObjectReference{Name: nodeName}
 					})).Should(Succeed())
 				}
 			})
@@ -853,19 +910,24 @@ var _ = Describe("With a running controller", func() {
 				By("Creating Machines owned by the ControlPlaneMachineSet")
 				machineBuilder := resourcebuilder.Machine().AsMaster().WithGenerateName("state-test-").WithNamespace(namespaceName)
 
-				Expect(k8sClient.Create(ctx, machineBuilder.WithProviderSpecBuilder(usEast1aProviderSpecBuilder.WithInstanceType("different")).Build())).To(Succeed())
-				Expect(k8sClient.Create(ctx, machineBuilder.WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build())).To(Succeed())
-				Expect(k8sClient.Create(ctx, machineBuilder.WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build())).To(Succeed())
+				machines := map[int]resourcebuilder.MachineBuilder{
+					0: machineBuilder.WithProviderSpecBuilder(usEast1aProviderSpecBuilder.WithInstanceType("different")),
+					1: machineBuilder.WithProviderSpecBuilder(usEast1bProviderSpecBuilder),
+					2: machineBuilder.WithProviderSpecBuilder(usEast1cProviderSpecBuilder),
+				}
 
-				By("Ensuring Machines are Running")
-				machines := &machinev1beta1.MachineList{}
-				Expect(k8sClient.List(ctx, machines)).To(Succeed())
+				for i := range machines {
+					nodeName := fmt.Sprintf("node-%d", i)
+					machineName := fmt.Sprintf("master-%d", i)
 
-				for _, machine := range machines.Items {
-					m := machine.DeepCopy()
+					machine := machines[i].WithName(machineName).Build()
 
-					Eventually(komega.UpdateStatus(m, func() {
-						m.Status.Phase = &running
+					Expect(k8sClient.Create(ctx, machine)).To(Succeed())
+					Expect(k8sClient.Create(ctx, masterNodeBuilder.WithName(nodeName).AsReady().Build())).To(Succeed())
+
+					Eventually(komega.UpdateStatus(machine, func() {
+						machine.Status.Phase = &running
+						machine.Status.NodeRef = &corev1.ObjectReference{Name: nodeName}
 					})).Should(Succeed())
 				}
 			})
@@ -991,9 +1053,25 @@ var _ = Describe("With a running controller", func() {
 			By("Creating Machines owned by the ControlPlaneMachineSet")
 			machineBuilder := resourcebuilder.Machine().AsMaster().WithNamespace(namespaceName)
 
-			Expect(k8sClient.Create(ctx, machineBuilder.WithName("master-0").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build())).To(Succeed())
-			Expect(k8sClient.Create(ctx, machineBuilder.WithName("master-1").WithProviderSpecBuilder(usEast1bProviderSpecBuilder).Build())).To(Succeed())
-			Expect(k8sClient.Create(ctx, machineBuilder.WithName("master-2").WithProviderSpecBuilder(usEast1cProviderSpecBuilder).Build())).To(Succeed())
+			machines := map[int]resourcebuilder.MachineBuilder{
+				0: machineBuilder.WithProviderSpecBuilder(usEast1aProviderSpecBuilder),
+				1: machineBuilder.WithProviderSpecBuilder(usEast1bProviderSpecBuilder),
+				2: machineBuilder.WithProviderSpecBuilder(usEast1cProviderSpecBuilder),
+			}
+
+			for i := range machines {
+				nodeName := fmt.Sprintf("node-%d", i)
+				machineName := fmt.Sprintf("master-%d", i)
+
+				machine := machines[i].WithName(machineName).Build()
+
+				Expect(k8sClient.Create(ctx, machine)).To(Succeed())
+				Expect(k8sClient.Create(ctx, masterNodeBuilder.WithName(nodeName).AsReady().Build())).To(Succeed())
+
+				Eventually(komega.UpdateStatus(machine, func() {
+					machine.Status.NodeRef = &corev1.ObjectReference{Name: nodeName}
+				})).Should(Succeed())
+			}
 
 			By("Registering the integration machine manager")
 
@@ -1072,9 +1150,25 @@ var _ = Describe("With a running controller", func() {
 			By("Creating Machines in a single failure domain")
 			machineBuilder := resourcebuilder.Machine().AsMaster().WithNamespace(namespaceName)
 
-			Expect(k8sClient.Create(ctx, machineBuilder.WithName("master-0").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build())).To(Succeed())
-			Expect(k8sClient.Create(ctx, machineBuilder.WithName("master-1").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build())).To(Succeed())
-			Expect(k8sClient.Create(ctx, machineBuilder.WithName("master-2").WithProviderSpecBuilder(usEast1aProviderSpecBuilder).Build())).To(Succeed())
+			machines := map[int]resourcebuilder.MachineBuilder{
+				0: machineBuilder.WithProviderSpecBuilder(usEast1aProviderSpecBuilder),
+				1: machineBuilder.WithProviderSpecBuilder(usEast1aProviderSpecBuilder),
+				2: machineBuilder.WithProviderSpecBuilder(usEast1aProviderSpecBuilder),
+			}
+
+			for i := range machines {
+				nodeName := fmt.Sprintf("node-%d", i)
+				machineName := fmt.Sprintf("master-%d", i)
+
+				machine := machines[i].WithName(machineName).Build()
+
+				Expect(k8sClient.Create(ctx, machine)).To(Succeed())
+				Expect(k8sClient.Create(ctx, masterNodeBuilder.WithName(nodeName).AsReady().Build())).To(Succeed())
+
+				Eventually(komega.UpdateStatus(machine, func() {
+					machine.Status.NodeRef = &corev1.ObjectReference{Name: nodeName}
+				})).Should(Succeed())
+			}
 
 			By("Registering the integration machine manager")
 

--- a/pkg/controllers/controlplanemachineset/updates_test.go
+++ b/pkg/controllers/controlplanemachineset/updates_test.go
@@ -234,6 +234,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 					},
 					}
 				},
+				expectedResult: ctrl.Result{RequeueAfter: 5 * time.Second},
 			}),
 			Entry("with updates required in a single index, and the replacement machine is ready", rollingUpdateTableInput{
 				cpmsBuilder: cpmsBuilder.WithReplicas(3),
@@ -409,6 +410,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 						},
 					}
 				},
+				expectedResult: ctrl.Result{RequeueAfter: 5 * time.Second},
 			}),
 			Entry("with updates are required in multiple indexes, and the replacement machine is ready", rollingUpdateTableInput{
 				cpmsBuilder: cpmsBuilder.WithReplicas(3),
@@ -544,6 +546,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 					},
 					}
 				},
+				expectedResult: ctrl.Result{RequeueAfter: 5 * time.Second},
 			}),
 			Entry("with a missing index, and other indexes needing updates", rollingUpdateTableInput{
 				cpmsBuilder: cpmsBuilder.WithReplicas(3),
@@ -622,6 +625,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 						},
 					}
 				},
+				expectedResult: ctrl.Result{RequeueAfter: 5 * time.Second},
 			}),
 			Entry("with a missing index, and other indexes needing updates, and their replacement machines are ready", rollingUpdateTableInput{
 				cpmsBuilder: cpmsBuilder.WithReplicas(3),
@@ -1012,6 +1016,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 						},
 					}
 				},
+				expectedResult: ctrl.Result{RequeueAfter: 5 * time.Second},
 			}),
 			Entry("with no updates required, but a machine has been deleted, and its replacement is ready", rollingUpdateTableInput{
 				cpmsBuilder: cpmsBuilder.WithReplicas(3),
@@ -1235,6 +1240,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 					},
 					}
 				},
+				expectedResult: ctrl.Result{RequeueAfter: 5 * time.Second},
 			}),
 			Entry("with updates required in a single index, and replacement machine is ready", onDeleteUpdateTableInput{
 				cpmsBuilder: cpmsBuilder.WithReplicas(3),
@@ -1450,6 +1456,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 						},
 					}
 				},
+				expectedResult: ctrl.Result{RequeueAfter: 5 * time.Second},
 			}),
 			Entry("with updates required in multiple indexes, and multiple machines have been deleted, and the replacement machines are pending", onDeleteUpdateTableInput{
 				cpmsBuilder: cpmsBuilder.WithReplicas(3),
@@ -1493,6 +1500,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 						},
 					}
 				},
+				expectedResult: ctrl.Result{RequeueAfter: 5 * time.Second},
 			}),
 			Entry("with updates required in multiple indexes, and a single machine has been deleted, and the replacement machine is ready", onDeleteUpdateTableInput{
 				cpmsBuilder: cpmsBuilder.WithReplicas(3),
@@ -1573,6 +1581,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 						},
 					}
 				},
+				expectedResult: ctrl.Result{RequeueAfter: 5 * time.Second},
 			}),
 			Entry("with updates required in multiple indexes, and multiple machines have been deleted, and all replacement machines are ready", onDeleteUpdateTableInput{
 				cpmsBuilder: cpmsBuilder.WithReplicas(3),
@@ -1666,6 +1675,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 					},
 					}
 				},
+				expectedResult: ctrl.Result{RequeueAfter: 5 * time.Second},
 			}),
 			Entry("with a missing index, and other indexes need updating", onDeleteUpdateTableInput{
 				cpmsBuilder: cpmsBuilder.WithReplicas(3),
@@ -1738,6 +1748,7 @@ var _ = Describe("reconcileMachineUpdates", func() {
 						},
 					}
 				},
+				expectedResult: ctrl.Result{RequeueAfter: 5 * time.Second},
 			}),
 			Entry("with no updates required, but a Machine has been deleted", onDeleteUpdateTableInput{
 				cpmsBuilder: cpmsBuilder.WithReplicas(3),

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/provider_test.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/provider_test.go
@@ -137,6 +137,7 @@ var _ = Describe("MachineProvider", func() {
 
 		providerSpecBuilder := resourcebuilder.AWSProviderSpec()
 		masterMachineBuilder := resourcebuilder.Machine().AsMaster().WithLabel(machinev1beta1.MachineClusterIDLabel, clusterID).WithNamespace(namespaceName)
+		masterNodeBuilder := resourcebuilder.Node().AsMaster().AsReady()
 
 		machineGVR := machinev1beta1.GroupVersion.WithResource("machines")
 		nodeGVR := corev1.SchemeGroupVersion.WithResource("nodes")
@@ -166,6 +167,7 @@ var _ = Describe("MachineProvider", func() {
 
 		type getMachineInfosTableInput struct {
 			machines             []*machinev1beta1.Machine
+			nodes                []*corev1.Node
 			failureDomains       map[int32]failuredomain.FailureDomain
 			expectedError        error
 			expectedMachineInfos []machineproviders.MachineInfo
@@ -182,6 +184,15 @@ var _ = Describe("MachineProvider", func() {
 
 				machine.Status = *status
 				Expect(k8sClient.Status().Update(ctx, machine)).To(Succeed())
+			}
+
+			for _, node := range in.nodes {
+				status := node.Status.DeepCopy()
+
+				Expect(k8sClient.Create(ctx, node)).To(Succeed())
+
+				node.Status = *status
+				Expect(k8sClient.Status().Update(ctx, node)).To(Succeed())
 			}
 
 			// Inject namespace in the expected machine infos since it doesn't happen during
@@ -238,6 +249,7 @@ var _ = Describe("MachineProvider", func() {
 		},
 			Entry("with no Machines", getMachineInfosTableInput{
 				machines: []*machinev1beta1.Machine{},
+				nodes:    []*corev1.Node{},
 				failureDomains: map[int32]failuredomain.FailureDomain{
 					0: failuredomain.NewAWSFailureDomain(resourcebuilder.AWSFailureDomain().WithAvailabilityZone("us-east-1a").Build()),
 					1: failuredomain.NewAWSFailureDomain(resourcebuilder.AWSFailureDomain().WithAvailabilityZone("us-east-1b").Build()),
@@ -313,6 +325,12 @@ var _ = Describe("MachineProvider", func() {
 					masterMachineBuilder.WithName(masterMachineName("2")).WithProviderSpecBuilder(providerSpecBuilder.WithAvailabilityZone("us-east-1c").WithSubnet(usEast1cSubnetbeta1)).
 						WithPhase("Running").WithNodeRef(corev1.ObjectReference{Name: "node-2"}).Build(),
 				},
+
+				nodes: []*corev1.Node{
+					masterNodeBuilder.WithName("node-0").Build(),
+					masterNodeBuilder.WithName("node-1").Build(),
+					masterNodeBuilder.WithName("node-2").Build(),
+				},
 				failureDomains: map[int32]failuredomain.FailureDomain{
 					0: failuredomain.NewAWSFailureDomain(resourcebuilder.AWSFailureDomain().WithAvailabilityZone("us-east-1a").WithSubnet(usEast1aSubnet).Build()),
 					1: failuredomain.NewAWSFailureDomain(resourcebuilder.AWSFailureDomain().WithAvailabilityZone("us-east-1b").WithSubnet(usEast1bSubnet).Build()),
@@ -370,6 +388,11 @@ var _ = Describe("MachineProvider", func() {
 						WithPhase("Running").WithNodeRef(corev1.ObjectReference{Name: "node-1"}).Build(),
 					masterMachineBuilder.WithName(masterMachineName("2")).WithProviderSpecBuilder(providerSpecBuilder.WithAvailabilityZone("us-east-1c").WithSubnet(usEast1cSubnetbeta1)).
 						WithPhase("Deleting").WithNodeRef(corev1.ObjectReference{Name: "node-2"}).Build(),
+				},
+				nodes: []*corev1.Node{
+					masterNodeBuilder.WithName("node-0").Build(),
+					masterNodeBuilder.WithName("node-1").Build(),
+					masterNodeBuilder.WithName("node-2").Build(),
 				},
 				failureDomains: map[int32]failuredomain.FailureDomain{
 					0: failuredomain.NewAWSFailureDomain(resourcebuilder.AWSFailureDomain().WithAvailabilityZone("us-east-1a").WithSubnet(usEast1aSubnet).Build()),
@@ -429,6 +452,10 @@ var _ = Describe("MachineProvider", func() {
 					masterMachineBuilder.WithName(masterMachineName("2")).WithProviderSpecBuilder(providerSpecBuilder.WithAvailabilityZone("us-east-1c").WithSubnet(usEast1cSubnetbeta1)).
 						WithPhase("Deleting").Build(),
 				},
+				nodes: []*corev1.Node{
+					masterNodeBuilder.WithName("node-0").Build(),
+					masterNodeBuilder.WithName("node-1").Build(),
+				},
 				failureDomains: map[int32]failuredomain.FailureDomain{
 					0: failuredomain.NewAWSFailureDomain(resourcebuilder.AWSFailureDomain().WithAvailabilityZone("us-east-1a").WithSubnet(usEast1aSubnet).Build()),
 					1: failuredomain.NewAWSFailureDomain(resourcebuilder.AWSFailureDomain().WithAvailabilityZone("us-east-1b").WithSubnet(usEast1bSubnet).Build()),
@@ -486,6 +513,11 @@ var _ = Describe("MachineProvider", func() {
 						WithPhase("Running").WithNodeRef(corev1.ObjectReference{Name: "node-1"}).Build(),
 					masterMachineBuilder.WithName(masterMachineName("2")).WithProviderSpecBuilder(providerSpecBuilder.WithAvailabilityZone("us-east-1c").WithSubnet(usEast1cSubnetbeta1)).
 						WithPhase("Running").WithNodeRef(corev1.ObjectReference{Name: "node-2"}).Build(),
+				},
+				nodes: []*corev1.Node{
+					masterNodeBuilder.WithName("node-0").Build(),
+					masterNodeBuilder.WithName("node-1").Build(),
+					masterNodeBuilder.WithName("node-2").Build(),
 				},
 				failureDomains: map[int32]failuredomain.FailureDomain{
 					0: failuredomain.NewAWSFailureDomain(resourcebuilder.AWSFailureDomain().WithAvailabilityZone("us-east-1a").WithSubnet(usEast1aSubnet).Build()),
@@ -545,6 +577,11 @@ var _ = Describe("MachineProvider", func() {
 					masterMachineBuilder.WithName(masterMachineName("2")).WithProviderSpecBuilder(providerSpecBuilder.WithAvailabilityZone("us-east-1c").WithSubnet(usEast1cSubnetbeta1)).
 						WithPhase("Running").WithNodeRef(corev1.ObjectReference{Name: "node-2"}).Build(),
 				},
+				nodes: []*corev1.Node{
+					masterNodeBuilder.WithName("node-0").Build(),
+					masterNodeBuilder.WithName("node-1").Build(),
+					masterNodeBuilder.WithName("node-2").Build(),
+				},
 				failureDomains: map[int32]failuredomain.FailureDomain{
 					0: failuredomain.NewAWSFailureDomain(resourcebuilder.AWSFailureDomain().WithAvailabilityZone("us-east-1a").WithSubnet(usEast1aSubnet).Build()),
 					1: failuredomain.NewAWSFailureDomain(resourcebuilder.AWSFailureDomain().WithAvailabilityZone("us-east-1b").WithSubnet(usEast1bSubnet).Build()),
@@ -602,6 +639,11 @@ var _ = Describe("MachineProvider", func() {
 						WithPhase("Running").WithNodeRef(corev1.ObjectReference{Name: "node-1"}).Build(),
 					masterMachineBuilder.WithName(masterMachineName("2")).WithProviderSpecBuilder(providerSpecBuilder.WithAvailabilityZone("us-east-1c").WithSubnet(usEast1cSubnetbeta1)).
 						WithPhase("Running").WithNodeRef(corev1.ObjectReference{Name: "node-2"}).Build(),
+				},
+				nodes: []*corev1.Node{
+					masterNodeBuilder.WithName("node-0").Build(),
+					masterNodeBuilder.WithName("node-1").Build(),
+					masterNodeBuilder.WithName("node-2").Build(),
 				},
 				failureDomains: map[int32]failuredomain.FailureDomain{
 					0: failuredomain.NewAWSFailureDomain(resourcebuilder.AWSFailureDomain().WithAvailabilityZone("us-east-1a").WithSubnet(usEast1aSubnet).Build()),
@@ -662,6 +704,12 @@ var _ = Describe("MachineProvider", func() {
 						WithPhase("Running").WithNodeRef(corev1.ObjectReference{Name: "node-2"}).Build(),
 					masterMachineBuilder.WithName(masterMachineName("abcde-2")).WithProviderSpecBuilder(providerSpecBuilder.WithAvailabilityZone("us-east-1c").WithSubnet(usEast1cSubnetbeta1)).
 						WithPhase("Running").WithNodeRef(corev1.ObjectReference{Name: "node-replacement-2"}).Build(),
+				},
+				nodes: []*corev1.Node{
+					masterNodeBuilder.WithName("node-0").Build(),
+					masterNodeBuilder.WithName("node-1").Build(),
+					masterNodeBuilder.WithName("node-2").Build(),
+					masterNodeBuilder.WithName("node-replacement-2").Build(),
 				},
 				failureDomains: map[int32]failuredomain.FailureDomain{
 					0: failuredomain.NewAWSFailureDomain(resourcebuilder.AWSFailureDomain().WithAvailabilityZone("us-east-1a").WithSubnet(usEast1aSubnet).Build()),
@@ -734,6 +782,11 @@ var _ = Describe("MachineProvider", func() {
 					masterMachineBuilder.WithName(masterMachineName("2")).WithProviderSpecBuilder(providerSpecBuilder.WithAvailabilityZone("us-east-1c").WithSubnet(usEast1cSubnetbeta1)).
 						WithPhase("Running").WithNodeRef(corev1.ObjectReference{Name: "node-2"}).Build(),
 				},
+				nodes: []*corev1.Node{
+					masterNodeBuilder.WithName("node-0").Build(),
+					masterNodeBuilder.WithName("node-1").Build(),
+					masterNodeBuilder.WithName("node-2").Build(),
+				},
 				failureDomains: map[int32]failuredomain.FailureDomain{
 					// The failure domain mapping logic is trusted as the source of truth for the failure domain.
 					// It is responsible for mapping the machine indexes to failure domains.
@@ -794,6 +847,11 @@ var _ = Describe("MachineProvider", func() {
 					masterMachineBuilder.WithName(clusterID + "-master-c").WithProviderSpecBuilder(providerSpecBuilder.WithAvailabilityZone("us-east-1c").WithSubnet(usEast1cSubnetbeta1)).
 						WithPhase("Running").WithNodeRef(corev1.ObjectReference{Name: "node-2"}).Build(),
 				},
+				nodes: []*corev1.Node{
+					masterNodeBuilder.WithName("node-0").Build(),
+					masterNodeBuilder.WithName("node-1").Build(),
+					masterNodeBuilder.WithName("node-2").Build(),
+				},
 				failureDomains: map[int32]failuredomain.FailureDomain{
 					0: failuredomain.NewAWSFailureDomain(resourcebuilder.AWSFailureDomain().WithAvailabilityZone("us-east-1b").WithSubnet(usEast1bSubnet).Build()),
 					1: failuredomain.NewAWSFailureDomain(resourcebuilder.AWSFailureDomain().WithAvailabilityZone("us-east-1c").WithSubnet(usEast1cSubnet).Build()),
@@ -852,6 +910,11 @@ var _ = Describe("MachineProvider", func() {
 					masterMachineBuilder.WithName(clusterID + "-master-c").WithProviderSpecBuilder(providerSpecBuilder.WithAvailabilityZone("us-east-1d")).
 						WithPhase("Running").WithNodeRef(corev1.ObjectReference{Name: "node-2"}).Build(),
 				},
+				nodes: []*corev1.Node{
+					masterNodeBuilder.WithName("node-0").Build(),
+					masterNodeBuilder.WithName("node-1").Build(),
+					masterNodeBuilder.WithName("node-2").Build(),
+				},
 				failureDomains: map[int32]failuredomain.FailureDomain{
 					0: failuredomain.NewAWSFailureDomain(resourcebuilder.AWSFailureDomain().WithAvailabilityZone("us-east-1b").WithSubnet(usEast1bSubnet).Build()),
 					1: failuredomain.NewAWSFailureDomain(resourcebuilder.AWSFailureDomain().WithAvailabilityZone("us-east-1c").WithSubnet(usEast1cSubnet).Build()),
@@ -874,6 +937,10 @@ var _ = Describe("MachineProvider", func() {
 						WithPhase("Failed").WithErrorMessage("Cannot create VM").Build(),
 					masterMachineBuilder.WithName(masterMachineName("2")).WithProviderSpecBuilder(providerSpecBuilder.WithAvailabilityZone("us-east-1c").WithSubnet(usEast1cSubnetbeta1)).
 						WithPhase("Running").WithNodeRef(corev1.ObjectReference{Name: "node-2"}).Build(),
+				},
+				nodes: []*corev1.Node{
+					masterNodeBuilder.WithName("node-0").Build(),
+					masterNodeBuilder.WithName("node-2").Build(),
 				},
 				failureDomains: map[int32]failuredomain.FailureDomain{
 					0: failuredomain.NewAWSFailureDomain(resourcebuilder.AWSFailureDomain().WithAvailabilityZone("us-east-1a").WithSubnet(usEast1aSubnet).Build()),
@@ -933,6 +1000,11 @@ var _ = Describe("MachineProvider", func() {
 					resourcebuilder.Machine().AsWorker().WithNamespace(namespaceName).WithName("worker-abcde").WithProviderSpecBuilder(providerSpecBuilder.WithAvailabilityZone("us-east-1c").WithSubnet(usEast1cSubnetbeta1)).
 						WithPhase("Running").WithNodeRef(corev1.ObjectReference{Name: "node-2"}).Build(),
 				},
+				nodes: []*corev1.Node{
+					masterNodeBuilder.WithName("node-0").Build(),
+					masterNodeBuilder.WithName("node-1").Build(),
+					masterNodeBuilder.WithName("node-2").Build(),
+				},
 				failureDomains: map[int32]failuredomain.FailureDomain{
 					0: failuredomain.NewAWSFailureDomain(resourcebuilder.AWSFailureDomain().WithAvailabilityZone("us-east-1a").WithSubnet(usEast1aSubnet).Build()),
 					1: failuredomain.NewAWSFailureDomain(resourcebuilder.AWSFailureDomain().WithAvailabilityZone("us-east-1b").WithSubnet(usEast1bSubnet).Build()),
@@ -977,6 +1049,11 @@ var _ = Describe("MachineProvider", func() {
 						WithPhase("Running").WithNodeRef(corev1.ObjectReference{Name: "node-1"}).Build(),
 					masterMachineBuilder.WithName(masterMachineName("2")).WithProviderSpecBuilder(providerSpecBuilder.WithAvailabilityZone("us-east-1a").WithSubnet(usEast1aSubnetbeta1)).
 						WithPhase("Running").WithNodeRef(corev1.ObjectReference{Name: "node-2"}).Build(),
+				},
+				nodes: []*corev1.Node{
+					masterNodeBuilder.WithName("node-0").Build(),
+					masterNodeBuilder.WithName("node-1").Build(),
+					masterNodeBuilder.WithName("node-2").Build(),
 				},
 				failureDomains: map[int32]failuredomain.FailureDomain{
 					0: failuredomain.NewAWSFailureDomain(resourcebuilder.AWSFailureDomain().WithAvailabilityZone("us-east-1a").WithSubnet(usEast1aSubnet).Build()),
@@ -1036,6 +1113,11 @@ var _ = Describe("MachineProvider", func() {
 					masterMachineBuilder.WithName(masterMachineName("2")).WithProviderSpecBuilder(providerSpecBuilder.WithAvailabilityZone("us-east-1a").WithSubnet(usEast1aSubnetbeta1)).
 						WithPhase("Running").WithNodeRef(corev1.ObjectReference{Name: "node-2"}).Build(),
 				},
+				nodes: []*corev1.Node{
+					masterNodeBuilder.WithName("node-0").Build(),
+					masterNodeBuilder.WithName("node-1").Build(),
+					masterNodeBuilder.WithName("node-2").Build(),
+				},
 				failureDomains: map[int32]failuredomain.FailureDomain{},
 				expectedMachineInfos: []machineproviders.MachineInfo{
 					readyMachineInfoBuilder.WithIndex(0).WithMachineName(masterMachineName("0")).WithNodeName("node-0").Build(),
@@ -1090,6 +1172,11 @@ var _ = Describe("MachineProvider", func() {
 					masterMachineBuilder.WithName(masterMachineName("2")).WithProviderSpecBuilder(providerSpecBuilder.WithAvailabilityZone("us-east-1b").WithSubnet(usEast1aSubnetbeta1)).
 						WithPhase("Running").WithNodeRef(corev1.ObjectReference{Name: "node-2"}).Build(),
 				},
+				nodes: []*corev1.Node{
+					masterNodeBuilder.WithName("node-0").Build(),
+					masterNodeBuilder.WithName("node-1").Build(),
+					masterNodeBuilder.WithName("node-2").Build(),
+				},
 				failureDomains: map[int32]failuredomain.FailureDomain{},
 				expectedMachineInfos: []machineproviders.MachineInfo{
 					readyMachineInfoBuilder.WithIndex(0).WithMachineName(masterMachineName("0")).WithNodeName("node-0").Build(),
@@ -1143,6 +1230,11 @@ var _ = Describe("MachineProvider", func() {
 						WithPhase("Running").WithNodeRef(corev1.ObjectReference{Name: "node-4"}).Build(),
 					masterMachineBuilder.WithName(masterMachineName("5")).WithProviderSpecBuilder(providerSpecBuilder.WithAvailabilityZone("us-east-1c").WithSubnet(usEast1cSubnetbeta1)).
 						WithPhase("Running").WithNodeRef(corev1.ObjectReference{Name: "node-5"}).Build(),
+				},
+				nodes: []*corev1.Node{
+					masterNodeBuilder.WithName("node-3").Build(),
+					masterNodeBuilder.WithName("node-4").Build(),
+					masterNodeBuilder.WithName("node-5").Build(),
 				},
 				failureDomains: map[int32]failuredomain.FailureDomain{
 					3: failuredomain.NewAWSFailureDomain(resourcebuilder.AWSFailureDomain().WithAvailabilityZone("us-east-1a").WithSubnet(usEast1aSubnet).Build()),
@@ -1201,6 +1293,11 @@ var _ = Describe("MachineProvider", func() {
 						WithPhase("Running").WithNodeRef(corev1.ObjectReference{Name: "node-2"}).Build(),
 					masterMachineBuilder.WithName(masterMachineName("4")).WithProviderSpecBuilder(providerSpecBuilder.WithAvailabilityZone("us-east-1c").WithSubnet(usEast1cSubnetbeta1)).
 						WithPhase("Running").WithNodeRef(corev1.ObjectReference{Name: "node-4"}).Build(),
+				},
+				nodes: []*corev1.Node{
+					masterNodeBuilder.WithName("node-0").Build(),
+					masterNodeBuilder.WithName("node-2").Build(),
+					masterNodeBuilder.WithName("node-4").Build(),
 				},
 				failureDomains: map[int32]failuredomain.FailureDomain{
 					0: failuredomain.NewAWSFailureDomain(resourcebuilder.AWSFailureDomain().WithAvailabilityZone("us-east-1a").WithSubnet(usEast1aSubnet).Build()),

--- a/pkg/test/resourcebuilder/node.go
+++ b/pkg/test/resourcebuilder/node.go
@@ -36,6 +36,7 @@ type NodeBuilder struct {
 	generateName string
 	name         string
 	labels       map[string]string
+	conditions   []corev1.NodeCondition
 }
 
 // Build builds a new node based on the configuration provided.
@@ -45,6 +46,9 @@ func (m NodeBuilder) Build() *corev1.Node {
 			GenerateName: m.generateName,
 			Name:         m.name,
 			Labels:       m.labels,
+		},
+		Status: corev1.NodeStatus{
+			Conditions: m.conditions,
 		},
 	}
 
@@ -59,6 +63,32 @@ func (m NodeBuilder) AsWorker() NodeBuilder {
 // AsMaster sets the master role on the node labels for the node builder.
 func (m NodeBuilder) AsMaster() NodeBuilder {
 	return m.WithLabel(masterNodeRoleLabel, "")
+}
+
+// AsNotReady sets the node as ready for the node builder.
+func (m NodeBuilder) AsNotReady() NodeBuilder {
+	return m.WithConditions([]corev1.NodeCondition{
+		{
+			Type:   corev1.NodeReady,
+			Status: corev1.ConditionFalse,
+		},
+	})
+}
+
+// AsReady sets the node as ready for the node builder.
+func (m NodeBuilder) AsReady() NodeBuilder {
+	return m.WithConditions([]corev1.NodeCondition{
+		{
+			Type:   corev1.NodeReady,
+			Status: corev1.ConditionTrue,
+		},
+	})
+}
+
+// WithConditions sets the conditions for the node builder.
+func (m NodeBuilder) WithConditions(conditions []corev1.NodeCondition) NodeBuilder {
+	m.conditions = conditions
+	return m
 }
 
 // WithGenerateName sets the generateName for the node builder.

--- a/pkg/util/suite_test.go
+++ b/pkg/util/suite_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	configv1 "github.com/openshift/api/config/v1"
+	machinev1 "github.com/openshift/api/machine/v1"
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	//+kubebuilder:scaffold:imports
+)
+
+var cfg *rest.Config
+var k8sClient client.Client
+var testEnv *envtest.Environment
+var testScheme *runtime.Scheme
+var ctx = context.Background()
+
+func TestUtil(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Util Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "vendor", "github.com", "openshift", "api", "machine", "v1"),
+			filepath.Join("..", "..", "vendor", "github.com", "openshift", "api", "machine", "v1beta1"),
+			filepath.Join("..", "..", "vendor", "github.com", "openshift", "api", "config", "v1"),
+		},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	var err error
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	testScheme = scheme.Scheme
+	Expect(machinev1.Install(testScheme)).To(Succeed())
+	Expect(machinev1beta1.Install(testScheme)).To(Succeed())
+	Expect(configv1.Install(testScheme)).To(Succeed())
+
+	//+kubebuilder:scaffold:scheme
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: testScheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+	komega.SetClient(k8sClient)
+	komega.SetContext(ctx)
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/pkg/util/watch_filters.go
+++ b/pkg/util/watch_filters.go
@@ -22,8 +22,12 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	machinev1 "github.com/openshift/api/machine/v1"
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+
+	corev1 "k8s.io/api/core/v1"
+
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -34,6 +38,12 @@ const (
 
 	// machineTypeLabelName is the label used to identify the type of a machine.
 	machineTypeLabelName = "machine.openshift.io/cluster-api-machine-type"
+
+	// nodeRoleMasterLabelName is the label used to identify the role of the node.
+	nodeRoleMasterLabelName = "node-role.kubernetes.io/master"
+
+	// nodeRoleControlPlaneLabelName is the label used to identify the role of the node.
+	nodeRoleControlPlaneLabelName = "node-role.kubernetes.io/control-plane"
 
 	// machineMasterRoleLabelName is the label value to identify the role of a control plane machine.
 	machineMasterRoleLabelName = "master"
@@ -119,4 +129,85 @@ func FilterControlPlaneMachines(namespace string) predicate.Predicate {
 			(labels[machineTypeLabelName] == machineMasterTypeLabelName ||
 				labels[machineTypeLabelName] == machineControlPlaneTypeLabelName)
 	})
+}
+
+// FilterControlPlaneNodes filters nodes requests to just the nodes that present as control plane nodes
+// and that have had a transition in the NodeReady condition.
+func FilterControlPlaneNodes() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			node, ok := e.Object.(*corev1.Node)
+			if !ok {
+				panic(fmt.Sprintf("expected to get an of object of type corev1.Node: got type %T", e.Object))
+			}
+
+			return isControlPlaneNode(node)
+		},
+		UpdateFunc: updateFuncFilterControlPlaneNodes,
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			node, ok := e.Object.(*corev1.Node)
+			if !ok {
+				panic(fmt.Sprintf("expected to get an of object of type corev1.Node: got type %T", e.Object))
+			}
+
+			return isControlPlaneNode(node)
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			if _, ok := e.Object.(*corev1.Node); !ok {
+				panic(fmt.Sprintf("expected to get an of object of type corev1.Node: got type %T", e.Object))
+			}
+
+			// We are only interested in events that can change a Node status,
+			// so we ignore generic events.
+			return false
+		},
+	}
+}
+
+// isControlPlaneNode checks whether the provided node is a control plane one.
+func isControlPlaneNode(node *corev1.Node) bool {
+	// Ensuring that this is a master machine by checking required labels.
+	labels := node.GetLabels()
+	_, hasMasterLabel := labels[nodeRoleMasterLabelName]
+	_, hasControlPlaneLabel := labels[nodeRoleControlPlaneLabelName]
+
+	// Only consider if Node is a control plane.
+	return hasMasterLabel || hasControlPlaneLabel
+}
+
+// updateFuncFilterControlPlaneNodes filters an event based on whether the node is a control plane
+// or not and if it has recently transitioned in its readiness status.
+func updateFuncFilterControlPlaneNodes(e event.UpdateEvent) bool {
+	node, ok := e.ObjectNew.(*corev1.Node)
+	if !ok {
+		panic(fmt.Sprintf("expected to get an of object of type corev1.Node: got type %T", e.ObjectNew))
+	}
+
+	oldNode, ok := e.ObjectOld.(*corev1.Node)
+	if !ok && oldNode != nil {
+		panic(fmt.Sprintf("expected to get an of object of type corev1.Node: got type %T", e.ObjectOld))
+	}
+
+	if !isControlPlaneNode(node) {
+		return false
+	}
+
+	var wasNodeReady, isNodeReady corev1.ConditionStatus
+
+	for _, c := range oldNode.Status.Conditions {
+		if c.Type == corev1.NodeReady {
+			wasNodeReady = c.Status
+			break
+		}
+	}
+
+	for _, c := range node.Status.Conditions {
+		if c.Type == corev1.NodeReady {
+			isNodeReady = c.Status
+			break
+		}
+	}
+
+	// Only consider if the node has changed in its readiness.
+	return wasNodeReady != isNodeReady
 }

--- a/test/integration/machine_manager.go
+++ b/test/integration/machine_manager.go
@@ -25,7 +25,9 @@ import (
 
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -100,6 +102,8 @@ func (r *integrationMachineManager) SetupWithManager(mgr ctrl.Manager) error {
 
 // Reconcile handles the reconciliation loop for the machine manager.
 // It sets the finalizer and then progresses the Machine through the phases until it is running.
+//
+//nolint:cyclop
 func (r *integrationMachineManager) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	logger := log.FromContext(ctx, "namespace", req.Namespace, "name", req.Name)
 
@@ -116,26 +120,33 @@ func (r *integrationMachineManager) Reconcile(ctx context.Context, req reconcile
 		return ctrl.Result{}, fmt.Errorf("unable to fetch machine: %w", err)
 	}
 
+	machinePhase := pointer.StringDeref(machine.Status.Phase, "")
+
 	if machine.DeletionTimestamp != nil {
-		if machine.Status.Phase != nil && *machine.Status.Phase != phaseDeleting {
+		if machinePhase != phaseDeleting {
 			return r.setPhase(ctx, logger, req, machine, phaseDeleting)
 		}
-
-		return r.removeFinalizer(ctx, logger, req, machine)
-	}
-
-	// All machines should have a finalizer set first.
-	if len(machine.GetFinalizers()) == 0 {
+	} else if len(machine.GetFinalizers()) == 0 {
 		return r.addFinalizer(ctx, logger, req, machine)
 	}
 
-	switch pointer.StringDeref(machine.Status.Phase, "") {
+	switch machinePhase {
 	case "":
 		return r.setPhase(ctx, logger, req, machine, phaseProvisioning)
 	case phaseProvisioning:
 		return r.setPhase(ctx, logger, req, machine, phaseProvisioned)
 	case phaseProvisioned:
 		return r.setPhase(ctx, logger, req, machine, phaseRunning)
+	case phaseRunning:
+		return r.ensureNodeforMachine(ctx, logger, machine)
+	case phaseDeleting:
+		linkedNode := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: machine.Status.NodeRef.Name}}
+		if err := r.Delete(ctx, &linkedNode); err != nil &&
+			!apierrors.IsNotFound(err) {
+			return ctrl.Result{}, fmt.Errorf("unable to delete machine's node: %w", err)
+		}
+
+		return r.removeFinalizer(ctx, logger, req, machine)
 	}
 
 	return reconcile.Result{}, nil
@@ -196,6 +207,47 @@ func (r *integrationMachineManager) setPhase(ctx context.Context, logger logr.Lo
 
 	r.lastAction[req] = action{
 		timeStamp: time.Now(),
+	}
+
+	return reconcile.Result{}, nil
+}
+
+// ensureNodeforMachine creates a node and links it to a machine.
+func (r *integrationMachineManager) ensureNodeforMachine(ctx context.Context, logger logr.Logger, machine *machinev1beta1.Machine) (reconcile.Result, error) {
+	if machine.Status.NodeRef != nil {
+		return reconcile.Result{}, nil
+	}
+
+	logger.Info("Creating node for machine", "machine", machine.Name)
+
+	node := corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "node-",
+		},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{
+				{
+					// The node must be Ready for the CPMS replica
+					// to be considered Ready.
+					Type:   corev1.NodeReady,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
+	}
+
+	if err := r.Create(ctx, &node); err != nil {
+		return ctrl.Result{}, fmt.Errorf("unable to create node for machine: %w", err)
+	}
+
+	logger.Info("Linking node to machine", "node", node.Name, "machine", machine.Name)
+
+	machine.Status.NodeRef = &corev1.ObjectReference{
+		Name: node.Name,
+	}
+
+	if err := r.Status().Update(ctx, machine); err != nil {
+		return reconcile.Result{}, fmt.Errorf("could not update machine: %w", err)
 	}
 
 	return reconcile.Result{}, nil


### PR DESCRIPTION
A manual backport of https://github.com/openshift/cluster-control-plane-machine-set-operator/pull/173 for 4.12
that also includes two other fixes for issues that were introduced by https://github.com/openshift/cluster-control-plane-machine-set-operator/pull/173:
- a backport of https://github.com/openshift/cluster-control-plane-machine-set-operator/pull/181
- a backport of https://github.com/openshift/cluster-control-plane-machine-set-operator/pull/184