### PR TITLE
[CORS-2666] Add Nutanix support for CPMSO

### DIFF
--- a/pkg/controllers/controlplanemachinesetgenerator/controller.go
+++ b/pkg/controllers/controlplanemachinesetgenerator/controller.go
@@ -210,6 +210,8 @@ func (r *ControlPlaneMachineSetGeneratorReconciler) reconcile(ctx context.Contex
 }
 
 // generateControlPlaneMachineSet generates a control plane machine set based on the current cluster state.
+//
+//nolint:cyclop
 func (r *ControlPlaneMachineSetGeneratorReconciler) generateControlPlaneMachineSet(logger logr.Logger,
 	platformType configv1.PlatformType, machines []machinev1beta1.Machine, machineSets []machinev1beta1.MachineSet) (*machinev1.ControlPlaneMachineSet, error) {
 	var (
@@ -230,6 +232,11 @@ func (r *ControlPlaneMachineSetGeneratorReconciler) generateControlPlaneMachineS
 		}
 	case configv1.GCPPlatformType:
 		cpmsSpecApplyConfig, err = generateControlPlaneMachineSetGCPSpec(machines, machineSets)
+		if err != nil {
+			return nil, fmt.Errorf("unable to generate control plane machine set spec: %w", err)
+		}
+	case configv1.NutanixPlatformType:
+		cpmsSpecApplyConfig, err = generateControlPlaneMachineSetNutanixSpec(machines)
 		if err != nil {
 			return nil, fmt.Errorf("unable to generate control plane machine set spec: %w", err)
 		}

--- a/pkg/controllers/controlplanemachinesetgenerator/nutanix.go
+++ b/pkg/controllers/controlplanemachinesetgenerator/nutanix.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controlplanemachinesetgenerator
+
+import (
+	"fmt"
+
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+	machinev1builder "github.com/openshift/client-go/machine/applyconfigurations/machine/v1"
+	machinev1beta1builder "github.com/openshift/client-go/machine/applyconfigurations/machine/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/openshift/cluster-control-plane-machine-set-operator/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig"
+)
+
+// generateControlPlaneMachineSetNutanixSpec generates a Nutanix flavored ControlPlaneMachineSet Spec.
+func generateControlPlaneMachineSetNutanixSpec(machines []machinev1beta1.Machine) (machinev1builder.ControlPlaneMachineSetSpecApplyConfiguration, error) {
+	controlPlaneMachineSetMachineSpecApplyConfig, err := buildControlPlaneMachineSetNutanixMachineSpec(machines)
+	if err != nil {
+		return machinev1builder.ControlPlaneMachineSetSpecApplyConfiguration{}, fmt.Errorf("failed to build ControlPlaneMachineSet's Nutanix spec: %w", err)
+	}
+
+	// We want to work with the newest machine.
+	controlPlaneMachineSetApplyConfigSpec := genericControlPlaneMachineSetSpec(replicas, machines[0].ObjectMeta.Labels[clusterIDLabelKey])
+	controlPlaneMachineSetApplyConfigSpec.Template.OpenShiftMachineV1Beta1Machine.Spec = controlPlaneMachineSetMachineSpecApplyConfig
+
+	return controlPlaneMachineSetApplyConfigSpec, nil
+}
+
+// buildControlPlaneMachineSetNutanixMachineSpec builds a Nutanix flavored MachineSpec for the ControlPlaneMachineSet.
+func buildControlPlaneMachineSetNutanixMachineSpec(machines []machinev1beta1.Machine) (*machinev1beta1builder.MachineSpecApplyConfiguration, error) {
+	// The machines slice is sorted by the creation time.
+	// We want to get the provider config for the newest machine.
+	providerConfig, err := providerconfig.NewProviderConfigFromMachineSpec(machines[0].Spec)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract machine's providerSpec: %w", err)
+	}
+
+	rawBytes, err := providerConfig.RawConfig()
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling providerSpec: %w", err)
+	}
+
+	re := runtime.RawExtension{
+		Raw: rawBytes,
+	}
+
+	msac := &machinev1beta1builder.MachineSpecApplyConfiguration{
+		ProviderSpec: &machinev1beta1builder.ProviderSpecApplyConfiguration{Value: &re},
+	}
+
+	return msac, nil
+}

--- a/pkg/controllers/controlplanemachinesetgenerator/utils.go
+++ b/pkg/controllers/controlplanemachinesetgenerator/utils.go
@@ -60,6 +60,8 @@ func sortMachineSetsByCreationTimeAscending(machineSets []machinev1beta1.Machine
 }
 
 // genericControlPlaneMachineSetSpec returns a generic ControlPlaneMachineSet spec, without provider specific details.
+//
+//nolint:unparam
 func genericControlPlaneMachineSetSpec(replicas int32, clusterID string) machinev1builder.ControlPlaneMachineSetSpecApplyConfiguration {
 	labels := map[string]string{
 		clusterIDLabelKey:          clusterID,

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/nutanix.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/nutanix.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package providerconfig
+
+import (
+	"encoding/json"
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+	machinev1 "github.com/openshift/api/machine/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// NutanixProviderConfig is a wrapper around machinev1.NutanixMachineProviderConfig.
+type NutanixProviderConfig struct {
+	providerConfig machinev1.NutanixMachineProviderConfig
+}
+
+// Config returns the stored NutanixMachineProviderConfig.
+func (n NutanixProviderConfig) Config() machinev1.NutanixMachineProviderConfig {
+	return n.providerConfig
+}
+
+func newNutanixProviderConfig(raw *runtime.RawExtension) (ProviderConfig, error) {
+	nutanixMachineProviderconfig := machinev1.NutanixMachineProviderConfig{}
+	if err := json.Unmarshal(raw.Raw, &nutanixMachineProviderconfig); err != nil {
+		return providerConfig{}, fmt.Errorf("unable to unmarshal provider config: %w", err)
+	}
+
+	npc := NutanixProviderConfig{
+		providerConfig: nutanixMachineProviderconfig,
+	}
+
+	config := providerConfig{
+		platformType: configv1.NutanixPlatformType,
+		nutanix:      npc,
+	}
+
+	return config, nil
+}


### PR DESCRIPTION
This adds basic support for Nutanix control plane machines for the purpose of self-healing control plane nodes. We would enhance this at a later point to add failure domain support.

**How was this tested?**
1. Create a CPMSO image with the changes in  this PR and use the installer built from [installer#7119](https://github.com/openshift/installer/pull/7119)
2. Create a new release image based on a [recent 4.14 release image](registry.ci.openshift.org/ocp/release:4.14.0-0.nightly-2023-04-19-125337) using `oc adm release new --from-release registry.ci.openshift.org/ocp/release:4.14.0-0.nightly-2023-04-19-125337 cluster-control-plane-machine-set-operator=image-registry:cluster-control-plane-machine-set-operator --to-image image-registry:release` and set the release image override environment variable to the newly created release image using `export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE=image-registry:release`
3. Create a install-config using `openshift-installer create install-config`
4. Run `openshift-installer create manifests` and verify ControlPlaneMachineSet manifest generated is as expected
```
apiVersion: machine.openshift.io/v1
kind: ControlPlaneMachineSet
metadata:
  creationTimestamp: null
  labels:
    machine.openshift.io/cluster-api-cluster: openshiftsid-wvs7z
  name: cluster
  namespace: openshift-machine-api
spec:
  replicas: 3
  selector:
    matchLabels:
      machine.openshift.io/cluster-api-cluster: openshiftsid-wvs7z
      machine.openshift.io/cluster-api-machine-role: master
      machine.openshift.io/cluster-api-machine-type: master
  strategy: {}
  template:
    machineType: machines_v1beta1_machine_openshift_io
    machines_v1beta1_machine_openshift_io:
      failureDomains:
        platform: ""
      metadata:
        labels:
          machine.openshift.io/cluster-api-cluster: openshiftsid-wvs7z
          machine.openshift.io/cluster-api-machine-role: master
          machine.openshift.io/cluster-api-machine-type: master
      spec:
        lifecycleHooks: {}
        metadata: {}
        providerSpec:
          value:
            apiVersion: machine.openshift.io/v1
            bootType: ""
            categories: null
            cluster:
              type: uuid
              uuid: 0005b0f1-8f43-a0f2-02b7-3cecef193712
            credentialsSecret:
              name: nutanix-credentials
            image:
              name: openshiftsid-wvs7z-rhcos
              type: name
            kind: NutanixMachineProviderConfig
            memorySize: 16Gi
            metadata:
              creationTimestamp: null
            project:
              type: ""
            subnets:
            - type: uuid
              uuid: c7938dc6-7659-453e-a688-e26020c68e43
            systemDiskSize: 120Gi
            userDataSecret:
              name: master-user-data
            vcpuSockets: 8
            vcpusPerSocket: 1
status: {}
```
5. Create a cluster successfully using `openshift-install create cluster`
```
$ oc get machines -A
NAMESPACE               NAME                              PHASE         TYPE   REGION    ZONE    AGE
openshift-machine-api   openshiftsid-v2tv8-master-0       Running       AHV    Unnamed   ganon   22m
openshift-machine-api   openshiftsid-v2tv8-master-1       Running       AHV    Unnamed   ganon   22m
openshift-machine-api   openshiftsid-v2tv8-master-2       Running       AHV    Unnamed   ganon   22m
openshift-machine-api   openshiftsid-v2tv8-worker-6xc8s   Running       AHV    Unnamed   ganon   12m
openshift-machine-api   openshiftsid-v2tv8-worker-c57mc   Running       AHV    Unnamed   ganon   12m
openshift-machine-api   openshiftsid-v2tv8-worker-pnc5c   Running   AHV    Unnamed   ganon   12m
```
6. Verify that the `ControlPlaneMachineSet` is `Active` and deleting ControlPlane and Worker machines leads to creation of new ones
```
$ oc -n openshift-machine-api get controlplanemachineset
NAME      DESIRED   CURRENT   READY   UPDATED   UNAVAILABLE   STATE    AGE
cluster   3         3         3       3                       Active   75m

$ oc -n openshift-machine-api delete machine openshiftsid-v2tv8-master-0
machine.machine.openshift.io "openshiftsid-v2tv8-master-0" deleted

$ oc -n openshift-machine-api delete machine openshiftsid-v2tv8-worker-pnc5c
machine.machine.openshift.io "openshiftsid-v2tv8-worker-pnc5c" deleted

$ oc -n openshift-machine-api get machines
NAME                                PHASE     TYPE   REGION    ZONE    AGE
openshiftsid-v2tv8-master-1         Running   AHV    Unnamed   ganon   75m
openshiftsid-v2tv8-master-2         Running   AHV    Unnamed   ganon   75m
openshiftsid-v2tv8-master-4rpfd-0   Running   AHV    Unnamed   ganon   24m
openshiftsid-v2tv8-worker-6xc8s     Running   AHV    Unnamed   ganon   65m
openshiftsid-v2tv8-worker-c57mc     Running   AHV    Unnamed   ganon   65m
openshiftsid-v2tv8-worker-ps5tn     Running   AHV    Unnamed   ganon   21m
```