### PR TITLE
e2e: OpenStack CPMS created automatically

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -528,7 +528,7 @@ func getPlatformSupportLevel(k8sClient runtimeclient.Client) (PlatformSupportLev
 	case configv1.NutanixPlatformType:
 		return Manual, platformType, nil
 	case configv1.OpenStackPlatformType:
-		return Manual, platformType, nil
+		return Full, platformType, nil
 	default:
 		return Unsupported, platformType, nil
 	}


### PR DESCRIPTION
We manage the OpenStack CPMS via the installer, so we can switch the e2e
in Full, so the framework won't create it for us.

Depends-on: https://github.com/openshift/installer/pull/7280
