### PR TITLE
 webhook/cpms: add failure domain validation to OpenStack

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/onsi/gomega v1.27.7
 	github.com/openshift/api v0.0.0-20230713214710-aaae7101a7ad
 	github.com/openshift/client-go v0.0.0-20230607134213-3cd0021bbee3
-	github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20230706132925-77764237f2e6
+	github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20230713202417-fed9d3e03e09
 	github.com/openshift/library-go v0.0.0-20230523150659-ab179469ba38
 	github.com/spf13/pflag v1.0.5
 	k8s.io/api v0.27.3

--- a/go.sum
+++ b/go.sum
@@ -449,8 +449,8 @@ github.com/openshift/api v0.0.0-20230713214710-aaae7101a7ad h1:m81rPZKrQecpPJQg4
 github.com/openshift/api v0.0.0-20230713214710-aaae7101a7ad/go.mod h1:yimSGmjsI+XF1mr+AKBs2//fSXIOhhetHGbMlBEfXbs=
 github.com/openshift/client-go v0.0.0-20230607134213-3cd0021bbee3 h1:uVCq/Sx2y4UZh+qCsCL1BBUJpc3DULHkN4j7XHHgHtw=
 github.com/openshift/client-go v0.0.0-20230607134213-3cd0021bbee3/go.mod h1:M+VUIcqx5IvgzejcbgmQnxETPrXRYlcufHpw2bAgz9Y=
-github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20230706132925-77764237f2e6 h1:6Gq1pKceLaK0EU/tkXLkkqE0DI3bcZoXUB33scvwHUM=
-github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20230706132925-77764237f2e6/go.mod h1:w4P7zcu7okmBpkjKJK71rl5hp1a8RFm1NraVrxVqiUs=
+github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20230713202417-fed9d3e03e09 h1:QpYJkEzFrU7vIaEAh9bxFchdz1OL85DSMjWLdvQZL10=
+github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20230713202417-fed9d3e03e09/go.mod h1:R2xmGk/Y/6ho1RojhHS4rOxJAMSUWmIYxOA8AL0w/cM=
 github.com/openshift/library-go v0.0.0-20230523150659-ab179469ba38 h1:rKEpSwRxeQ6eN915GbcuyikwyWu//V61w5zIUWD9b2U=
 github.com/openshift/library-go v0.0.0-20230523150659-ab179469ba38/go.mod h1:PJVatR/oS/EaFciwylyAr9hORSqQHrC+5bXf4L0wsBY=
 github.com/otiai10/copy v1.2.0 h1:HvG945u96iNadPoG2/Ja2+AUJeW5YuFQMixq9yirC+k=

--- a/pkg/controllers/controlplanemachinesetgenerator/controller_test.go
+++ b/pkg/controllers/controlplanemachinesetgenerator/controller_test.go
@@ -2199,40 +2199,48 @@ var _ = Describe("controlplanemachinesetgenerator controller on OpenStack", func
 	var (
 		az1FailureDomainBuilderOpenStack = machinev1resourcebuilder.OpenStackFailureDomain().WithComputeAvailabilityZone("nova-az1").WithRootVolume(&machinev1.RootVolume{
 			AvailabilityZone: "cinder-az1",
+			VolumeType:       "fast-az1",
 		})
 
 		az2FailureDomainBuilderOpenStack = machinev1resourcebuilder.OpenStackFailureDomain().WithComputeAvailabilityZone("nova-az2").WithRootVolume(&machinev1.RootVolume{
 			AvailabilityZone: "cinder-az2",
+			VolumeType:       "fast-az2",
 		})
 
 		az3FailureDomainBuilderOpenStack = machinev1resourcebuilder.OpenStackFailureDomain().WithComputeAvailabilityZone("nova-az3").WithRootVolume(&machinev1.RootVolume{
 			AvailabilityZone: "cinder-az3",
+			VolumeType:       "fast-az3",
 		})
 
 		az4FailureDomainBuilderOpenStack = machinev1resourcebuilder.OpenStackFailureDomain().WithComputeAvailabilityZone("nova-az4")
 
 		az5FailureDomainBuilderOpenStack = machinev1resourcebuilder.OpenStackFailureDomain().WithRootVolume(&machinev1.RootVolume{
 			AvailabilityZone: "cinder-az5",
+			VolumeType:       "fast-az5",
 		})
 
 		defaultProviderSpecBuilderOpenStack = machinev1beta1resourcebuilder.OpenStackProviderSpec()
 
 		az1ProviderSpecBuilderOpenStack = machinev1beta1resourcebuilder.OpenStackProviderSpec().WithZone("nova-az1").WithRootVolume(&machinev1alpha1.RootVolume{
-			Zone: "cinder-az1",
+			VolumeType: "fast-az1",
+			Zone:       "cinder-az1",
 		})
 
 		az2ProviderSpecBuilderOpenStack = machinev1beta1resourcebuilder.OpenStackProviderSpec().WithZone("nova-az2").WithRootVolume(&machinev1alpha1.RootVolume{
-			Zone: "cinder-az2",
+			VolumeType: "fast-az2",
+			Zone:       "cinder-az2",
 		})
 
 		az3ProviderSpecBuilderOpenStack = machinev1beta1resourcebuilder.OpenStackProviderSpec().WithZone("nova-az3").WithRootVolume(&machinev1alpha1.RootVolume{
-			Zone: "cinder-az3",
+			VolumeType: "fast-az3",
+			Zone:       "cinder-az3",
 		})
 
 		az4ProviderSpecBuilderOpenStack = machinev1beta1resourcebuilder.OpenStackProviderSpec().WithZone("nova-az4")
 
 		az5ProviderSpecBuilderOpenStack = machinev1beta1resourcebuilder.OpenStackProviderSpec().WithRootVolume(&machinev1alpha1.RootVolume{
-			Zone: "cinder-az5",
+			VolumeType: "fast-az5",
+			Zone:       "cinder-az5",
 		})
 
 		cpmsEmptyFailureDomainsBuilderOpenStack = machinev1.FailureDomains{}
@@ -2609,8 +2617,13 @@ var _ = Describe("controlplanemachinesetgenerator controller on OpenStack", func
 					if openStackMachineProviderConfig.AvailabilityZone != "" {
 						openStackMachineProviderConfig.AvailabilityZone = ""
 					}
-					if openStackMachineProviderConfig.RootVolume != nil && openStackMachineProviderConfig.RootVolume.Zone != "" {
-						openStackMachineProviderConfig.RootVolume.Zone = ""
+					if openStackMachineProviderConfig.RootVolume != nil {
+						if openStackMachineProviderConfig.RootVolume.VolumeType != "" {
+							openStackMachineProviderConfig.RootVolume.VolumeType = ""
+						}
+						if openStackMachineProviderConfig.RootVolume.Zone != "" {
+							openStackMachineProviderConfig.RootVolume.Zone = ""
+						}
 					}
 
 					Expect(cpmsProviderSpec.OpenStack().Config()).To(Equal(openStackMachineProviderConfig))
@@ -2668,8 +2681,13 @@ var _ = Describe("controlplanemachinesetgenerator controller on OpenStack", func
 					if openStackMachineProviderConfig.AvailabilityZone != "" {
 						openStackMachineProviderConfig.AvailabilityZone = ""
 					}
-					if openStackMachineProviderConfig.RootVolume != nil && openStackMachineProviderConfig.RootVolume.Zone != "" {
-						openStackMachineProviderConfig.RootVolume.Zone = ""
+					if openStackMachineProviderConfig.RootVolume != nil {
+						if openStackMachineProviderConfig.RootVolume.VolumeType != "" {
+							openStackMachineProviderConfig.RootVolume.VolumeType = ""
+						}
+						if openStackMachineProviderConfig.RootVolume.Zone != "" {
+							openStackMachineProviderConfig.RootVolume.Zone = ""
+						}
 					}
 
 					Expect(cpmsProviderSpec.OpenStack().Config()).To(Equal(openStackMachineProviderConfig))
@@ -2796,8 +2814,13 @@ var _ = Describe("controlplanemachinesetgenerator controller on OpenStack", func
 				if openStackMachineProviderConfig.AvailabilityZone != "" {
 					openStackMachineProviderConfig.AvailabilityZone = ""
 				}
-				if openStackMachineProviderConfig.RootVolume != nil && openStackMachineProviderConfig.RootVolume.Zone != "" {
-					openStackMachineProviderConfig.RootVolume.Zone = ""
+				if openStackMachineProviderConfig.RootVolume != nil {
+					if openStackMachineProviderConfig.RootVolume.VolumeType != "" {
+						openStackMachineProviderConfig.RootVolume.VolumeType = ""
+					}
+					if openStackMachineProviderConfig.RootVolume.Zone != "" {
+						openStackMachineProviderConfig.RootVolume.Zone = ""
+					}
 				}
 
 				oldUID := cpms.UID

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/failuredomain/failuredomain_test.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/failuredomain/failuredomain_test.go
@@ -189,9 +189,9 @@ var _ = Describe("FailureDomains", func() {
 
 			It("should construct a list of failure domains", func() {
 				Expect(failureDomains).To(ConsistOf(
-					HaveField("String()", "OpenStackFailureDomain{AvailabilityZone:nova-az0, RootVolume:{AvailabilityZone:cinder-az0}}"),
-					HaveField("String()", "OpenStackFailureDomain{AvailabilityZone:nova-az1, RootVolume:{AvailabilityZone:cinder-az1}}"),
-					HaveField("String()", "OpenStackFailureDomain{AvailabilityZone:nova-az2, RootVolume:{AvailabilityZone:cinder-az2}}"),
+					HaveField("String()", "OpenStackFailureDomain{AvailabilityZone:nova-az0, RootVolume:{AvailabilityZone:cinder-az0, VolumeType: fast-az0}}"),
+					HaveField("String()", "OpenStackFailureDomain{AvailabilityZone:nova-az1, RootVolume:{AvailabilityZone:cinder-az1, VolumeType: fast-az1}}"),
+					HaveField("String()", "OpenStackFailureDomain{AvailabilityZone:nova-az2, RootVolume:{AvailabilityZone:cinder-az2, VolumeType: fast-az2}}"),
 				))
 			})
 		})
@@ -202,9 +202,9 @@ var _ = Describe("FailureDomains", func() {
 
 			BeforeEach(func() {
 				config := machinev1resourcebuilder.OpenStackFailureDomains().WithFailureDomainBuilders(
-					machinev1resourcebuilder.OpenStackFailureDomainBuilder{AvailabilityZone: "nova-az0", RootVolume: &machinev1.RootVolume{VolumeType: "volume.hostA"}},
-					machinev1resourcebuilder.OpenStackFailureDomainBuilder{AvailabilityZone: "nova-az1", RootVolume: &machinev1.RootVolume{VolumeType: "volume.hostB"}},
-					machinev1resourcebuilder.OpenStackFailureDomainBuilder{AvailabilityZone: "nova-az2", RootVolume: &machinev1.RootVolume{VolumeType: "volume.hostC"}},
+					machinev1resourcebuilder.OpenStackFailureDomainBuilder{AvailabilityZone: "nova-az0", RootVolume: &machinev1.RootVolume{AvailabilityZone: "cinder-az0", VolumeType: "volume.hostA"}},
+					machinev1resourcebuilder.OpenStackFailureDomainBuilder{AvailabilityZone: "nova-az1", RootVolume: &machinev1.RootVolume{AvailabilityZone: "cinder-az1", VolumeType: "volume.hostB"}},
+					machinev1resourcebuilder.OpenStackFailureDomainBuilder{AvailabilityZone: "nova-az2", RootVolume: &machinev1.RootVolume{AvailabilityZone: "cinder-az2", VolumeType: "volume.hostC"}},
 				).BuildFailureDomains()
 
 				failureDomains, err = NewFailureDomains(config)
@@ -216,9 +216,9 @@ var _ = Describe("FailureDomains", func() {
 
 			It("should construct a list of failure domains", func() {
 				Expect(failureDomains).To(ConsistOf(
-					HaveField("String()", "OpenStackFailureDomain{AvailabilityZone:nova-az0, RootVolume:{VolumeType:volume.hostA}}"),
-					HaveField("String()", "OpenStackFailureDomain{AvailabilityZone:nova-az1, RootVolume:{VolumeType:volume.hostB}}"),
-					HaveField("String()", "OpenStackFailureDomain{AvailabilityZone:nova-az2, RootVolume:{VolumeType:volume.hostC}}"),
+					HaveField("String()", "OpenStackFailureDomain{AvailabilityZone:nova-az0, RootVolume:{AvailabilityZone:cinder-az0, VolumeType:volume.hostA}}"),
+					HaveField("String()", "OpenStackFailureDomain{AvailabilityZone:nova-az1, RootVolume:{AvailabilityZone:cinder-az1, VolumeType:volume.hostB}}"),
+					HaveField("String()", "OpenStackFailureDomain{AvailabilityZone:nova-az2, RootVolume:{AvailabilityZone:cinder-az2, VolumeType:volume.hostC}}"),
 				))
 			})
 		})
@@ -370,6 +370,7 @@ var _ = Describe("FailureDomains", func() {
 		var fd failureDomain
 		var filterRootVolume = machinev1.RootVolume{
 			AvailabilityZone: "cinder-az0",
+			VolumeType:       "fast-az0",
 		}
 
 		BeforeEach(func() {
@@ -385,7 +386,7 @@ var _ = Describe("FailureDomains", func() {
 			})
 
 			It("returns the Compute and Storage availability zones for String()", func() {
-				Expect(fd.String()).To(Equal("OpenStackFailureDomain{AvailabilityZone:nova-az0, RootVolume:{AvailabilityZone:cinder-az0}}"))
+				Expect(fd.String()).To(Equal("OpenStackFailureDomain{AvailabilityZone:nova-az0, RootVolume:{AvailabilityZone:cinder-az0, VolumeType:fast-az0}}"))
 			})
 		})
 
@@ -404,7 +405,7 @@ var _ = Describe("FailureDomains", func() {
 			})
 
 			It("returns the Storage availability zone for String()", func() {
-				Expect(fd.String()).To(Equal("OpenStackFailureDomain{RootVolume:{AvailabilityZone:cinder-az0}}"))
+				Expect(fd.String()).To(Equal("OpenStackFailureDomain{RootVolume:{AvailabilityZone:cinder-az0, VolumeType:fast-az0}}"))
 			})
 		})
 		Context("with no availability zones", func() {
@@ -423,6 +424,7 @@ var _ = Describe("FailureDomains", func() {
 		var fd2 failureDomain
 		var filterRootVolume = machinev1.RootVolume{
 			AvailabilityZone: "cinder-az0",
+			VolumeType:       "fast-az0",
 		}
 
 		Context("With two identical AWS failure domains", func() {

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/machine/v1/openstack_failure_domains.go
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/machine/v1/openstack_failure_domains.go
@@ -31,14 +31,17 @@ func OpenStackFailureDomains() OpenStackFailureDomainsBuilder {
 		OpenStackFailureDomain().WithComputeAvailabilityZone("nova-az0").
 			WithRootVolume(&machinev1.RootVolume{
 				AvailabilityZone: "cinder-az0",
+				VolumeType:       "fast-az0",
 			}),
 		OpenStackFailureDomain().WithComputeAvailabilityZone("nova-az1").
 			WithRootVolume(&machinev1.RootVolume{
 				AvailabilityZone: "cinder-az1",
+				VolumeType:       "fast-az1",
 			}),
 		OpenStackFailureDomain().WithComputeAvailabilityZone("nova-az2").
 			WithRootVolume(&machinev1.RootVolume{
 				AvailabilityZone: "cinder-az2",
+				VolumeType:       "fast-az2",
 			}),
 	}}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -542,7 +542,7 @@ github.com/openshift/client-go/config/clientset/versioned/typed/config/v1
 github.com/openshift/client-go/machine/applyconfigurations/internal
 github.com/openshift/client-go/machine/applyconfigurations/machine/v1
 github.com/openshift/client-go/machine/applyconfigurations/machine/v1beta1
-# github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20230706132925-77764237f2e6
+# github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20230713202417-fed9d3e03e09
 ## explicit; go 1.19
 github.com/openshift/cluster-api-actuator-pkg/testutils
 github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder


### PR DESCRIPTION
# High level change

* Add a new `checkOpenShiftFailureDomains` function to validate the
  specified failure domains.
* Use this new function on the OpenStack platform to validate two
  things:
  * That rootVolume has an AZ when needed
  * That rootVolume always has a volumeType.
* Add unit test coverage for the OpenStack checks.

# rootVolume `volumeType` validation 

## Context

This PR has an impact for the following environment:

* OpenShift on OpenStack IPI
* The control plane machines are using root volumes
* CPMS is enabled (will be the default in 4.14)

## Facts

Historically, the installer requires a volume type to be specified when deploying a control plane with root volumes:
https://github.com/openshift/installer/blob/ff1f4528081b599790224fce2b0d8c62ebc28014/pkg/asset/installconfig/openstack/validation/machinepool.go#L94-L97

While the `volumeType` is technically [not required](https://github.com/openshift/api/blob/81d582da354baeaa7755e0da51162cf3e8fd5dd5/machine/v1alpha1/types_openstack.go#L356-L358) in `rootVolume` v1alpha1 type, it has [always](https://github.com/openshift/installer/commit/30c95315ac7f01d1cc48a9e33d918b4ee9fca25f#diff-af03f0af30fa6f0ce4070327a45cc60259155197e00fed577d08ca96ccc9a32dR15-R17) been required by the Installer.

So the machines created on day 1 by the installer with a `rootVolume` will **always** have a defined `volumeType`.

## Problem

In the initial implementation of CPMS, we have marked the `volumeType` field as optional, and it's not clear what volume type would it use if a failure domain would exist with a `rootvolume` but no `volumeType`.
Can we safely rely on the default Cinder volume type? Should it be taken from the `providerSpec`? This doesn't align with the rest of CPMS where anything "failure domain related" should live in the Failure Domain API and not in the `providerSpec`.

## Proposed solution

It is proposed to require `volumeType` in a Failure Domain with a `rootVolume`, for multiple reasons:

* To be aligned with what the installer generates on day 1. Remember that machines with a `rootVolume` will **always** have a defined `volumeType`.
* Relying on the default cinder type is risky. For example, the default storage type configured in OpenStack Cinder might not be available or not exist anymore.
  Also, in the context of Availablity zones, it's possible that the default storage type is not available for a given AZ.
  So we think that it's better to be explict than make a decision for the user which might lead to deployment or upgrade errors.
* To not have to deal with a default value in the CPMS `providerSpec` which I don't think is the way CPMS was designed to be working. As far as I understand, the fields related to a failure domain should not go
  in `providerSpec`.


# rootVolume `AvailabilityZone` validation

## Problem

When a machine is created with a compute availability zone (defined via `mpool.zones`) and a storage root volume (defined as `mpool.rootVolume`) and that `rootVolume` has no specified `zones`, CAPO will use the compute AZ for the volume AZ.
This can be problematic if the AZ doesn't exist in Cinder.

Source:
https://github.com/kubernetes-sigs/cluster-api-provider-openstack/blob/9d183bd479fe9aed4f6e7ac3d5eee46681c518e7/pkg/cloud/services/compute/instance.go#L439-L442

```golang
func (s *Service) getOrCreateRootVolume(eventObject runtime.Object, instanceSpec *InstanceSpec, imageID string) (*volumes.Volume, error) {

(...)

        availabilityZone := instanceSpec.FailureDomain
        if rootVolume.AvailabilityZone != "" {
                availabilityZone = rootVolume.AvailabilityZone
        }

(...)
```

## Proposed solution

If a compute AZ is provided alongside with a root volume, we now require
the root volume to have an AZ, so we force the user to make a choice on
which AZ the root volume is deployed on.

We are also enforcing it via CEL validation in https://github.com/openshift/api/pull/1521 and in the installer via https://github.com/openshift/installer/pull/7309