### PR TITLE
test/e2e: override `RootVolume.VolumeType` to ""

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -450,6 +450,7 @@ func convertOpenStackProviderConfigToControlPlaneMachineSetProviderSpec(provider
 	openStackPs.AvailabilityZone = ""
 
 	if openStackPs.RootVolume != nil {
+		openStackPs.RootVolume.VolumeType = ""
 		openStackPs.RootVolume.Zone = ""
 	}
 


### PR DESCRIPTION
`VolumeType` is now part of the Failure Domain so we don't want it in
the CPMS Provider Spec.

This was missed in a previous PR.
