### PR TITLE
OCPCLOUD-2169: Check CPMS events are not present when we expect error

### DIFF
--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/provider_test.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/provider_test.go
@@ -1881,6 +1881,10 @@ var _ = Describe("MachineProvider", func() {
 					Consistently(komega.Get(machine)).Should(Succeed())
 				})
 
+				It("should not receive an event", func() {
+					Expect(recorder.Events).Should(Not(Receive()))
+				})
+
 				It("does not error", func() {
 					Expect(err).ToNot(HaveOccurred())
 				})
@@ -1914,6 +1918,10 @@ var _ = Describe("MachineProvider", func() {
 				}
 
 				err = machineProvider.DeleteMachine(ctx, logger.Logger(), machineRef)
+			})
+
+			It("should not receive an event", func() {
+				Expect(recorder.Events).Should(Not(Receive()))
 			})
 
 			It("returns an error", func() {


### PR DESCRIPTION
Follow up to #242.