### PR TITLE
Set stabilisationTimeout to 60 In rolling update

### DIFF
--- a/test/e2e/helpers/cases.go
+++ b/test/e2e/helpers/cases.go
@@ -102,7 +102,7 @@ func ItShouldPerformARollingUpdate(opts *RollingUpdatePeriodicTestOptions) {
 		By("Control plane machine replacement completed successfully")
 
 		By("Waiting for the cluster to stabilise after the rollout")
-		stabilisationTimeout := 30 * time.Minute
+		stabilisationTimeout := 60 * time.Minute
 		if opts.StabilisationTimeout.Seconds() != 0 {
 			stabilisationTimeout = opts.StabilisationTimeout
 		}


### PR DESCRIPTION
It may take up to 60 minutes for operators to be up in slow setups