### PR TITLE
OCPBUGS-20070: e2e: gcp e2-custom increase memory

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -786,8 +786,8 @@ func setNextGCPMachineSize(current, family, subfamily, subfamilyflavor string, m
 				ivCPU += 2
 			}
 			// For N1 machine types, select between 1 GB and 6.5 GB per vCPU, inclusive.
-			// Note: use 5GB per vCPU, as that's a comfortable bump.
-			mem = ivCPU * 5 * 1024
+			// Note: use 3GB per vCPU, as that's a comfortable bump.
+			mem = ivCPU * 3 * 1024
 
 		case family == "n2":
 			// For N2 custom machine types, you can create a machine type with 2 to 80 vCPUs and memory between 1 and 864 GB.
@@ -800,8 +800,8 @@ func setNextGCPMachineSize(current, family, subfamily, subfamilyflavor string, m
 				ivCPU += 4
 			}
 			// For the N2 machine series, select between 0.5 GB and 8.0 GB per vCPU, inclusive.
-			// Note: the max is 864GB (with 80vCPUs we reach ~410GB).
-			mem = ivCPU * 5 * 1024
+			// Note: the max is 864GB.
+			mem = ivCPU * 3 * 1024
 
 		case family == "n2d":
 			// You can create N2D custom machine types with 2, 4, 8, or 16 vCPUs.
@@ -820,7 +820,7 @@ func setNextGCPMachineSize(current, family, subfamily, subfamilyflavor string, m
 				ivCPU += 16
 			}
 			// For N2D machine types, select between 0.5 GB and 8.0 GB per vCPU in 0.256 GB increments.
-			mem = ivCPU * 5 * 1024
+			mem = ivCPU * 3 * 1024
 
 		case family == "e2" && subfamilyflavor == "micro":
 			// 0.25 vCPU, 1 to 2 GB of memory.
@@ -859,7 +859,7 @@ func setNextGCPMachineSize(current, family, subfamily, subfamilyflavor string, m
 				ivCPU += 2
 			}
 			// For E2, the ratio of memory per vCPU is 0.5 GB to 8 GB inclusive.
-			mem = ivCPU * 512
+			mem = ivCPU * 3 * 1024
 		}
 
 		return fmt.Sprintf("%s-%s-%d-%d", family, subfamily, ivCPU, mem), nil

--- a/test/e2e/framework/framework_test.go
+++ b/test/e2e/framework/framework_test.go
@@ -200,39 +200,39 @@ var _ = Describe("Framwork", func() {
 					}),
 					Entry("when the current Machine size is n1-custom-16-1024", nextInstanceSizeTableInput{
 						currentMachineSize: "n1-custom-16-1024",
-						expectedNextSize:   "n1-custom-18-92160",
+						expectedNextSize:   "n1-custom-18-55296",
 					}),
 					Entry("when the current Machine size is n1-custom-64-1024", nextInstanceSizeTableInput{
 						currentMachineSize: "n1-custom-64-1024",
-						expectedNextSize:   "n1-custom-64-327680",
+						expectedNextSize:   "n1-custom-64-196608",
 					}),
 					Entry("when the current Machine size is n2-custom-16-1024", nextInstanceSizeTableInput{
 						currentMachineSize: "n2-custom-16-1024",
-						expectedNextSize:   "n2-custom-18-92160",
+						expectedNextSize:   "n2-custom-18-55296",
 					}),
 					Entry("when the current Machine size is n2-custom-32-1024", nextInstanceSizeTableInput{
 						currentMachineSize: "n2-custom-32-1024",
-						expectedNextSize:   "n2-custom-36-184320",
+						expectedNextSize:   "n2-custom-36-110592",
 					}),
 					Entry("when the current Machine size is n2d-custom-2-1024", nextInstanceSizeTableInput{
 						currentMachineSize: "n2d-custom-2-1024",
-						expectedNextSize:   "n2d-custom-4-20480",
+						expectedNextSize:   "n2d-custom-4-12288",
 					}),
 					Entry("when the current Machine size is n2d-custom-4-1024", nextInstanceSizeTableInput{
 						currentMachineSize: "n2d-custom-4-1024",
-						expectedNextSize:   "n2d-custom-8-40960",
+						expectedNextSize:   "n2d-custom-8-24576",
 					}),
 					Entry("when the current Machine size is n2d-custom-8-1024", nextInstanceSizeTableInput{
 						currentMachineSize: "n2d-custom-8-1024",
-						expectedNextSize:   "n2d-custom-16-81920",
+						expectedNextSize:   "n2d-custom-16-49152",
 					}),
 					Entry("when the current Machine size is n2d-custom-16-1024", nextInstanceSizeTableInput{
 						currentMachineSize: "n2d-custom-16-1024",
-						expectedNextSize:   "n2d-custom-32-163840",
+						expectedNextSize:   "n2d-custom-32-98304",
 					}),
 					Entry("when the current Machine size is n2d-custom-32-1024", nextInstanceSizeTableInput{
 						currentMachineSize: "n2d-custom-32-1024",
-						expectedNextSize:   "n2d-custom-48-245760",
+						expectedNextSize:   "n2d-custom-48-147456",
 					}),
 					Entry("when the current Machine size is e2-custom-16", nextInstanceSizeTableInput{
 						currentMachineSize: "e2-custom-16",
@@ -241,7 +241,7 @@ var _ = Describe("Framwork", func() {
 					}),
 					Entry("when the current Machine size is e2-custom-2-1024", nextInstanceSizeTableInput{
 						currentMachineSize: "e2-custom-2-1024",
-						expectedNextSize:   "e2-custom-4-2048",
+						expectedNextSize:   "e2-custom-4-12288",
 					}),
 					Entry("when the current Machine size is e2-custom-micro-0.25-1024", nextInstanceSizeTableInput{
 						currentMachineSize: "e2-custom-micro-0.25-1024",


### PR DESCRIPTION
Builds upon https://github.com/openshift/cluster-control-plane-machine-set-operator/pull/244

Increases e2-custom memory for when bumping its size, as the current multiplier is too low and results in a machine with too low memory, which results in e2e failures.