### PR TITLE
SPLAT-1211: recognize topology and failure domains represented by the infrastructure resource

### DIFF
--- a/pkg/controllers/controlplanemachineset/controller.go
+++ b/pkg/controllers/controlplanemachineset/controller.go
@@ -60,6 +60,10 @@ const (
 	// degradedClusterState is used to denote that the control plane machine set has detected a degraded cluster.
 	// In this case, the controller will not perform any further actions.
 	degradedClusterState = "Cluster state is degraded. The control plane machine set will not take any action until issues have been resolved."
+
+	// infrastructureName is the name of the Infrastructure resource. Any changes to this resource will need to be
+	// reflected in changes to the ControlPlaneMachineSet configuration.
+	infrastructureName = "cluster"
 )
 
 var (
@@ -133,6 +137,11 @@ func (r *ControlPlaneMachineSetReconciler) SetupWithManager(mgr ctrl.Manager) er
 			&configv1.ClusterOperator{},
 			handler.EnqueueRequestsFromMapFunc(util.ObjToControlPlaneMachineSet(clusterControlPlaneMachineSetName, r.Namespace)),
 			builder.WithPredicates(util.FilterClusterOperator(r.OperatorName)),
+		).
+		Watches(
+			&configv1.Infrastructure{},
+			handler.EnqueueRequestsFromMapFunc(util.ObjToControlPlaneMachineSet(clusterControlPlaneMachineSetName, r.Namespace)),
+			builder.WithPredicates(util.FilterInfrastructure(infrastructureName)),
 		).
 		// Override the default log constructor as it makes the logs very chatty.
 		WithLogConstructor(func(req *reconcile.Request) logr.Logger {

--- a/pkg/controllers/controlplanemachineset/suite_test.go
+++ b/pkg/controllers/controlplanemachineset/suite_test.go
@@ -27,6 +27,8 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	machinev1 "github.com/openshift/api/machine/v1"
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+	configv1builder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/config/v1"
+	"github.com/openshift/cluster-control-plane-machine-set-operator/pkg/util"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -85,6 +87,9 @@ var _ = BeforeSuite(func() {
 	k8sClient, err = client.New(cfg, client.Options{Scheme: testScheme})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
+
+	infrastructure := configv1builder.Infrastructure().AsAWS("test", "eu-west-2").WithName(util.InfrastructureName).Build()
+	Expect(k8sClient.Create(ctx, infrastructure)).To(Succeed())
 
 	httpClient, err := rest.HTTPClientFor(cfg)
 	Expect(err).NotTo(HaveOccurred())

--- a/pkg/controllers/controlplanemachinesetgenerator/aws.go
+++ b/pkg/controllers/controlplanemachinesetgenerator/aws.go
@@ -41,7 +41,7 @@ const (
 
 // generateControlPlaneMachineSetAWSSpec generates an AWS flavored ControlPlaneMachineSet Spec.
 func generateControlPlaneMachineSetAWSSpec(logger logr.Logger, machines []machinev1beta1.Machine, machineSets []machinev1beta1.MachineSet) (machinev1builder.ControlPlaneMachineSetSpecApplyConfiguration, error) {
-	controlPlaneMachineSetMachineFailureDomainsApplyConfig, err := buildFailureDomains(logger, machineSets, machines)
+	controlPlaneMachineSetMachineFailureDomainsApplyConfig, err := buildFailureDomains(logger, machineSets, machines, nil)
 	if err != nil {
 		return machinev1builder.ControlPlaneMachineSetSpecApplyConfiguration{}, fmt.Errorf("failed to build ControlPlaneMachineSet's AWS failure domains: %w", err)
 	}
@@ -67,7 +67,7 @@ func buildControlPlaneMachineSetAWSMachineSpec(logger logr.Logger, machines []ma
 	// This is done so that if there are control plane machines with differing
 	// Provider Specs, we will use the most recent one. This is an attempt to try and inferr
 	// the spec that the user might want to choose among the different ones found in the cluster.
-	providerConfig, err := providerconfig.NewProviderConfigFromMachineSpec(logger, machines[0].Spec)
+	providerConfig, err := providerconfig.NewProviderConfigFromMachineSpec(logger, machines[0].Spec, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to extract machine's aws providerSpec: %w", err)
 	}

--- a/pkg/controllers/controlplanemachinesetgenerator/azure.go
+++ b/pkg/controllers/controlplanemachinesetgenerator/azure.go
@@ -33,7 +33,7 @@ import (
 
 // generateControlPlaneMachineSetAzureSpec generates an Azure flavored ControlPlaneMachineSet Spec.
 func generateControlPlaneMachineSetAzureSpec(logger logr.Logger, machines []machinev1beta1.Machine, machineSets []machinev1beta1.MachineSet) (machinev1builder.ControlPlaneMachineSetSpecApplyConfiguration, error) {
-	controlPlaneMachineSetMachineFailureDomainsApplyConfig, err := buildFailureDomains(logger, machineSets, machines)
+	controlPlaneMachineSetMachineFailureDomainsApplyConfig, err := buildFailureDomains(logger, machineSets, machines, nil)
 	if err != nil {
 		return machinev1builder.ControlPlaneMachineSetSpecApplyConfiguration{}, fmt.Errorf("failed to build ControlPlaneMachineSet's Azure failure domains: %w", err)
 	}
@@ -55,7 +55,7 @@ func generateControlPlaneMachineSetAzureSpec(logger logr.Logger, machines []mach
 func buildControlPlaneMachineSetAzureMachineSpec(logger logr.Logger, machines []machinev1beta1.Machine) (*machinev1beta1builder.MachineSpecApplyConfiguration, error) {
 	// The machines slice is sorted by the creation time.
 	// We want to get the provider config for the newest machine.
-	providerConfig, err := providerconfig.NewProviderConfigFromMachineSpec(logger, machines[0].Spec)
+	providerConfig, err := providerconfig.NewProviderConfigFromMachineSpec(logger, machines[0].Spec, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to extract machine's azure providerSpec: %w", err)
 	}

--- a/pkg/controllers/controlplanemachinesetgenerator/controller.go
+++ b/pkg/controllers/controlplanemachinesetgenerator/controller.go
@@ -45,10 +45,7 @@ const (
 	// clusterControlPlaneMachineSetName is the name of the ControlPlaneMachineSet.
 	// As ControlPlaneMachineSets are singletons within the namespace, only ControlPlaneMachineSets
 	// with this name should be reconciled.
-	clusterControlPlaneMachineSetName = "cluster"
-	// infrastructureName is the name of the Infrastructure,
-	// as Infrastructure is a singleton within the cluster.
-	infrastructureName                   = "cluster"
+	clusterControlPlaneMachineSetName    = "cluster"
 	machineRoleLabelKey                  = "machine.openshift.io/cluster-api-machine-role"
 	clusterIDLabelKey                    = "machine.openshift.io/cluster-api-cluster"
 	clusterMachineRoleLabelKey           = "machine.openshift.io/cluster-api-machine-role"
@@ -89,6 +86,7 @@ type ControlPlaneMachineSetGeneratorReconciler struct {
 	// Namespace is the namespace in which the ControlPlaneMachineSetGenerator controller should operate.
 	// Any ControlPlaneMachineSet not in this namespace should be ignored.
 	Namespace string
+	APIReader client.Reader
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -110,6 +108,7 @@ func (r *ControlPlaneMachineSetGeneratorReconciler) SetupWithManager(mgr ctrl.Ma
 	// Set up API helpers from the manager.
 	r.Scheme = mgr.GetScheme()
 	r.RESTMapper = mgr.GetRESTMapper()
+	r.APIReader = mgr.GetAPIReader()
 
 	return nil
 }
@@ -158,8 +157,7 @@ func (r *ControlPlaneMachineSetGeneratorReconciler) Reconcile(ctx context.Contex
 // and would like to keep it this way.
 //
 //nolint:cyclop
-func (r *ControlPlaneMachineSetGeneratorReconciler) reconcile(ctx context.Context, logger logr.Logger,
-	cpms *machinev1.ControlPlaneMachineSet) (ctrl.Result, error) {
+func (r *ControlPlaneMachineSetGeneratorReconciler) reconcile(ctx context.Context, logger logr.Logger, cpms *machinev1.ControlPlaneMachineSet) (ctrl.Result, error) {
 	machines, err := r.getControlPlaneMachines(ctx)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to get control plane machines: %w", err)
@@ -174,16 +172,17 @@ func (r *ControlPlaneMachineSetGeneratorReconciler) reconcile(ctx context.Contex
 		return reconcile.Result{}, fmt.Errorf("failed to get machinesets: %w", err)
 	}
 
-	infrastructure, err := r.getInfrastructure(ctx, infrastructureName)
+	infrastructure, err := util.GetInfrastructure(ctx, r.Client)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to get infrastructure object: %w", err)
 	}
 
 	// generate an up to date ControlPlaneMachineSet based on the current cluster state.
-	generatedCPMS, err := r.generateControlPlaneMachineSet(logger, infrastructure.Status.PlatformStatus.Type, machines, machineSets)
+	generatedCPMS, err := r.generateControlPlaneMachineSet(logger, infrastructure, machines, machineSets)
 	if errors.Is(err, errUnsupportedPlatform) {
 		// Do not requeue if the platform is not supported.
 		// Nothing to do in this case.
+		logger.Info(fmt.Sprintf("%s unsupported platform", infrastructure.Status.PlatformStatus.Type))
 		return reconcile.Result{}, nil
 	} else if err != nil {
 		return reconcile.Result{}, fmt.Errorf("unable to generate control plane machine set: %w", err)
@@ -215,12 +214,13 @@ func (r *ControlPlaneMachineSetGeneratorReconciler) reconcile(ctx context.Contex
 // generateControlPlaneMachineSet generates a control plane machine set based on the current cluster state.
 //
 //nolint:cyclop
-func (r *ControlPlaneMachineSetGeneratorReconciler) generateControlPlaneMachineSet(logger logr.Logger,
-	platformType configv1.PlatformType, machines []machinev1beta1.Machine, machineSets []machinev1beta1.MachineSet) (*machinev1.ControlPlaneMachineSet, error) {
+func (r *ControlPlaneMachineSetGeneratorReconciler) generateControlPlaneMachineSet(logger logr.Logger, infrastructure *configv1.Infrastructure, machines []machinev1beta1.Machine, machineSets []machinev1beta1.MachineSet) (*machinev1.ControlPlaneMachineSet, error) {
 	var (
 		cpmsSpecApplyConfig machinev1builder.ControlPlaneMachineSetSpecApplyConfiguration
 		err                 error
 	)
+
+	platformType := infrastructure.Status.PlatformStatus.Type
 
 	switch platformType {
 	case configv1.AWSPlatformType:
@@ -342,16 +342,6 @@ func (r *ControlPlaneMachineSetGeneratorReconciler) getMachineSets(ctx context.C
 	}
 
 	return sortMachineSetsByCreationTimeAscending(machineSets.Items), nil
-}
-
-// getInfrastructure returns the infrastructure matching the infrastructureName.
-func (r *ControlPlaneMachineSetGeneratorReconciler) getInfrastructure(ctx context.Context, infrastructureName string) (*configv1.Infrastructure, error) {
-	infrastructure := &configv1.Infrastructure{}
-	if err := r.Get(ctx, client.ObjectKey{Name: infrastructureName}, infrastructure); err != nil {
-		return nil, fmt.Errorf("unable to get infrastructure object: %w", err)
-	}
-
-	return infrastructure, nil
 }
 
 // isSupportedControlPlaneMachinesNumber checks if the number of control plane machines in the cluster is supported by the ControlPlaneMachineSet.

--- a/pkg/controllers/controlplanemachinesetgenerator/controller_test.go
+++ b/pkg/controllers/controlplanemachinesetgenerator/controller_test.go
@@ -47,6 +47,12 @@ import (
 	"github.com/openshift/cluster-control-plane-machine-set-operator/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig"
 )
 
+const (
+	// infrastructureName is the name of the Infrastructure,
+	// as Infrastructure is a singleton within the cluster.
+	infrastructureName = "cluster"
+)
+
 var _ = Describe("controlplanemachinesetgenerator controller on AWS", func() {
 
 	var (
@@ -434,10 +440,10 @@ var _ = Describe("controlplanemachinesetgenerator controller on AWS", func() {
 					Eventually(komega.Get(cpms)).Should(Succeed())
 					// In this case expect the machine Provider Spec of the youngest machine to be used here.
 					// In this case it should be `machine-2` given that's the one we created last.
-					cpmsProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec)
+					cpmsProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec, nil)
 					Expect(err).To(BeNil())
 
-					machineProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), machine2.Spec)
+					machineProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), machine2.Spec, nil)
 					Expect(err).To(BeNil())
 
 					// Remove from the machine Provider Spec the fields that won't be
@@ -489,10 +495,10 @@ var _ = Describe("controlplanemachinesetgenerator controller on AWS", func() {
 					Eventually(komega.Get(cpms)).Should(Succeed())
 					// In this case expect the machine Provider Spec of the youngest machine to be used here.
 					// In this case it should be `machine-2` given that's the one we created last.
-					cpmsProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec)
+					cpmsProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec, nil)
 					Expect(err).To(BeNil())
 
-					machineProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), machine2.Spec)
+					machineProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), machine2.Spec, nil)
 					Expect(err).To(BeNil())
 
 					// Remove from the machine Provider Spec the fields that won't be
@@ -573,8 +579,15 @@ var _ = Describe("controlplanemachinesetgenerator controller on AWS", func() {
 				By("Creating Control Plane Machines")
 				machines := create3CPMachines()
 
+				infrastructure := configv1resourcebuilder.Infrastructure().WithName(infrastructureName).Build()
+				infrastructure.Status = configv1.InfrastructureStatus{
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: configv1.NonePlatformType,
+					},
+				}
+
 				logger = testutils.NewTestLogger()
-				generatedCPMS, err := reconciler.generateControlPlaneMachineSet(logger.Logger(), configv1.NonePlatformType, *machines, nil)
+				generatedCPMS, err := reconciler.generateControlPlaneMachineSet(logger.Logger(), infrastructure, *machines, nil)
 				Expect(generatedCPMS).To(BeNil())
 				Expect(err).To(MatchError(errUnsupportedPlatform))
 			})
@@ -616,7 +629,7 @@ var _ = Describe("controlplanemachinesetgenerator controller on AWS", func() {
 			It("should recreate ControlPlaneMachineSet with the provider spec matching the youngest machine provider spec", func() {
 				// In this case expect the machine Provider Spec of the youngest machine to be used here.
 				// In this case it should be `machine-1` given that's the one we created last.
-				machineProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), machine2.Spec)
+				machineProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), machine2.Spec, nil)
 				Expect(err).To(BeNil())
 
 				// Remove from the machine Provider Spec the fields that won't be
@@ -630,7 +643,7 @@ var _ = Describe("controlplanemachinesetgenerator controller on AWS", func() {
 				Eventually(komega.Object(cpms), time.Second*30).Should(
 					HaveField("Spec.Template.OpenShiftMachineV1Beta1Machine.Spec",
 						WithTransform(func(in machinev1beta1.MachineSpec) machinev1beta1.AWSMachineProviderConfig {
-							mPS, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), in)
+							mPS, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), in, nil)
 							if err != nil {
 								return machinev1beta1.AWSMachineProviderConfig{}
 							}
@@ -1012,10 +1025,10 @@ var _ = Describe("controlplanemachinesetgenerator controller on Azure", func() {
 					Eventually(komega.Get(cpms)).Should(Succeed())
 					// In this case expect the machine Provider Spec of the youngest machine to be used here.
 					// In this case it should be `machine-2` given that's the one we created last.
-					cpmsProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec)
+					cpmsProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec, nil)
 					Expect(err).To(BeNil())
 
-					machineProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), machine2.Spec)
+					machineProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), machine2.Spec, nil)
 					Expect(err).To(BeNil())
 
 					// Remove from the machine Provider Spec the fields that won't be
@@ -1066,10 +1079,10 @@ var _ = Describe("controlplanemachinesetgenerator controller on Azure", func() {
 					Eventually(komega.Get(cpms)).Should(Succeed())
 					// In this case expect the machine Provider Spec of the youngest machine to be used here.
 					// In this case it should be `machine-2` given that's the one we created last.
-					cpmsProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec)
+					cpmsProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec, nil)
 					Expect(err).To(BeNil())
 
-					machineProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), machine2.Spec)
+					machineProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), machine2.Spec, nil)
 					Expect(err).To(BeNil())
 
 					// Remove from the machine Provider Spec the fields that won't be
@@ -1149,8 +1162,15 @@ var _ = Describe("controlplanemachinesetgenerator controller on Azure", func() {
 				By("Creating Control Plane Machines")
 				machines := create3CPMachines()
 
+				infrastructure := configv1resourcebuilder.Infrastructure().WithName(infrastructureName).Build()
+				infrastructure.Status = configv1.InfrastructureStatus{
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: configv1.NonePlatformType,
+					},
+				}
+
 				logger = testutils.NewTestLogger()
-				generatedCPMS, err := reconciler.generateControlPlaneMachineSet(logger.Logger(), configv1.NonePlatformType, *machines, nil)
+				generatedCPMS, err := reconciler.generateControlPlaneMachineSet(logger.Logger(), infrastructure, *machines, nil)
 				Expect(generatedCPMS).To(BeNil())
 				Expect(err).To(MatchError(errUnsupportedPlatform))
 			})
@@ -1192,7 +1212,7 @@ var _ = Describe("controlplanemachinesetgenerator controller on Azure", func() {
 			It("should recreate ControlPlaneMachineSet with the provider spec matching the youngest machine provider spec", func() {
 				// In this case expect the machine Provider Spec of the youngest machine to be used here.
 				// In this case it should be `machine-1` given that's the one we created last.
-				machineProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), machine2.Spec)
+				machineProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), machine2.Spec, nil)
 				Expect(err).To(BeNil())
 
 				// Remove from the machine Provider Spec the fields that won't be
@@ -1205,7 +1225,7 @@ var _ = Describe("controlplanemachinesetgenerator controller on Azure", func() {
 				Eventually(komega.Object(cpms), time.Second*30).Should(
 					HaveField("Spec.Template.OpenShiftMachineV1Beta1Machine.Spec",
 						WithTransform(func(in machinev1beta1.MachineSpec) machinev1beta1.AzureMachineProviderSpec {
-							mPS, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), in)
+							mPS, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), in, nil)
 							if err != nil {
 								return machinev1beta1.AzureMachineProviderSpec{}
 							}
@@ -1587,10 +1607,10 @@ var _ = Describe("controlplanemachinesetgenerator controller on GCP", func() {
 					Eventually(komega.Get(cpms)).Should(Succeed())
 					// In this case expect the machine Provider Spec of the youngest machine to be used here.
 					// In this case it should be `machine-2` given that's the one we created last.
-					cpmsProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec)
+					cpmsProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec, nil)
 					Expect(err).To(BeNil())
 
-					machineProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), machine2.Spec)
+					machineProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), machine2.Spec, nil)
 					Expect(err).To(BeNil())
 
 					// Remove from the machine Provider Spec the fields that won't be
@@ -1641,10 +1661,10 @@ var _ = Describe("controlplanemachinesetgenerator controller on GCP", func() {
 					Eventually(komega.Get(cpms)).Should(Succeed())
 					// In this case expect the machine Provider Spec of the youngest machine to be used here.
 					// In this case it should be `machine-2` given that's the one we created last.
-					cpmsProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec)
+					cpmsProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec, nil)
 					Expect(err).To(BeNil())
 
-					machineProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), machine2.Spec)
+					machineProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), machine2.Spec, nil)
 					Expect(err).To(BeNil())
 
 					// Remove from the machine Provider Spec the fields that won't be
@@ -1724,8 +1744,15 @@ var _ = Describe("controlplanemachinesetgenerator controller on GCP", func() {
 				By("Creating Control Plane Machines")
 				machines := create3CPMachines()
 
+				infrastructure := configv1resourcebuilder.Infrastructure().WithName(infrastructureName).Build()
+				infrastructure.Status = configv1.InfrastructureStatus{
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: configv1.NonePlatformType,
+					},
+				}
+
 				logger = testutils.NewTestLogger()
-				generatedCPMS, err := reconciler.generateControlPlaneMachineSet(logger.Logger(), configv1.NonePlatformType, *machines, nil)
+				generatedCPMS, err := reconciler.generateControlPlaneMachineSet(logger.Logger(), infrastructure, *machines, nil)
 				Expect(generatedCPMS).To(BeNil())
 				Expect(err).To(MatchError(errUnsupportedPlatform))
 			})
@@ -1767,7 +1794,7 @@ var _ = Describe("controlplanemachinesetgenerator controller on GCP", func() {
 			It("should recreate ControlPlaneMachineSet with the provider spec matching the youngest machine provider spec", func() {
 				// In this case expect the machine Provider Spec of the youngest machine to be used here.
 				// In this case it should be `machine-1` given that's the one we created last.
-				machineProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), machine2.Spec)
+				machineProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), machine2.Spec, nil)
 				Expect(err).To(BeNil())
 
 				// Remove from the machine Provider Spec the fields that won't be
@@ -1780,7 +1807,7 @@ var _ = Describe("controlplanemachinesetgenerator controller on GCP", func() {
 				Eventually(komega.Object(cpms), time.Second*30).Should(
 					HaveField("Spec.Template.OpenShiftMachineV1Beta1Machine.Spec",
 						WithTransform(func(in machinev1beta1.MachineSpec) machinev1beta1.GCPMachineProviderSpec {
-							mPS, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), in)
+							mPS, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), in, nil)
 							if err != nil {
 								return machinev1beta1.GCPMachineProviderSpec{}
 							}
@@ -2092,10 +2119,10 @@ var _ = Describe("controlplanemachinesetgenerator controller on Nutanix", func()
 					Eventually(komega.Get(cpms)).Should(Succeed())
 					// In this case expect the machine Provider Spec of the youngest machine to be used here.
 					// In this case it should be `machine-2` given that's the one we created last.
-					cpmsProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec)
+					cpmsProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec, nil)
 					Expect(err).To(BeNil())
 
-					machineProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), machine2.Spec)
+					machineProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), machine2.Spec, nil)
 					Expect(err).To(BeNil())
 
 					machineProviderConfig := machineProviderSpec.Generic()
@@ -2127,12 +2154,13 @@ var _ = Describe("controlplanemachinesetgenerator controller on Nutanix", func()
 				It("should create the ControlPlaneMachineSet with the provider spec matching the youngest machine provider spec", func() {
 					By("Checking the Control Plane Machine Set has been created")
 					Eventually(komega.Get(cpms)).Should(Succeed())
+
 					// In this case expect the machine Provider Spec of the youngest machine to be used here.
 					// In this case it should be `machine-2` given that's the one we created last.
-					cpmsProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec)
+					cpmsProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec, nil)
 					Expect(err).To(BeNil())
 
-					machineProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), machine2.Spec)
+					machineProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), machine2.Spec, nil)
 					Expect(err).To(BeNil())
 
 					// Remove from the machine Provider Spec the fields that won't be
@@ -2188,8 +2216,15 @@ var _ = Describe("controlplanemachinesetgenerator controller on Nutanix", func()
 				By("Creating Control Plane Machines")
 				machines := create3CPMachines()
 
+				infrastructure := configv1resourcebuilder.Infrastructure().WithName(infrastructureName).Build()
+				infrastructure.Status = configv1.InfrastructureStatus{
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: configv1.NonePlatformType,
+					},
+				}
+
 				logger = testutils.NewTestLogger()
-				generatedCPMS, err := reconciler.generateControlPlaneMachineSet(logger.Logger(), configv1.NonePlatformType, *machines, nil)
+				generatedCPMS, err := reconciler.generateControlPlaneMachineSet(logger.Logger(), infrastructure, *machines, nil)
 				Expect(generatedCPMS).To(BeNil())
 				Expect(err).To(MatchError(errUnsupportedPlatform))
 			})
@@ -2570,10 +2605,10 @@ var _ = Describe("controlplanemachinesetgenerator controller on OpenStack", func
 					Eventually(komega.Get(cpms)).Should(Succeed())
 					// In this case expect the machine Provider Spec of the youngest machine to be used here.
 					// In this case it should be `machine-2` given that's the one we created last.
-					cpmsProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec)
+					cpmsProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec, nil)
 					Expect(err).To(BeNil())
 
-					machineProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), machine2.Spec)
+					machineProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), machine2.Spec, nil)
 					Expect(err).To(BeNil())
 
 					openStackMachineProviderConfig := machineProviderSpec.OpenStack().Config()
@@ -2627,10 +2662,10 @@ var _ = Describe("controlplanemachinesetgenerator controller on OpenStack", func
 					Eventually(komega.Get(cpms)).Should(Succeed())
 					// In this case expect the machine Provider Spec of the youngest machine to be used here.
 					// In this case it should be `machine-2` given that's the one we created last.
-					cpmsProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec)
+					cpmsProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec, nil)
 					Expect(err).To(BeNil())
 
-					machineProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), machine2.Spec)
+					machineProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), machine2.Spec, nil)
 					Expect(err).To(BeNil())
 
 					// Remove from the machine Provider Spec the fields that won't be
@@ -2691,10 +2726,10 @@ var _ = Describe("controlplanemachinesetgenerator controller on OpenStack", func
 					Eventually(komega.Get(cpms)).Should(Succeed())
 					// In this case expect the machine Provider Spec of the youngest machine to be used here.
 					// In this case it should be `machine-2` given that's the one we created last.
-					cpmsProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec)
+					cpmsProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec, nil)
 					Expect(err).To(BeNil())
 
-					machineProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), machine2.Spec)
+					machineProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), machine2.Spec, nil)
 					Expect(err).To(BeNil())
 
 					// Remove from the machine Provider Spec the fields that won't be
@@ -2784,8 +2819,15 @@ var _ = Describe("controlplanemachinesetgenerator controller on OpenStack", func
 				By("Creating Control Plane Machines")
 				machines := create3CPMachines()
 
+				infrastructure := configv1resourcebuilder.Infrastructure().WithName(infrastructureName).Build()
+				infrastructure.Status = configv1.InfrastructureStatus{
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: configv1.NonePlatformType,
+					},
+				}
+
 				logger = testutils.NewTestLogger()
-				generatedCPMS, err := reconciler.generateControlPlaneMachineSet(logger.Logger(), configv1.NonePlatformType, *machines, nil)
+				generatedCPMS, err := reconciler.generateControlPlaneMachineSet(logger.Logger(), infrastructure, *machines, nil)
 				Expect(generatedCPMS).To(BeNil())
 				Expect(err).To(MatchError(errUnsupportedPlatform))
 			})
@@ -2827,7 +2869,7 @@ var _ = Describe("controlplanemachinesetgenerator controller on OpenStack", func
 			It("should recreate ControlPlaneMachineSet with the provider spec matching the youngest machine provider spec", func() {
 				// In this case expect the machine Provider Spec of the youngest machine to be used here.
 				// In this case it should be `machine-1` given that's the one we created last.
-				machineProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), machine2.Spec)
+				machineProviderSpec, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), machine2.Spec, nil)
 				Expect(err).To(BeNil())
 
 				// Remove from the machine Provider Spec the fields that won't be
@@ -2850,7 +2892,7 @@ var _ = Describe("controlplanemachinesetgenerator controller on OpenStack", func
 				Eventually(komega.Object(cpms), time.Second*30).Should(
 					HaveField("Spec.Template.OpenShiftMachineV1Beta1Machine.Spec",
 						WithTransform(func(in machinev1beta1.MachineSpec) machinev1alpha1.OpenstackProviderSpec {
-							mPS, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), in)
+							mPS, err := providerconfig.NewProviderConfigFromMachineSpec(mgr.GetLogger(), in, nil)
 							if err != nil {
 								return machinev1alpha1.OpenstackProviderSpec{}
 							}

--- a/pkg/controllers/controlplanemachinesetgenerator/gcp.go
+++ b/pkg/controllers/controlplanemachinesetgenerator/gcp.go
@@ -33,7 +33,7 @@ import (
 
 // generateControlPlaneMachineSetGCPSpec generates an GCP flavored ControlPlaneMachineSet Spec.
 func generateControlPlaneMachineSetGCPSpec(logger logr.Logger, machines []machinev1beta1.Machine, machineSets []machinev1beta1.MachineSet) (machinev1builder.ControlPlaneMachineSetSpecApplyConfiguration, error) {
-	controlPlaneMachineSetMachineFailureDomainsApplyConfig, err := buildFailureDomains(logger, machineSets, machines)
+	controlPlaneMachineSetMachineFailureDomainsApplyConfig, err := buildFailureDomains(logger, machineSets, machines, nil)
 	if err != nil {
 		return machinev1builder.ControlPlaneMachineSetSpecApplyConfiguration{}, fmt.Errorf("failed to build ControlPlaneMachineSet's GCP failure domains: %w", err)
 	}
@@ -55,7 +55,7 @@ func generateControlPlaneMachineSetGCPSpec(logger logr.Logger, machines []machin
 func buildControlPlaneMachineSetGCPMachineSpec(logger logr.Logger, machines []machinev1beta1.Machine) (*machinev1beta1builder.MachineSpecApplyConfiguration, error) {
 	// The machines slice is sorted by the creation time.
 	// We want to get the provider config for the newest machine.
-	providerConfig, err := providerconfig.NewProviderConfigFromMachineSpec(logger, machines[0].Spec)
+	providerConfig, err := providerconfig.NewProviderConfigFromMachineSpec(logger, machines[0].Spec, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to extract machine's GCP providerSpec: %w", err)
 	}

--- a/pkg/controllers/controlplanemachinesetgenerator/nutanix.go
+++ b/pkg/controllers/controlplanemachinesetgenerator/nutanix.go
@@ -46,7 +46,7 @@ func generateControlPlaneMachineSetNutanixSpec(logger logr.Logger, machines []ma
 func buildControlPlaneMachineSetNutanixMachineSpec(logger logr.Logger, machines []machinev1beta1.Machine) (*machinev1beta1builder.MachineSpecApplyConfiguration, error) {
 	// The machines slice is sorted by the creation time.
 	// We want to get the provider config for the newest machine.
-	providerConfig, err := providerconfig.NewProviderConfigFromMachineSpec(logger, machines[0].Spec)
+	providerConfig, err := providerconfig.NewProviderConfigFromMachineSpec(logger, machines[0].Spec, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to extract machine's providerSpec: %w", err)
 	}

--- a/pkg/controllers/controlplanemachinesetgenerator/openstack.go
+++ b/pkg/controllers/controlplanemachinesetgenerator/openstack.go
@@ -33,7 +33,7 @@ import (
 
 // checkOpenStackMachinesServerGroups checks if all machines have the same ServerGroup (the reference is the newest machine's ServerGroup).
 func checkOpenStackMachinesServerGroups(logger logr.Logger, machines []machinev1beta1.Machine) error {
-	newestMachineProviderConfig, err := providerconfig.NewProviderConfigFromMachineSpec(logger, machines[0].Spec)
+	newestMachineProviderConfig, err := providerconfig.NewProviderConfigFromMachineSpec(logger, machines[0].Spec, nil)
 	if err != nil {
 		return fmt.Errorf("failed to extract newest machine's OpenStack providerSpec: %w", err)
 	}
@@ -43,7 +43,7 @@ func checkOpenStackMachinesServerGroups(logger logr.Logger, machines []machinev1
 
 	for _, machine := range machines {
 		// get the providerSpec from the machine
-		providerConfig, err := providerconfig.NewProviderConfigFromMachineSpec(logger, machine.Spec)
+		providerConfig, err := providerconfig.NewProviderConfigFromMachineSpec(logger, machine.Spec, nil)
 		if err != nil {
 			return fmt.Errorf("failed to extract machine's OpenStack providerSpec: %w", err)
 		}
@@ -65,7 +65,7 @@ func generateControlPlaneMachineSetOpenStackSpec(logger logr.Logger, machines []
 		return machinev1builder.ControlPlaneMachineSetSpecApplyConfiguration{}, fmt.Errorf("failed to check OpenStack machines ServerGroup: %w", err)
 	}
 
-	controlPlaneMachineSetMachineFailureDomainsApplyConfig, err := buildFailureDomains(logger, machineSets, machines)
+	controlPlaneMachineSetMachineFailureDomainsApplyConfig, err := buildFailureDomains(logger, machineSets, machines, nil)
 	if err != nil {
 		return machinev1builder.ControlPlaneMachineSetSpecApplyConfiguration{}, fmt.Errorf("failed to build ControlPlaneMachineSet's OpenStack failure domains: %w", err)
 	}
@@ -87,7 +87,7 @@ func generateControlPlaneMachineSetOpenStackSpec(logger logr.Logger, machines []
 func buildControlPlaneMachineSetOpenStackMachineSpec(logger logr.Logger, machines []machinev1beta1.Machine, failureDomains *machinev1builder.FailureDomainsApplyConfiguration) (*machinev1beta1builder.MachineSpecApplyConfiguration, error) {
 	// The machines slice is sorted by the creation time.
 	// We want to get the provider config for the newest machine.
-	providerConfig, err := providerconfig.NewProviderConfigFromMachineSpec(logger, machines[0].Spec)
+	providerConfig, err := providerconfig.NewProviderConfigFromMachineSpec(logger, machines[0].Spec, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to extract machine's OpenStack providerSpec: %w", err)
 	}

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/mapping_test.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/mapping_test.go
@@ -234,7 +234,7 @@ var _ = Describe("Failure Domain Mapping", func() {
 				machines = append(machines, *machine)
 			}
 
-			mapping, err := mapMachineIndexesToFailureDomains(logger.Logger(), machines, in.replicas, failureDomains)
+			mapping, err := mapMachineIndexesToFailureDomains(logger.Logger(), machines, in.replicas, failureDomains, nil)
 			if in.expectedError != nil {
 				Expect(err).To(MatchError(in.expectedError))
 			} else {
@@ -1574,7 +1574,7 @@ var _ = Describe("Failure Domain Mapping", func() {
 				machines = append(machines, *machine)
 			}
 
-			mapping, deletingIndexes, err := createMachineMapping(logger.Logger(), machines)
+			mapping, deletingIndexes, err := createMachineMapping(logger.Logger(), machines, nil)
 			if in.expectedError != nil {
 				Expect(err).To(MatchError(in.expectedError))
 			} else {

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/provider_test.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/provider_test.go
@@ -372,7 +372,7 @@ var _ = Describe("MachineProvider", func() {
 				BuildTemplate().OpenShiftMachineV1Beta1Machine
 			Expect(template).ToNot(BeNil())
 
-			providerConfig, err := providerconfig.NewProviderConfigFromMachineTemplate(logger.Logger(), *template)
+			providerConfig, err := providerconfig.NewProviderConfigFromMachineTemplate(logger.Logger(), *template, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			selector, err := metav1.LabelSelectorAsSelector(&cpms.Spec.Selector)
@@ -1665,7 +1665,7 @@ var _ = Describe("MachineProvider", func() {
 					WithLabel(machinev1beta1.MachineClusterIDLabel, "cpms-aws-cluster-id").
 					BuildTemplate()
 
-				providerConfig, err := providerconfig.NewProviderConfigFromMachineTemplate(logger.Logger(), *template.OpenShiftMachineV1Beta1Machine)
+				providerConfig, err := providerconfig.NewProviderConfigFromMachineTemplate(logger.Logger(), *template.OpenShiftMachineV1Beta1Machine, nil)
 				Expect(err).ToNot(HaveOccurred())
 
 				selector, err := metav1.LabelSelectorAsSelector(&machinev1resourcebuilder.ControlPlaneMachineSet().Build().Spec.Selector)
@@ -1748,7 +1748,7 @@ var _ = Describe("MachineProvider", func() {
 						WithLabel(machinev1beta1.MachineClusterIDLabel, "cpms-aws-cluster-id").
 						BuildTemplate()
 
-					providerConfig, err := providerconfig.NewProviderConfigFromMachineTemplate(logger.Logger(), *template.OpenShiftMachineV1Beta1Machine)
+					providerConfig, err := providerconfig.NewProviderConfigFromMachineTemplate(logger.Logger(), *template.OpenShiftMachineV1Beta1Machine, nil)
 					Expect(err).ToNot(HaveOccurred())
 
 					openshiftProvider, ok := provider.(*openshiftMachineProvider)
@@ -1781,7 +1781,7 @@ var _ = Describe("MachineProvider", func() {
 				BuildTemplate().OpenShiftMachineV1Beta1Machine
 			Expect(template).ToNot(BeNil())
 
-			providerConfig, err := providerconfig.NewProviderConfigFromMachineTemplate(logger.Logger(), *template)
+			providerConfig, err := providerconfig.NewProviderConfigFromMachineTemplate(logger.Logger(), *template, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			selector, err := metav1.LabelSelectorAsSelector(&cpms.Spec.Selector)

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/providerconfig_test.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/providerconfig_test.go
@@ -45,6 +45,7 @@ var _ = Describe("Provider Config", func() {
 			providerSpecBuilder   resourcebuilder.RawExtensionBuilder
 			providerConfigMatcher types.GomegaMatcher
 			expectedPlatformType  configv1.PlatformType
+			infrastructure        *configv1.Infrastructure
 			expectedError         error
 		}
 
@@ -65,7 +66,7 @@ var _ = Describe("Provider Config", func() {
 				in.modifyTemplate(&tmpl)
 			}
 
-			providerConfig, err := NewProviderConfigFromMachineTemplate(logger.Logger(), *tmpl.OpenShiftMachineV1Beta1Machine)
+			providerConfig, err := NewProviderConfigFromMachineTemplate(logger.Logger(), *tmpl.OpenShiftMachineV1Beta1Machine, in.infrastructure)
 			if in.expectedError != nil {
 				Expect(err).To(MatchError(in.expectedError))
 				return
@@ -329,11 +330,13 @@ var _ = Describe("Provider Config", func() {
 			providerSpecBuilder   resourcebuilder.RawExtensionBuilder
 			providerConfigMatcher types.GomegaMatcher
 			expectedPlatformType  configv1.PlatformType
+			infrastructure        configv1.Infrastructure
 			expectedError         error
 		}
 
-		var logger testutils.TestLogger
-
+		var (
+			logger testutils.TestLogger
+		)
 		BeforeEach(func() {
 			logger = testutils.NewTestLogger()
 		})
@@ -345,7 +348,7 @@ var _ = Describe("Provider Config", func() {
 				in.modifyMachine(machine)
 			}
 
-			providerConfig, err := NewProviderConfigFromMachineSpec(logger.Logger(), machine.Spec)
+			providerConfig, err := NewProviderConfigFromMachineSpec(logger.Logger(), machine.Spec, &in.infrastructure)
 			if in.expectedError != nil {
 				Expect(err).To(MatchError(in.expectedError))
 				return
@@ -412,7 +415,7 @@ var _ = Describe("Provider Config", func() {
 		}
 
 		DescribeTable("should correctly extract the failure domains", func(in extractFailureDomainsFromMachinesTableInput) {
-			failureDomains, err := ExtractFailureDomainsFromMachines(logger.Logger(), in.machines)
+			failureDomains, err := ExtractFailureDomainsFromMachines(logger.Logger(), in.machines, nil)
 
 			if in.expectedError != nil {
 				Expect(err).To(Equal(MatchError(in.expectedError)))
@@ -713,13 +716,13 @@ var _ = Describe("Provider Config", func() {
 			}),
 			Entry("with matching Generic configs", equalTableInput{
 				basePC: &providerConfig{
-					platformType: configv1.VSpherePlatformType,
+					platformType: configv1.ExternalPlatformType,
 					generic: GenericProviderConfig{
 						providerSpec: machinev1beta1resourcebuilder.VSphereProviderSpec().BuildRawExtension(),
 					},
 				},
 				comparePC: &providerConfig{
-					platformType: configv1.VSpherePlatformType,
+					platformType: configv1.ExternalPlatformType,
 					generic: GenericProviderConfig{
 						providerSpec: machinev1beta1resourcebuilder.VSphereProviderSpec().BuildRawExtension(),
 					},
@@ -728,13 +731,13 @@ var _ = Describe("Provider Config", func() {
 			}),
 			Entry("with mis-matched spec using Generic configs", equalTableInput{
 				basePC: &providerConfig{
-					platformType: configv1.VSpherePlatformType,
+					platformType: configv1.ExternalPlatformType,
 					generic: GenericProviderConfig{
 						providerSpec: machinev1beta1resourcebuilder.VSphereProviderSpec().BuildRawExtension(),
 					},
 				},
 				comparePC: &providerConfig{
-					platformType: configv1.VSpherePlatformType,
+					platformType: configv1.ExternalPlatformType,
 					generic: GenericProviderConfig{
 						providerSpec: machinev1beta1resourcebuilder.VSphereProviderSpec().WithTemplate("different-template").BuildRawExtension(),
 					},
@@ -825,5 +828,4 @@ var _ = Describe("Provider Config", func() {
 			}),
 		)
 	})
-
 })

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/suite_test.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/suite_test.go
@@ -27,6 +27,8 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	machinev1 "github.com/openshift/api/machine/v1"
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+	configv1builder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/config/v1"
+	"github.com/openshift/cluster-control-plane-machine-set-operator/pkg/util"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -80,6 +82,9 @@ var _ = BeforeSuite(func() {
 	k8sClient, err = client.New(cfg, client.Options{Scheme: testScheme})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
+
+	infrastructure := configv1builder.Infrastructure().AsAWS("test", "eu-west-2").WithName(util.InfrastructureName).Build()
+	Expect(k8sClient.Create(ctx, infrastructure)).To(Succeed())
 
 	komega.SetClient(k8sClient)
 	komega.SetContext(ctx)

--- a/pkg/machineproviders/providers/suite_test.go
+++ b/pkg/machineproviders/providers/suite_test.go
@@ -27,6 +27,8 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	machinev1 "github.com/openshift/api/machine/v1"
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+	configv1builder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/config/v1"
+	"github.com/openshift/cluster-control-plane-machine-set-operator/pkg/util"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -80,6 +82,9 @@ var _ = BeforeSuite(func() {
 	k8sClient, err = client.New(cfg, client.Options{Scheme: testScheme})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
+
+	infrastructure := configv1builder.Infrastructure().AsAWS("test", "eu-west-2").WithName(util.InfrastructureName).Build()
+	Expect(k8sClient.Create(ctx, infrastructure)).To(Succeed())
 
 	komega.SetClient(k8sClient)
 	komega.SetContext(ctx)

--- a/pkg/test/suite_test.go
+++ b/pkg/test/suite_test.go
@@ -24,6 +24,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+	configv1builder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/config/v1"
+	"github.com/openshift/cluster-control-plane-machine-set-operator/pkg/util"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -69,6 +71,9 @@ var _ = BeforeSuite(func() {
 	k8sClient, err = client.New(cfg, client.Options{Scheme: testScheme})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
+
+	infrastructure := configv1builder.Infrastructure().AsAWS("test", "eu-west-2").WithName(util.InfrastructureName).Build()
+	Expect(k8sClient.Create(ctx, infrastructure)).To(Succeed())
 
 	komega.SetClient(k8sClient)
 	komega.SetContext(ctx)

--- a/pkg/util/infrastructure.go
+++ b/pkg/util/infrastructure.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+const (
+	// InfrastructureName is the name of the Infrastructure,
+	// as Infrastructure is a singleton within the cluster.
+	InfrastructureName = "cluster"
+)
+
+// GetInfrastructure returns the infrastructure matching the infrastructureName.
+func GetInfrastructure(ctx context.Context, cl client.Client) (*configv1.Infrastructure, error) {
+	infrastructure := &configv1.Infrastructure{}
+	if err := cl.Get(ctx, client.ObjectKey{Name: InfrastructureName}, infrastructure); err != nil {
+		return nil, fmt.Errorf("unable to get infrastructure object: %w", err)
+	}
+
+	return infrastructure, nil
+}

--- a/pkg/util/watch_filters.go
+++ b/pkg/util/watch_filters.go
@@ -165,6 +165,24 @@ func FilterControlPlaneNodes() predicate.Predicate {
 	}
 }
 
+// FilterInfrastructure filters out responding to any Infrastructure object that is not the one specified.
+func FilterInfrastructure(infraName string) predicate.Predicate {
+	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
+		infra, ok := obj.(*configv1.Infrastructure)
+		if !ok {
+			panic("expected to get an of object of type configv1.infrastructure")
+		}
+
+		shouldReconcile := infra.GetName() == infraName
+
+		if shouldReconcile {
+			klog.V(2).Info("reconcile triggered by infrastructure change")
+		}
+
+		return shouldReconcile
+	})
+}
+
 // isControlPlaneNode checks whether the provided node is a control plane one.
 func isControlPlaneNode(node *corev1.Node) bool {
 	// Ensuring that this is a master machine by checking required labels.

--- a/pkg/webhooks/controlplanemachineset/suite_test.go
+++ b/pkg/webhooks/controlplanemachineset/suite_test.go
@@ -26,8 +26,10 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	configv1 "github.com/openshift/api/config/v1"
 	machinev1 "github.com/openshift/api/machine/v1"
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+	configv1builder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/config/v1"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/discovery"
@@ -62,6 +64,7 @@ var _ = BeforeSuite(func() {
 		CRDDirectoryPaths: []string{
 			filepath.Join("..", "..", "..", "vendor", "github.com", "openshift", "api", "machine", "v1beta1"),
 			filepath.Join("..", "..", "..", "vendor", "github.com", "openshift", "api", "machine", "v1"),
+			filepath.Join("..", "..", "..", "vendor", "github.com", "openshift", "api", "config", "v1"),
 		},
 		ErrorIfCRDPathMissing: true,
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
@@ -77,12 +80,16 @@ var _ = BeforeSuite(func() {
 	testScheme = scheme.Scheme
 	Expect(machinev1.Install(testScheme)).To(Succeed())
 	Expect(machinev1beta1.Install(testScheme)).To(Succeed())
+	Expect(configv1.Install(testScheme)).To(Succeed())
 
 	//+kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: testScheme})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
+
+	infrastructure := configv1builder.Infrastructure().AsAWS("cluster", "us-east-1").WithName("cluster").Build()
+	Expect(k8sClient.Create(ctx, infrastructure)).To(Succeed())
 
 	// CEL requires Kube 1.25 and above, so check for the minimum server version.
 	discoveryClient, err := discovery.NewDiscoveryClientForConfig(cfg)

--- a/pkg/webhooks/controlplanemachineset/webhooks.go
+++ b/pkg/webhooks/controlplanemachineset/webhooks.go
@@ -27,6 +27,7 @@ import (
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 	"github.com/openshift/cluster-control-plane-machine-set-operator/pkg/machineproviders/providers/openshift/machine/v1beta1/failuredomain"
 	"github.com/openshift/cluster-control-plane-machine-set-operator/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig"
+	"github.com/openshift/cluster-control-plane-machine-set-operator/pkg/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -74,6 +75,7 @@ type ControlPlaneMachineSetWebhook struct {
 // SetupWebhookWithManager sets up a new ControlPlaneMachineSet webhook with the manager.
 func (r *ControlPlaneMachineSetWebhook) SetupWebhookWithManager(mgr ctrl.Manager, logger logr.Logger) error {
 	r.client = mgr.GetClient()
+
 	if err := ctrl.NewWebhookManagedBy(mgr).
 		WithValidator(r).
 		For(&machinev1.ControlPlaneMachineSet{}).
@@ -94,14 +96,19 @@ func (r *ControlPlaneMachineSetWebhook) ValidateCreate(ctx context.Context, obj 
 	// TODO: actually plug in admission warnings.
 	var warnings []string
 
+	infrastructure, err := util.GetInfrastructure(ctx, r.client)
+	if err != nil {
+		return warnings, fmt.Errorf("error getting infrastructure resource: %w", err)
+	}
+
 	cpms, ok := obj.(*machinev1.ControlPlaneMachineSet)
 	if !ok {
 		return warnings, errObjNotCPMS
 	}
 
 	errs = append(errs, validateMetadata(field.NewPath("metadata"), cpms.ObjectMeta)...)
-	errs = append(errs, r.validateSpec(ctx, field.NewPath("spec"), cpms)...)
-	errs = append(errs, r.validateSpecOnCreate(ctx, field.NewPath("spec"), cpms)...)
+	errs = append(errs, r.validateSpec(ctx, field.NewPath("spec"), cpms, infrastructure)...)
+	errs = append(errs, r.validateSpecOnCreate(ctx, field.NewPath("spec"), cpms, infrastructure)...)
 
 	if len(errs) > 0 {
 		return warnings, utilerrors.NewAggregate(errs)
@@ -125,8 +132,13 @@ func (r *ControlPlaneMachineSetWebhook) ValidateUpdate(ctx context.Context, oldO
 		return warnings, errObjNotCPMS
 	}
 
+	infrastructure, err := util.GetInfrastructure(ctx, r.client)
+	if err != nil {
+		return warnings, fmt.Errorf("error getting infrastructure resource: %w", err)
+	}
+
 	errs = append(errs, validateMetadata(field.NewPath("metadata"), cpms.ObjectMeta)...)
-	errs = append(errs, r.validateSpec(ctx, field.NewPath("spec"), cpms)...)
+	errs = append(errs, r.validateSpec(ctx, field.NewPath("spec"), cpms, infrastructure)...)
 
 	if len(errs) > 0 {
 		return warnings, utilerrors.NewAggregate(errs)
@@ -141,7 +153,7 @@ func (r *ControlPlaneMachineSetWebhook) ValidateDelete(ctx context.Context, obj 
 }
 
 // validateSpecOnCreate runs the create time validations on the ControlPlaneMachineSet spec.
-func (r *ControlPlaneMachineSetWebhook) validateSpecOnCreate(ctx context.Context, parentPath *field.Path, cpms *machinev1.ControlPlaneMachineSet) []error {
+func (r *ControlPlaneMachineSetWebhook) validateSpecOnCreate(ctx context.Context, parentPath *field.Path, cpms *machinev1.ControlPlaneMachineSet, infrastructure *configv1.Infrastructure) []error {
 	// TODO: This should be MachineInfos and should come from the MachineProvider.
 	// This is a blocker for adding Cluster API support right now.
 	controlPlaneMachines, err := r.fetchControlPlaneMachines(ctx)
@@ -160,7 +172,7 @@ func (r *ControlPlaneMachineSetWebhook) validateSpecOnCreate(ctx context.Context
 			fmt.Sprintf("control plane machine set replicas (%d) does not match the current number of control plane machines (%d)", *cpms.Spec.Replicas, len(controlPlaneMachines))))
 	}
 
-	errs = append(errs, validateTemplateOnCreate(r.logger, parentPath.Child("template"), cpms.Spec.Template, controlPlaneMachines)...)
+	errs = append(errs, validateTemplateOnCreate(r.logger, parentPath.Child("template"), cpms.Spec.Template, controlPlaneMachines, infrastructure)...)
 
 	return errs
 }
@@ -177,16 +189,16 @@ func validateMetadata(parentPath *field.Path, metadata metav1.ObjectMeta) []erro
 }
 
 // validateSpec validates that the spec of the ControlPlaneMachineSet resource is valid.
-func (r *ControlPlaneMachineSetWebhook) validateSpec(ctx context.Context, parentPath *field.Path, cpms *machinev1.ControlPlaneMachineSet) []error {
+func (r *ControlPlaneMachineSetWebhook) validateSpec(ctx context.Context, parentPath *field.Path, cpms *machinev1.ControlPlaneMachineSet, infrastructure *configv1.Infrastructure) []error {
 	errs := []error{}
 
-	errs = append(errs, r.validateTemplate(ctx, cpms.Namespace, parentPath.Child("template"), cpms.Spec.Template, cpms.Spec.Selector)...)
+	errs = append(errs, r.validateTemplate(ctx, cpms.Namespace, parentPath.Child("template"), cpms.Spec.Template, cpms.Spec.Selector, infrastructure)...)
 
 	return errs
 }
 
 // validateTemplate validates the common (on create and update) checks for the ControlPlaneMachineSet template.
-func (r *ControlPlaneMachineSetWebhook) validateTemplate(ctx context.Context, namespaceName string, parentPath *field.Path, template machinev1.ControlPlaneMachineSetTemplate, selector metav1.LabelSelector) []error {
+func (r *ControlPlaneMachineSetWebhook) validateTemplate(ctx context.Context, namespaceName string, parentPath *field.Path, template machinev1.ControlPlaneMachineSetTemplate, selector metav1.LabelSelector, infrastructure *configv1.Infrastructure) []error {
 	switch template.MachineType {
 	case machinev1.OpenShiftMachineV1Beta1MachineType:
 		openshiftMachineTemplatePath := parentPath.Child(string(machinev1.OpenShiftMachineV1Beta1MachineType))
@@ -197,7 +209,7 @@ func (r *ControlPlaneMachineSetWebhook) validateTemplate(ctx context.Context, na
 			return []error{field.Required(openshiftMachineTemplatePath, fmt.Sprintf("%s is required when machine type is %s", machinev1.OpenShiftMachineV1Beta1MachineType, machinev1.OpenShiftMachineV1Beta1MachineType))}
 		}
 
-		return r.validateOpenShiftMachineV1BetaTemplate(ctx, namespaceName, openshiftMachineTemplatePath, *template.OpenShiftMachineV1Beta1Machine, selector)
+		return r.validateOpenShiftMachineV1BetaTemplate(ctx, namespaceName, openshiftMachineTemplatePath, *template.OpenShiftMachineV1Beta1Machine, selector, infrastructure)
 	default:
 		return []error{field.NotSupported(parentPath.Child("machineType"), template.MachineType, []string{string(machinev1.OpenShiftMachineV1Beta1MachineType)})}
 	}
@@ -205,7 +217,7 @@ func (r *ControlPlaneMachineSetWebhook) validateTemplate(ctx context.Context, na
 
 // validateTemplateOnCreate validates the failure domains defined in the template match up with the Machines
 // that already exist within the cluster. This check is only performed on create.
-func validateTemplateOnCreate(logger logr.Logger, parentPath *field.Path, template machinev1.ControlPlaneMachineSetTemplate, machines []machinev1beta1.Machine) []error {
+func validateTemplateOnCreate(logger logr.Logger, parentPath *field.Path, template machinev1.ControlPlaneMachineSetTemplate, machines []machinev1beta1.Machine, infrastructure *configv1.Infrastructure) []error {
 	switch template.MachineType {
 	case machinev1.OpenShiftMachineV1Beta1MachineType:
 		openshiftMachineTemplatePath := parentPath.Child(string(machinev1.OpenShiftMachineV1Beta1MachineType))
@@ -216,27 +228,27 @@ func validateTemplateOnCreate(logger logr.Logger, parentPath *field.Path, templa
 			return []error{field.Required(openshiftMachineTemplatePath, fmt.Sprintf("%s is required when machine type is %s", machinev1.OpenShiftMachineV1Beta1MachineType, machinev1.OpenShiftMachineV1Beta1MachineType))}
 		}
 
-		return validateOpenShiftMachineV1BetaTemplateOnCreate(logger, openshiftMachineTemplatePath, *template.OpenShiftMachineV1Beta1Machine, machines)
+		return validateOpenShiftMachineV1BetaTemplateOnCreate(logger, openshiftMachineTemplatePath, *template.OpenShiftMachineV1Beta1Machine, machines, infrastructure)
 	default:
 		return []error{field.NotSupported(parentPath.Child("machineType"), template.MachineType, []string{string(machinev1.OpenShiftMachineV1Beta1MachineType)})}
 	}
 }
 
 // validateOpenShiftMachineV1BetaTemplate validates the OpenShift Machine API v1beta1 template.
-func (r *ControlPlaneMachineSetWebhook) validateOpenShiftMachineV1BetaTemplate(ctx context.Context, namespaceName string, parentPath *field.Path, template machinev1.OpenShiftMachineV1Beta1MachineTemplate, selector metav1.LabelSelector) []error {
+func (r *ControlPlaneMachineSetWebhook) validateOpenShiftMachineV1BetaTemplate(ctx context.Context, namespaceName string, parentPath *field.Path, template machinev1.OpenShiftMachineV1Beta1MachineTemplate, selector metav1.LabelSelector, infrastructure *configv1.Infrastructure) []error {
 	errs := []error{}
 
 	errs = append(errs, validateTemplateLabels(parentPath.Child("metadata", "labels"), template.ObjectMeta.Labels, selector)...)
-	errs = append(errs, validateOpenShiftProviderConfig(r.logger, parentPath, template)...)
-	errs = append(errs, r.validateOpenShiftProviderMachineSpec(ctx, namespaceName, parentPath.Child("spec", "providerSpec"), template)...)
+	errs = append(errs, validateOpenShiftProviderConfig(r.logger, parentPath, template, infrastructure)...)
+	errs = append(errs, r.validateOpenShiftProviderMachineSpec(ctx, namespaceName, parentPath.Child("spec", "providerSpec"), template, infrastructure)...)
 
 	return errs
 }
 
-func (r *ControlPlaneMachineSetWebhook) validateOpenShiftProviderMachineSpec(ctx context.Context, namespaceName string, parentPath *field.Path, template machinev1.OpenShiftMachineV1Beta1MachineTemplate) []error {
+func (r *ControlPlaneMachineSetWebhook) validateOpenShiftProviderMachineSpec(ctx context.Context, namespaceName string, parentPath *field.Path, template machinev1.OpenShiftMachineV1Beta1MachineTemplate, infrastructure *configv1.Infrastructure) []error {
 	errs := []error{}
 
-	providerConfig, err := providerconfig.NewProviderConfigFromMachineTemplate(r.logger, template)
+	providerConfig, err := providerconfig.NewProviderConfigFromMachineTemplate(r.logger, template, infrastructure)
 	if err != nil {
 		return []error{field.Invalid(parentPath, template.Spec.ProviderSpec.Value, fmt.Sprintf("error determining provider configuration: %s", err))}
 	}
@@ -286,13 +298,13 @@ func (r *ControlPlaneMachineSetWebhook) validateOpenShiftProviderMachineSpec(ctx
 
 // validateOpenShiftMachineV1BetaTemplateOnCreate validates the failure domains in the provided template match up with those
 // present in the Machines provided.
-func validateOpenShiftMachineV1BetaTemplateOnCreate(logger logr.Logger, parentPath *field.Path, template machinev1.OpenShiftMachineV1Beta1MachineTemplate, machines []machinev1beta1.Machine) []error {
+func validateOpenShiftMachineV1BetaTemplateOnCreate(logger logr.Logger, parentPath *field.Path, template machinev1.OpenShiftMachineV1Beta1MachineTemplate, machines []machinev1beta1.Machine, infrastructure *configv1.Infrastructure) []error {
 	errs := []error{}
 
 	if template.FailureDomains.Platform == "" {
-		errs = append(errs, checkOpenShiftProviderSpecFailureDomainMatchesMachines(logger, parentPath.Child("spec", "providerSpec"), template, machines)...)
+		errs = append(errs, checkOpenShiftProviderSpecFailureDomainMatchesMachines(logger, parentPath.Child("spec", "providerSpec"), template, machines, infrastructure)...)
 	} else {
-		errs = append(errs, checkOpenShiftFailureDomainsMatchMachines(logger, parentPath.Child("failureDomains"), template.FailureDomains, machines)...)
+		errs = append(errs, checkOpenShiftFailureDomainsMatchMachines(logger, parentPath.Child("failureDomains"), template.FailureDomains, machines, infrastructure)...)
 	}
 
 	return errs
@@ -318,10 +330,10 @@ func validateTemplateLabels(labelsPath *field.Path, templateLabels map[string]st
 
 // validateOpenShiftProviderConfig checks the provider config on the ControlPlaneMachineSet to ensure that the
 // ControlPlaneMachineSet can safely replace control plane machines.
-func validateOpenShiftProviderConfig(logger logr.Logger, parentPath *field.Path, template machinev1.OpenShiftMachineV1Beta1MachineTemplate) []error {
+func validateOpenShiftProviderConfig(logger logr.Logger, parentPath *field.Path, template machinev1.OpenShiftMachineV1Beta1MachineTemplate, infrastructure *configv1.Infrastructure) []error {
 	providerSpecPath := parentPath.Child("spec", "providerSpec")
 
-	providerConfig, err := providerconfig.NewProviderConfigFromMachineTemplate(logger, template)
+	providerConfig, err := providerconfig.NewProviderConfigFromMachineTemplate(logger, template, infrastructure)
 	if err != nil {
 		return []error{field.Invalid(providerSpecPath, template.Spec.ProviderSpec, fmt.Sprintf("error determining provider configuration: %s", err))}
 	}
@@ -386,17 +398,17 @@ func (r *ControlPlaneMachineSetWebhook) fetchControlPlaneMachines(ctx context.Co
 // failure domain extracted from the OpenShift Machine template MachineSpec on the ControlPlaneMachineSet.
 // This check is performed when no failure domains are defined on the OpenShift Machine template on the ControlPlaneMachineSet.
 // For example on single zone AWS deployment.
-func checkOpenShiftProviderSpecFailureDomainMatchesMachines(logger logr.Logger, parentPath *field.Path, template machinev1.OpenShiftMachineV1Beta1MachineTemplate, machines []machinev1beta1.Machine) []error {
+func checkOpenShiftProviderSpecFailureDomainMatchesMachines(logger logr.Logger, parentPath *field.Path, template machinev1.OpenShiftMachineV1Beta1MachineTemplate, machines []machinev1beta1.Machine, infrastructure *configv1.Infrastructure) []error {
 	errs := []error{}
 
-	templateProviderConfig, err := providerconfig.NewProviderConfigFromMachineTemplate(logger, template)
+	templateProviderConfig, err := providerconfig.NewProviderConfigFromMachineTemplate(logger, template, infrastructure)
 	if err != nil {
 		return []error{field.Invalid(parentPath, template, fmt.Sprintf("error parsing provider config from machine template: %v", err))}
 	}
 
 	templateProviderSpecFailureDomain := templateProviderConfig.ExtractFailureDomain()
 
-	failureDomains, err := providerconfig.ExtractFailureDomainsFromMachines(logger, machines)
+	failureDomains, err := providerconfig.ExtractFailureDomainsFromMachines(logger, machines, infrastructure)
 	if err != nil {
 		return append(errs, field.InternalError(parentPath, fmt.Errorf("could not get failure domains from cluster machines: %w", err)))
 	}
@@ -412,10 +424,10 @@ func checkOpenShiftProviderSpecFailureDomainMatchesMachines(logger logr.Logger, 
 
 // checkOpenShiftFailureDomainsMatchMachines ensures that failure domains of the Control Plane Machines match the
 // failure domains defined on the OpenShift Machine template on the ControlPlaneMachineSet.
-func checkOpenShiftFailureDomainsMatchMachines(logger logr.Logger, parentPath *field.Path, failureDomains machinev1.FailureDomains, machines []machinev1beta1.Machine) []error {
+func checkOpenShiftFailureDomainsMatchMachines(logger logr.Logger, parentPath *field.Path, failureDomains machinev1.FailureDomains, machines []machinev1beta1.Machine, infrastructure *configv1.Infrastructure) []error {
 	errs := []error{}
 
-	machineFailureDomains, err := getMachineFailureDomains(logger, machines)
+	machineFailureDomains, err := getMachineFailureDomains(logger, machines, infrastructure)
 	if err != nil {
 		return append(errs, field.InternalError(parentPath.Child("platform"), fmt.Errorf("could not get failure domains from cluster machines on platform %s: %w", failureDomains.Platform, err)))
 	}
@@ -443,11 +455,11 @@ func checkOpenShiftFailureDomainsMatchMachines(logger logr.Logger, parentPath *f
 // getMachineFailureDomains returns a list of failure domains used by the control plane machines.
 // We use this instead of providerconfig.ExtractFailureDomainsFromMachines because we want to
 // keep all machines and the providerconfig util deduplicates the failure domains.
-func getMachineFailureDomains(logger logr.Logger, machines []machinev1beta1.Machine) ([]failuredomain.FailureDomain, error) {
+func getMachineFailureDomains(logger logr.Logger, machines []machinev1beta1.Machine, infrastructure *configv1.Infrastructure) ([]failuredomain.FailureDomain, error) {
 	machineFailureDomains := []failuredomain.FailureDomain{}
 
 	for _, machine := range machines {
-		failureDomain, err := providerconfig.ExtractFailureDomainFromMachine(logger, machine)
+		failureDomain, err := providerconfig.ExtractFailureDomainFromMachine(logger, machine, infrastructure)
 		if err != nil {
 			return nil, fmt.Errorf("could not extract failure domain from machine: %w", err)
 		}

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -227,7 +227,7 @@ func (f *framework) IncreaseProviderSpecInstanceSize(rawProviderSpec *runtime.Ra
 		ProviderSpec: machinev1beta1.ProviderSpec{
 			Value: rawProviderSpec,
 		},
-	})
+	}, nil)
 	if err != nil {
 		return fmt.Errorf("failed to get provider config: %w", err)
 	}
@@ -254,7 +254,7 @@ func (f *framework) TagInstanceInProviderSpec(rawProviderSpec *runtime.RawExtens
 		ProviderSpec: machinev1beta1.ProviderSpec{
 			Value: rawProviderSpec,
 		},
-	})
+	}, nil)
 	if err != nil {
 		return fmt.Errorf("failed to get provider config: %w", err)
 	}
@@ -274,7 +274,7 @@ func (f *framework) UpdateDefaultedValueFromCPMS(rawProviderSpec *runtime.RawExt
 		ProviderSpec: machinev1beta1.ProviderSpec{
 			Value: rawProviderSpec,
 		},
-	})
+	}, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get provider config: %w", err)
 	}
@@ -358,7 +358,7 @@ func updateCredentialsSecretNameNutanix(providerConfig providerconfig.ProviderCo
 func (f *framework) ConvertToControlPlaneMachineSetProviderSpec(providerSpec machinev1beta1.ProviderSpec) (*runtime.RawExtension, error) {
 	providerConfig, err := providerconfig.NewProviderConfigFromMachineSpec(f.logger, machinev1beta1.MachineSpec{
 		ProviderSpec: providerSpec,
-	})
+	}, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get provider config: %w", err)
 	}


### PR DESCRIPTION
This PR introduces the infrastructure resource to aid in the resolution of topology and failure domains for platforms such as vSphere.