### PR TITLE
OCPBUGS-21863: webhooks: set min version TLS 1.2

### DIFF
--- a/cmd/control-plane-machine-set-operator/main.go
+++ b/cmd/control-plane-machine-set-operator/main.go
@@ -121,6 +121,7 @@ func main() { //nolint:funlen,cyclop
 			TLSOpts: []func(*tls.Config){
 				func(t *tls.Config) {
 					t.MinVersion = tls.VersionTLS12
+					t.CipherSuites = util.GetAllowedTLSCipherSuites()
 				},
 			},
 		}),

--- a/cmd/control-plane-machine-set-operator/main.go
+++ b/cmd/control-plane-machine-set-operator/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"crypto/tls"
 	"flag"
 	"fmt"
 	"os"
@@ -117,6 +118,11 @@ func main() { //nolint:funlen,cyclop
 		},
 		WebhookServer: webhook.NewServer(webhook.Options{
 			Port: webhookPort,
+			TLSOpts: []func(*tls.Config){
+				func(t *tls.Config) {
+					t.MinVersion = tls.VersionTLS12
+				},
+			},
 		}),
 		HealthProbeBindAddress:        probeAddr,
 		LeaderElectionNamespace:       leaderElectionConfig.ResourceNamespace,

--- a/pkg/util/tls.go
+++ b/pkg/util/tls.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"crypto/tls"
+)
+
+// GetAllowedTLSCipherSuites returns a slice of security vetted TLS CipherSuites.
+func GetAllowedTLSCipherSuites() []uint16 {
+	defaultTLSSuites := tls.CipherSuites()
+
+	insecure := map[uint16]interface{}{
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA: nil,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA: nil,
+		tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA:   nil,
+		tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA:   nil,
+		tls.TLS_RSA_WITH_AES_128_CBC_SHA:         nil,
+		tls.TLS_RSA_WITH_AES_128_GCM_SHA256:      nil,
+		tls.TLS_RSA_WITH_AES_256_CBC_SHA:         nil,
+	}
+
+	included := make([]uint16, 0, len(defaultTLSSuites)-len(insecure))
+
+	for _, s := range defaultTLSSuites {
+		if _, contains := insecure[s.ID]; contains {
+			// The processed suite is insecure, don't include it.
+			continue
+		}
+
+		included = append(included, s.ID)
+	}
+
+	return included
+}


### PR DESCRIPTION
This PR aims at removing the offering of deprecated protocols TLS protocol versions (TLSv1, TLSv1.1), from the webhooks endpoints of the operator.

In TLS now there are also cipher suites that are considered weak, making them potentially vulnerable to certain attacks, such as BEAST, LUCKY13 or SWEET32.

These suites in Go are labelled as `InsecureCipherSuites` (see [them here](https://github.com/golang/go/blob/fb726698b7c0255fa5ef62c042c1387c5ff05049/src/crypto/tls/cipher_suites.go#L77-L95)) and are proactively removed from the offered/usable ciphers for TLS encryption. The Go security team keeps them up to date with the most recent security practices.

 What ciphers to exclude to prevent BEAST, LUCKY13 or SWEET32 attacks:

- BEAST attacks are only exploitable in TLS 1.0 (TLS 1.1+ have mitigations in place for this).
So moving to TLS 1.2+ mitigates this.
- RC4 ciphersuite has practically exploitable biases. See https://www.rc4nomore.com.
- SHA-256 variants of the CBC ciphersuites don't implement any Lucky13
countermeasures. See http://www.isg.rhul.ac.uk/tls/Lucky13.html and
https://www.imperialviolet.org/2013/02/04/luckythirteen.html.
- 3DES has 64-bit blocks, which makes it fundamentally susceptible to
birthday attacks, like SWEET32. See https://sweet32.info.
- ECDHE (with CBC) and FFDHE cipher suites don't have forward secrecy.

Go already excludes all the above, vulnerable ciphersuites from the usable TLS ciphers, by putting them in the `InsecureCipherSuites`, which as stated ([here](https://github.com/golang/go/blob/fb726698b7c0255fa5ef62c042c1387c5ff05049/src/crypto/tls/cipher_suites.go#L46-L49)):

> // CipherSuites returns a list of cipher suites currently implemented by this
// package, excluding those with security issues, which are returned by
// [InsecureCipherSuites].

which means we don't need to manually include/exclude any vulnerable ciphersuite, as those are already taken care of for us by Go.

---
Edit:

After chatting with our Security team we decided to exclude some extra CipherSuites form the default Go ones.

> From the Go CipherSuites I would drop these ones:
TLS_RSA_WITH_AES_128_CBC_SHA
TLS_RSA_WITH_AES_256_CBC_SHA
TLS_RSA_WITH_AES_128_GCM_SHA256
TLS_RSA_WITH_AES_256_GCM_SHA256
TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
>
> The CBC encryption method is reported as weak due to the inherent risks associated with its implementation. Improper implementations of CBC can make the connection susceptible to padding oracle attacks or vulnerable to timing attacks. While TLS libraries have been patched multiple times to address these attacks, the complexity involved in implementing CBC correctly makes it prone to weaknesses.
>
> As for the RSA key exchange, it lacks forward secrecy and fails to protect past sessions against future compromises. If long-term secret keys are compromised, encrypted communications and previously recorded sessions can be retrieved and decrypted. Exploiting this issue effectively would require compromising the secret keys and the TLS sessions recorded.

