### PR TITLE
[release-4.14] OCPBUGS-20566: webhooks: set min version TLS 1.2 + exclude weak ciphersuites

### DIFF
--- a/cmd/control-plane-machine-set-operator/main.go
+++ b/cmd/control-plane-machine-set-operator/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"crypto/tls"
 	"flag"
 	"fmt"
 	"os"
@@ -38,6 +39,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	cpmscontroller "github.com/openshift/cluster-control-plane-machine-set-operator/pkg/controllers/controlplanemachineset"
 	cpmsgeneratorcontroller "github.com/openshift/cluster-control-plane-machine-set-operator/pkg/controllers/controlplanemachinesetgenerator"
@@ -108,9 +110,16 @@ func main() { //nolint:funlen,cyclop
 	})
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme:                        scheme,
-		MetricsBindAddress:            metricsAddr,
-		Port:                          webhookPort,
+		Scheme:             scheme,
+		MetricsBindAddress: metricsAddr,
+		WebhookServer: webhook.NewServer(webhook.Options{
+			Port: webhookPort,
+			TLSOpts: []func(*tls.Config){
+				func(t *tls.Config) {
+					t.MinVersion = tls.VersionTLS12
+				},
+			},
+		}),
 		HealthProbeBindAddress:        probeAddr,
 		LeaderElectionNamespace:       leaderElectionConfig.ResourceNamespace,
 		LeaderElection:                leaderElectionConfig.LeaderElect,

--- a/cmd/control-plane-machine-set-operator/main.go
+++ b/cmd/control-plane-machine-set-operator/main.go
@@ -117,6 +117,7 @@ func main() { //nolint:funlen,cyclop
 			TLSOpts: []func(*tls.Config){
 				func(t *tls.Config) {
 					t.MinVersion = tls.VersionTLS12
+					t.CipherSuites = util.GetAllowedTLSCipherSuites()
 				},
 			},
 		}),

--- a/pkg/util/tls.go
+++ b/pkg/util/tls.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"crypto/tls"
+)
+
+// GetAllowedTLSCipherSuites returns a slice of security vetted TLS CipherSuites.
+func GetAllowedTLSCipherSuites() []uint16 {
+	defaultTLSSuites := tls.CipherSuites()
+
+	insecure := map[uint16]interface{}{
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA: nil,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA: nil,
+		tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA:   nil,
+		tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA:   nil,
+		tls.TLS_RSA_WITH_AES_128_CBC_SHA:         nil,
+		tls.TLS_RSA_WITH_AES_128_GCM_SHA256:      nil,
+		tls.TLS_RSA_WITH_AES_256_CBC_SHA:         nil,
+	}
+
+	included := make([]uint16, 0, len(defaultTLSSuites)-len(insecure))
+
+	for _, s := range defaultTLSSuites {
+		if _, contains := insecure[s.ID]; contains {
+			// The processed suite is insecure, don't include it.
+			continue
+		}
+
+		included = append(included, s.ID)
+	}
+
+	return included
+}


### PR DESCRIPTION
Manual backport of https://github.com/openshift/cluster-control-plane-machine-set-operator/pull/252