### PR TITLE
azure: update Zone to be a string and not a pointer anymore

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/onsi/gomega v1.28.0
 	github.com/openshift/api v0.0.0-20231002140248-174e989c9ee1
 	github.com/openshift/client-go v0.0.0-20230926161409-848405da69e1
-	github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20230807182045-90182bd8375e
+	github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20231009113757-6dc642e1cfa6
 	github.com/openshift/library-go v0.0.0-20231003133513-3a0c1fc00519
 	github.com/spf13/pflag v1.0.5
 	k8s.io/api v0.28.2

--- a/go.sum
+++ b/go.sum
@@ -451,8 +451,8 @@ github.com/openshift/api v0.0.0-20230807121159-a81c3efc8824 h1:tyXFOOOL6pmacGu9j
 github.com/openshift/api v0.0.0-20230807121159-a81c3efc8824/go.mod h1:yimSGmjsI+XF1mr+AKBs2//fSXIOhhetHGbMlBEfXbs=
 github.com/openshift/client-go v0.0.0-20230926161409-848405da69e1 h1:W1N/3nVciqmjPjn2xldHjb0AwwCQzlGxLvX5BCgE8H4=
 github.com/openshift/client-go v0.0.0-20230926161409-848405da69e1/go.mod h1:ihUJrhBcYAGYQrJu/gP2OMgfVds5f5z5kbeLNBqjHLo=
-github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20230807182045-90182bd8375e h1:3nCSymYhYgFL38SXK9Kar4xfpQjiwyRyji3wnOT6c4Y=
-github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20230807182045-90182bd8375e/go.mod h1:opmqmLcaSbCFdHCbHYnFmBIjP/cHbf6L1aPtHSxyymw=
+github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20231009113757-6dc642e1cfa6 h1:JQavQwm7mILQWBA7V+6pZ77gvrqZpCrt2P95jVEdQos=
+github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20231009113757-6dc642e1cfa6/go.mod h1:Ie+cEHb8shwhqWjzxwJeriXeA5r5j2lifIrzoDYx+Dw=
 github.com/openshift/library-go v0.0.0-20231003133513-3a0c1fc00519 h1:i4tHhSfvDj0g0rmD6nHE+FtdLFEQyDWbkuRi8xs5SQ8=
 github.com/openshift/library-go v0.0.0-20231003133513-3a0c1fc00519/go.mod h1:hl8bxWuFMM72N4YH7FKLGWtYhDz/A0xwvaa8Yr5fxYU=
 github.com/otiai10/copy v1.2.0 h1:HvG945u96iNadPoG2/Ja2+AUJeW5YuFQMixq9yirC+k=

--- a/pkg/controllers/controlplanemachinesetgenerator/azure.go
+++ b/pkg/controllers/controlplanemachinesetgenerator/azure.go
@@ -62,7 +62,7 @@ func buildControlPlaneMachineSetAzureMachineSpec(logger logr.Logger, machines []
 
 	azureProviderSpec := providerConfig.Azure().Config()
 	// Remove field related to the faliure domain.
-	azureProviderSpec.Zone = nil
+	azureProviderSpec.Zone = ""
 
 	rawBytes, err := json.Marshal(azureProviderSpec)
 	if err != nil {

--- a/pkg/controllers/controlplanemachinesetgenerator/controller_test.go
+++ b/pkg/controllers/controlplanemachinesetgenerator/controller_test.go
@@ -1021,7 +1021,7 @@ var _ = Describe("controlplanemachinesetgenerator controller on Azure", func() {
 					// Remove from the machine Provider Spec the fields that won't be
 					// present on the ControlPlaneMachineSet Provider Spec.
 					azureMachineProviderConfig := machineProviderSpec.Azure().Config()
-					azureMachineProviderConfig.Zone = nil
+					azureMachineProviderConfig.Zone = ""
 
 					Expect(cpmsProviderSpec.Azure().Config()).To(Equal(azureMachineProviderConfig))
 				})
@@ -1075,7 +1075,7 @@ var _ = Describe("controlplanemachinesetgenerator controller on Azure", func() {
 					// Remove from the machine Provider Spec the fields that won't be
 					// present on the ControlPlaneMachineSet Provider Spec.
 					azureMachineProviderConfig := machineProviderSpec.Azure().Config()
-					azureMachineProviderConfig.Zone = nil
+					azureMachineProviderConfig.Zone = ""
 
 					Expect(cpmsProviderSpec.Azure().Config()).To(Equal(azureMachineProviderConfig))
 				})
@@ -1198,7 +1198,7 @@ var _ = Describe("controlplanemachinesetgenerator controller on Azure", func() {
 				// Remove from the machine Provider Spec the fields that won't be
 				// present on the ControlPlaneMachineSet Provider Spec.
 				azureMachineProviderConfig := machineProviderSpec.Azure().Config()
-				azureMachineProviderConfig.Zone = nil
+				azureMachineProviderConfig.Zone = ""
 
 				oldUID := cpms.UID
 

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/azure.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/azure.go
@@ -24,7 +24,6 @@ import (
 	machinev1 "github.com/openshift/api/machine/v1"
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/ptr"
 )
 
 // AzureProviderConfig holds the provider spec of an Azure Machine.
@@ -39,7 +38,7 @@ type AzureProviderConfig struct {
 func (a AzureProviderConfig) InjectFailureDomain(fd machinev1.AzureFailureDomain) AzureProviderConfig {
 	newAzureProviderConfig := a
 
-	newAzureProviderConfig.providerConfig.Zone = &fd.Zone
+	newAzureProviderConfig.providerConfig.Zone = fd.Zone
 
 	return newAzureProviderConfig
 }
@@ -48,7 +47,7 @@ func (a AzureProviderConfig) InjectFailureDomain(fd machinev1.AzureFailureDomain
 // information stored within the AzureProviderConfig.
 func (a AzureProviderConfig) ExtractFailureDomain() machinev1.AzureFailureDomain {
 	return machinev1.AzureFailureDomain{
-		Zone: ptr.Deref(a.providerConfig.Zone, ""),
+		Zone: a.providerConfig.Zone,
 	}
 }
 

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -416,7 +416,7 @@ func convertGCPProviderConfigToControlPlaneMachineSetProviderSpec(providerConfig
 // raw control plane machine set provider spec.
 func convertAzureProviderConfigToControlPlaneMachineSetProviderSpec(providerConfig providerconfig.ProviderConfig) (*runtime.RawExtension, error) {
 	azurePs := providerConfig.Azure().Config()
-	azurePs.Zone = nil
+	azurePs.Zone = ""
 
 	rawBytes, err := json.Marshal(azurePs)
 	if err != nil {

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/Makefile
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/Makefile
@@ -6,7 +6,7 @@ GOPROXY ?=
 export GOPROXY
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.27
+ENVTEST_K8S_VERSION = 1.28
 
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 ENVTEST = go run ${PROJECT_DIR}/vendor/sigs.k8s.io/controller-runtime/tools/setup-envtest

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/machine/v1/aws_failure_domains.go
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/machine/v1/aws_failure_domains.go
@@ -19,7 +19,7 @@ package v1
 import (
 	configv1 "github.com/openshift/api/config/v1"
 	machinev1 "github.com/openshift/api/machine/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 // AWSFailureDomains creates a new failure domains builder for AWS.
@@ -29,17 +29,17 @@ func AWSFailureDomains() AWSFailureDomainsBuilder {
 			AWSFailureDomain().WithAvailabilityZone("us-east-1a").
 				WithSubnet(machinev1.AWSResourceReference{
 					Type: machinev1.AWSIDReferenceType,
-					ID:   pointer.String("subenet-us-east-1a"),
+					ID:   ptr.To[string]("subenet-us-east-1a"),
 				}),
 			AWSFailureDomain().WithAvailabilityZone("us-east-1b").
 				WithSubnet(machinev1.AWSResourceReference{
 					Type: machinev1.AWSIDReferenceType,
-					ID:   pointer.String("subenet-us-east-1b"),
+					ID:   ptr.To[string]("subenet-us-east-1b"),
 				}),
 			AWSFailureDomain().WithAvailabilityZone("us-east-1c").
 				WithSubnet(machinev1.AWSResourceReference{
 					Type: machinev1.AWSIDReferenceType,
-					ID:   pointer.String("subenet-us-east-1c"),
+					ID:   ptr.To[string]("subenet-us-east-1c"),
 				}),
 		},
 	}

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/machine/v1/azure_failure_domains.go
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/machine/v1/azure_failure_domains.go
@@ -72,18 +72,26 @@ func AzureFailureDomain() AzureFailureDomainBuilder {
 
 // AzureFailureDomainBuilder is used to build an Azure failuredomain.
 type AzureFailureDomainBuilder struct {
-	Zone string
+	Zone   string
+	Subnet string
 }
 
 // Build builds a Azure failuredomain from the configuration.
 func (a AzureFailureDomainBuilder) Build() machinev1.AzureFailureDomain {
 	return machinev1.AzureFailureDomain{
-		Zone: a.Zone,
+		Zone:   a.Zone,
+		Subnet: a.Subnet,
 	}
 }
 
 // WithZone sets the zone for the Azure failuredomain builder.
 func (a AzureFailureDomainBuilder) WithZone(zone string) AzureFailureDomainBuilder {
 	a.Zone = zone
+	return a
+}
+
+// WithSubnet sets the subnet for the Azure failuredomain builder.
+func (a AzureFailureDomainBuilder) WithSubnet(subnet string) AzureFailureDomainBuilder {
+	a.Subnet = subnet
 	return a
 }

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/machine/v1/control_plane_machine_set.go
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/machine/v1/control_plane_machine_set.go
@@ -21,7 +21,7 @@ import (
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 	"github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -86,7 +86,7 @@ func (m ControlPlaneMachineSetBuilder) Build() *machinev1.ControlPlaneMachineSet
 			Generation: m.generation,
 		},
 		Spec: machinev1.ControlPlaneMachineSetSpec{
-			Replicas: pointer.Int32(m.replicas),
+			Replicas: ptr.To[int32](m.replicas),
 			Selector: m.selector,
 			State:    m.state,
 			Strategy: machinev1.ControlPlaneMachineSetStrategy{

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/machine/v1beta1/aws_provider_spec.go
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/machine/v1beta1/aws_provider_spec.go
@@ -23,7 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 // AWSProviderSpec creates a new AWS machine config builder.
@@ -72,14 +72,14 @@ func (m AWSProviderSpecBuilder) Build() *machinev1beta1.AWSMachineProviderConfig
 			Kind:       "AWSMachineProviderConfig",
 		},
 		AMI: machinev1beta1.AWSResourceReference{
-			ID: pointer.String("aws-ami-12345678"),
+			ID: ptr.To[string]("aws-ami-12345678"),
 		},
 		BlockDevices: []machinev1beta1.BlockDeviceMappingSpec{
 			{
 				EBS: &machinev1beta1.EBSBlockDeviceSpec{
-					Encrypted:  pointer.Bool(true),
-					VolumeSize: pointer.Int64(120),
-					VolumeType: pointer.String("gp3"),
+					Encrypted:  ptr.To[bool](true),
+					VolumeSize: ptr.To[int64](120),
+					VolumeType: ptr.To[string]("gp3"),
 				},
 			},
 		},
@@ -87,7 +87,7 @@ func (m AWSProviderSpecBuilder) Build() *machinev1beta1.AWSMachineProviderConfig
 			Name: "aws-cloud-credentials",
 		},
 		IAMInstanceProfile: &machinev1beta1.AWSResourceReference{
-			ID: pointer.String("aws-iam-instance-profile-12345678"),
+			ID: ptr.To[string]("aws-iam-instance-profile-12345678"),
 		},
 		InstanceType: m.instanceType,
 		LoadBalancers: []machinev1beta1.LoadBalancerReference{

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/machine/v1beta1/azure_provider_spec.go
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/machine/v1beta1/azure_provider_spec.go
@@ -31,6 +31,7 @@ func AzureProviderSpec() AzureProviderSpecBuilder {
 		internalLoadBalancer: "internal-load-balancer-12345678",
 		vmSize:               "Standard_D4s_v3",
 		zone:                 "1",
+		subnet:               "cluster-subnet-12345678",
 	}
 }
 
@@ -39,6 +40,7 @@ type AzureProviderSpecBuilder struct {
 	internalLoadBalancer string
 	vmSize               string
 	zone                 string
+	subnet               string
 }
 
 // Build builds a new Azure machine config based on the configuration provided.
@@ -74,9 +76,9 @@ func (m AzureProviderSpecBuilder) Build() *machinev1beta1.AzureMachineProviderSp
 		PublicLoadBalancer:    "public-load-balancer-12345678",
 		PublicIP:              false,
 		ResourceGroup:         "resource-group-12345678",
-		Zone:                  &m.zone,
+		Zone:                  m.zone,
 		AcceleratedNetworking: true,
-		Subnet:                "subnet-12345678",
+		Subnet:                m.subnet,
 	}
 }
 
@@ -110,5 +112,11 @@ func (m AzureProviderSpecBuilder) WithVMSize(vmSize string) AzureProviderSpecBui
 // WithZone sets the availabilityZone for the Azure machine config builder.
 func (m AzureProviderSpecBuilder) WithZone(az string) AzureProviderSpecBuilder {
 	m.zone = az
+	return m
+}
+
+// WithZone sets the availabilityZone for the Azure machine config builder.
+func (m AzureProviderSpecBuilder) WithSubnet(subnet string) AzureProviderSpecBuilder {
+	m.subnet = subnet
 	return m
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -553,8 +553,8 @@ github.com/openshift/client-go/config/clientset/versioned/typed/config/v1
 github.com/openshift/client-go/machine/applyconfigurations/internal
 github.com/openshift/client-go/machine/applyconfigurations/machine/v1
 github.com/openshift/client-go/machine/applyconfigurations/machine/v1beta1
-# github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20230807182045-90182bd8375e
-## explicit; go 1.19
+# github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20231009113757-6dc642e1cfa6
+## explicit; go 1.20
 github.com/openshift/cluster-api-actuator-pkg/testutils
 github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder
 github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/config/v1


### PR DESCRIPTION
- [vendoring] bump cluster-api-actuator-pkg/testutils to latest
- azure: Zone is now a String (not a pointer)
