### PR TITLE
OCPCLOUD-1894: Implement admission warning for missing target pools

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20231130130825-ea989e248004
 	github.com/openshift/library-go v0.0.0-20231003133513-3a0c1fc00519
 	github.com/spf13/pflag v1.0.5
+	go.uber.org/zap v1.25.0
 	k8s.io/api v0.28.2
 	k8s.io/apimachinery v0.28.2
 	k8s.io/client-go v0.28.2
@@ -209,7 +210,6 @@ require (
 	gitlab.com/bosi/decorder v0.4.0 // indirect
 	go.tmz.dev/musttag v0.7.2 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	go.uber.org/zap v1.25.0 // indirect
 	golang.org/x/exp v0.0.0-20230510235704-dd950f8aeaea // indirect
 	golang.org/x/exp/typeparams v0.0.0-20230307190834-24139beb5833 // indirect
 	golang.org/x/mod v0.12.0 // indirect

--- a/pkg/webhooks/controlplanemachineset/suite_test.go
+++ b/pkg/webhooks/controlplanemachineset/suite_test.go
@@ -25,6 +25,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	uberZap "go.uber.org/zap"
 
 	configv1 "github.com/openshift/api/config/v1"
 	machinev1 "github.com/openshift/api/machine/v1"
@@ -56,8 +57,10 @@ func TestAPIs(t *testing.T) {
 	RunSpecs(t, "Controller Suite")
 }
 
+var targetPoolsNotSetWarningCounter = NewMessageCounter(fmt.Sprintf("spec.template.machines_v1beta1_machine_openshift_io.spec.providerSpec.value.targetPools: %s", warnTargetPoolsNotSet))
+
 var _ = BeforeSuite(func() {
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.RawZapOpts(uberZap.Hooks(targetPoolsNotSetWarningCounter.Trigger)), zap.UseDevMode(true)))
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{


### PR DESCRIPTION
This PR implements admission warning for when CPMS providerSpec does not have targetPools field set. This needs to be warning instead of error because on private clusters we don't use target pools.

The warnings are only available as log messages in custom KubeAPIWarningLogger logger that is instantiated from parent logger for controller-runtime when creating client. I added a hook to the parent logger to count the warning messages to enable testing.