### PR TITLE
SPLAT-1410: Modified vSphere config provider to not lose AddressesFromPools when applying Failure Domains

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/onsi/gomega v1.30.0
 	github.com/openshift/api v0.0.0-20240124164020-e2ce40831f2e
 	github.com/openshift/client-go v0.0.0-20240125160436-aa5df63097c4
-	github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20231130130825-ea989e248004
+	github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20240201120052-f5a6a5f74055
 	github.com/openshift/library-go v0.0.0-20240115112243-470c096a1ca9
 	github.com/spf13/pflag v1.0.5
 	go.uber.org/zap v1.26.0

--- a/go.sum
+++ b/go.sum
@@ -460,8 +460,8 @@ github.com/openshift/api v0.0.0-20240124164020-e2ce40831f2e h1:cxgCNo/R769CO23AK
 github.com/openshift/api v0.0.0-20240124164020-e2ce40831f2e/go.mod h1:CxgbWAlvu2iQB0UmKTtRu1YfepRg1/vJ64n2DlIEVz4=
 github.com/openshift/client-go v0.0.0-20240125160436-aa5df63097c4 h1:Ct+/c9d5rjZudN+VBLxRJIQfPy1gJZier1P1KdpvCaM=
 github.com/openshift/client-go v0.0.0-20240125160436-aa5df63097c4/go.mod h1:ZS5cpA+0zI/ziDQxAKKvGkRKn9BJppqDYdAph+OUTlo=
-github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20231130130825-ea989e248004 h1:z5MmF35DnAa+HOX6AHMrGhkm7YXaKZAxrNL3JsYHJ1I=
-github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20231130130825-ea989e248004/go.mod h1:8U97lU5NyyrNKkVcG3zRXFbI33Z5D+GZYp6k4oHoT9k=
+github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20240201120052-f5a6a5f74055 h1:tDyJ73kGqi2RbS5bgpDXfKxckR2JbVOX4sMR4yf46mE=
+github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20240201120052-f5a6a5f74055/go.mod h1:osVq9/R6qKHBQxDP4cYTvkgXVBKOMs1SOfPLFfn0m7A=
 github.com/openshift/library-go v0.0.0-20240115112243-470c096a1ca9 h1:dQmXUWo3Ko+8K/fxKPF01NuTrD92d/ABBQ4NfxkwbAY=
 github.com/openshift/library-go v0.0.0-20240115112243-470c096a1ca9/go.mod h1:82B0gt8XawdXWRtKMrm3jSMTeRsiOSYKCi4F0fvPjG0=
 github.com/otiai10/copy v1.2.0 h1:HvG945u96iNadPoG2/Ja2+AUJeW5YuFQMixq9yirC+k=

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/machine/v1beta1/vsphere_provider_spec.go
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/machine/v1beta1/vsphere_provider_spec.go
@@ -42,6 +42,7 @@ type VSphereProviderSpecBuilder struct {
 	failureDomainName string
 	infrastructure    *configv1.Infrastructure
 	ippool            bool
+	tags              []string
 }
 
 // Build builds a new VSphere machine config based on the configuration provided.
@@ -94,11 +95,7 @@ func (v VSphereProviderSpecBuilder) Build() *machinev1beta1.VSphereMachineProvid
 							vSphereFailureDomain.Topology.Datacenter,
 							vSphereFailureDomain.Topology.ComputeCluster),
 					}
-					networkDevices = []machinev1beta1.NetworkDeviceSpec{
-						{
-							NetworkName: vSphereFailureDomain.Topology.Networks[0],
-						},
-					}
+					networkDevices[0].NetworkName = vSphereFailureDomain.Topology.Networks[0]
 					template = v.template
 				}
 			}
@@ -122,6 +119,7 @@ func (v VSphereProviderSpecBuilder) Build() *machinev1beta1.VSphereMachineProvid
 		Network: machinev1beta1.NetworkSpec{
 			Devices: networkDevices,
 		},
+		TagIDs:    v.tags,
 		Workspace: workspace,
 		NumCPUs:   4,
 		Template:  template,
@@ -161,6 +159,12 @@ func (v VSphereProviderSpecBuilder) WithInfrastructure(infrastructure configv1.I
 // WithTemplate sets the template for the VSphere machine config builder.
 func (v VSphereProviderSpecBuilder) WithTemplate(template string) VSphereProviderSpecBuilder {
 	v.template = template
+	return v
+}
+
+// WithTags sets the tags for the VSphere machine config builder.
+func (v VSphereProviderSpecBuilder) WithTags(tags []string) VSphereProviderSpecBuilder {
+	v.tags = tags
 	return v
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -639,8 +639,8 @@ github.com/openshift/client-go/config/listers/config/v1alpha1
 github.com/openshift/client-go/machine/applyconfigurations/internal
 github.com/openshift/client-go/machine/applyconfigurations/machine/v1
 github.com/openshift/client-go/machine/applyconfigurations/machine/v1beta1
-# github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20231130130825-ea989e248004
-## explicit; go 1.20
+# github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20240201120052-f5a6a5f74055
+## explicit; go 1.21
 github.com/openshift/cluster-api-actuator-pkg/testutils
 github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder
 github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/config/v1


### PR DESCRIPTION
[SPLAT-1410](https://issues.redhat.com/browse/SPLAT-1410)

## Changes
- Modified providerconfig/vsphere.go to keep CPMS machine provider spec networking in order to maintain the AddressesFromPool
- Added log output of networking to allow improved debugging when log level >= 4.

## Dependencies
- https://github.com/openshift/cluster-api-actuator-pkg/pull/310