### PR TITLE
OCPBUGS-28230: add FallbackToLogsOnError for easier debugging

### DIFF
--- a/manifests/0000_30_control-plane-machine-set-operator_03_deployment.yaml
+++ b/manifests/0000_30_control-plane-machine-set-operator_03_deployment.yaml
@@ -50,6 +50,7 @@ spec:
           requests:
             cpu: 10m
             memory: 50Mi
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: control-plane-machine-set-operator-tls


### PR DESCRIPTION
All openshift operators must include FallbackToLogsOnError to ease debugging.