### PR TITLE
OCPBUGS-29114: Fixed control plane machine set handling of static IPs when AddressesFromPools is not in use.

### DIFF
--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/vsphere.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/vsphere.go
@@ -183,6 +183,20 @@ func newVSphereProviderConfig(logger logr.Logger, raw *runtime.RawExtension, inf
 		infrastructure: infrastructure,
 	}
 
+	// For networking, we only need to compare the network name.  For static IPs, we can ignore all ip configuration;
+	// however, we may need to verify the addressesFromPools is present.
+	for index, device := range vsphereMachineProviderSpec.Network.Devices {
+		vsphereMachineProviderSpec.Network.Devices[index] = machinev1beta1.NetworkDeviceSpec{}
+		if device.NetworkName != "" {
+			vsphereMachineProviderSpec.Network.Devices[index].NetworkName = device.NetworkName
+		}
+
+		if device.AddressesFromPools != nil {
+			vsphereMachineProviderSpec.Network.Devices[index].AddressesFromPools = device.AddressesFromPools
+			vsphereMachineProviderSpec.Network.Devices[index].Nameservers = device.Nameservers
+		}
+	}
+
 	config := providerConfig{
 		platformType: configv1.VSpherePlatformType,
 		vsphere:      VSphereProviderConfig,


### PR DESCRIPTION
OCPBUGS-29114

## Changes
- Modified logic when creating new provider config for a machine to trim out static IP content that is not relevant. 
  - Keep NetworkName to compare with FailureDomain.
  - Keep AddressesFromPools and Nameservers when AddressFromPool is set.  Both are linked for static IPs.
- Updated Unit Tests to check static IP outputs.

## Dependency
https://github.com/openshift/installer/pull/7985
- Installer does have a change to fix the initial definition of the Control Plane Machine Set (CPMS) to no include Nameserver when AddressesFromPools is not set.