### PR TITLE
SPLAT-1410: Fix vSphere machineprovider InjectFailureDomain to handle empty network device list.

### DIFF
--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/vsphere.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/vsphere.go
@@ -91,13 +91,15 @@ func (v VSphereProviderConfig) InjectFailureDomain(fd machinev1.VSphereFailureDo
 
 	newVSphereProviderConfig.providerConfig.Workspace = newVSphereProviderConfig.getWorkspaceFromFailureDomain(failureDomain)
 	topology := failureDomain.Topology
+	network := newVSphereProviderConfig.providerConfig.Network
 
 	logNetworkInfo(newVSphereProviderConfig.providerConfig.Network, "control plane machine set network before failure domain: %v", v.logger)
 
 	if len(topology.Networks) > 0 {
 		networkSpec := machinev1beta1.NetworkSpec{}
 		// If original has AddressesFromPools, that means static IP is desired for the CPMS.  Keep that and just add the FD info.
-		if len(newVSphereProviderConfig.providerConfig.Network.Devices[0].AddressesFromPools) > 0 {
+		// Note, CPMS may have no network devices defined relying on FD to provide.
+		if len(network.Devices) > 0 && len(network.Devices[0].AddressesFromPools) > 0 {
 			networkSpec.Devices = newVSphereProviderConfig.providerConfig.Network.Devices
 		}
 

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/vsphere_test.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/vsphere_test.go
@@ -209,4 +209,17 @@ var _ = Describe("VSphere Provider Config", Label("vSphereProviderConfig"), func
 			Expect(newProviderSpec.VSphere().providerConfig.Network.Devices[0].Nameservers).To(BeNil())
 		})
 	})
+
+	Context("no network configured", func() {
+		BeforeEach(func() {
+			providerConfig.providerConfig.Network = machinev1beta1.NetworkSpec{}
+		})
+
+		It("should not fail after injectFailureDomain", func() {
+			expected, err := providerConfig.InjectFailureDomain(providerConfig.ExtractFailureDomain())
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(expected.providerConfig.Network.Devices[0].NetworkName).To(Equal(providerConfig.infrastructure.Spec.PlatformSpec.VSphere.FailureDomains[0].Topology.Networks[0]),
+				"expected NetworkName to still be equal to the the original after injection of the Failure Domain")
+		})
+	})
 })


### PR DESCRIPTION
SPLAT-1410

## Changes
- Fixed vsphere machineprovider to handle empty network device list when injecting failure domain