### PR TITLE
AUTH-482: set required-scc for openshift workloads

### DIFF
--- a/manifests/0000_30_control-plane-machine-set-operator_03_deployment.yaml
+++ b/manifests/0000_30_control-plane-machine-set-operator_03_deployment.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: restricted-v2
       labels:
         k8s-app: control-plane-machine-set-operator
     spec:


### PR DESCRIPTION
References:
- [SCC docs](https://docs.openshift.com/container-platform/4.15/authentication/managing-security-context-constraints.html)
- [SCC pinning docs](https://docs.openshift.com/container-platform/4.15/authentication/managing-security-context-constraints.html#security-context-constraints-requiring_configuring-internal-oauth)