### PR TITLE
OCPBUGS-31808: Fix ExportFailureDomain to handle empty platform spec

### DIFF
--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/vsphere.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/vsphere.go
@@ -163,6 +163,11 @@ func (v VSphereProviderConfig) ExtractFailureDomain() machinev1.VSphereFailureDo
 		return machinev1.VSphereFailureDomain{}
 	}
 
+	// Older OCP installs will not have PlatformSpec set for infrastructure.
+	if v.infrastructure.Spec.PlatformSpec.VSphere == nil {
+		return machinev1.VSphereFailureDomain{}
+	}
+
 	failureDomains := v.infrastructure.Spec.PlatformSpec.VSphere.FailureDomains
 
 	for _, failureDomain := range failureDomains {

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/vsphere_test.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/vsphere_test.go
@@ -222,4 +222,16 @@ var _ = Describe("VSphere Provider Config", Label("vSphereProviderConfig"), func
 				"expected NetworkName to still be equal to the the original after injection of the Failure Domain")
 		})
 	})
+
+	Context("no vsphere platform spec in infrastructure", func() {
+		BeforeEach(func() {
+			providerConfig.infrastructure.Spec.PlatformSpec.VSphere = nil
+		})
+
+		It("should should return empty failure domain", func() {
+			expected := providerConfig.ExtractFailureDomain()
+
+			Expect(expected).To(Equal(v1.VSphereFailureDomain{}))
+		})
+	})
 })


### PR DESCRIPTION
[OCPBUGS-31808](https://issues.redhat.com/browse/OCPBUGS-31808)

### Changes
- Added logic to handler older infrastructure definitions where platform spec is not present.