### PR TITLE
OCPBUGS-32295: Modified webhook to allow templates by name instead of just by path.

### DIFF
--- a/pkg/webhooks/controlplanemachineset/webhooks.go
+++ b/pkg/webhooks/controlplanemachineset/webhooks.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/go-logr/logr"
 	configv1 "github.com/openshift/api/config/v1"
@@ -439,12 +440,14 @@ func validateOpenShiftOpenStackProviderConfig(parentPath *field.Path, providerCo
 }
 
 // validateOpenShiftVSphereProviderConfig runs VSphere specific checks on the provider config on the ControlPlaneMachineSet.
-// This ensure that the ControlPlaneMachineSet can safely replace VSphere control plane machines.
+// This ensures that the ControlPlaneMachineSet can safely replace VSphere control plane machines.
 func validateOpenShiftVSphereProviderConfig(parentPath *field.Path, providerConfig providerconfig.VSphereProviderConfig) []error {
 	errs := []error{}
 
+	// Check template format.  If "/" found, assume it's a path based definition and verify with pattern.
+	// If not a path template, then assume just a template name (older ocp installs)
 	templatePath := providerConfig.Config().Template
-	if len(templatePath) > 0 {
+	if len(templatePath) > 0 && strings.Contains(templatePath, "/") {
 		matched, err := regexp.MatchString(vsphereTemplateValidationPattern, templatePath)
 		if err != nil {
 			errs = append(errs, field.InternalError(parentPath.Child("template"), fmt.Errorf("error checking the validity of the template path: %w", err)))


### PR DESCRIPTION
[OCPBUGS-32295](https://issues.redhat.com/browse/OCPBUGS-32295)

### Changes
- Modified webhook logic when validating CPMS changes to allow vSphere template to be non path formatted as well.