### PR TITLE
[Release 4.15] OCPBUGS-32357: Modified webhook to allow templates by name instead of just by path.

### DIFF
--- a/pkg/webhooks/controlplanemachineset/suite_test.go
+++ b/pkg/webhooks/controlplanemachineset/suite_test.go
@@ -29,8 +29,6 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	machinev1 "github.com/openshift/api/machine/v1"
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
-	configv1builder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/config/v1"
-
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -87,9 +85,6 @@ var _ = BeforeSuite(func() {
 	k8sClient, err = client.New(cfg, client.Options{Scheme: testScheme})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
-
-	infrastructure := configv1builder.Infrastructure().AsAWS("cluster", "us-east-1").WithName("cluster").Build()
-	Expect(k8sClient.Create(ctx, infrastructure)).To(Succeed())
 
 	// CEL requires Kube 1.25 and above, so check for the minimum server version.
 	discoveryClient, err := discovery.NewDiscoveryClientForConfig(cfg)


### PR DESCRIPTION
Cherry-Pick of https://github.com/openshift/cluster-control-plane-machine-set-operator/pull/288

### Changes
- Modified webhook logic when validating CPMS changes to allow vSphere template to be non path formatted as well.