### PR TITLE
[Release 4.15] OCPBUGS-32414: Fix ExportFailureDomain to handle empty platform spec

### DIFF
--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/vsphere.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/vsphere.go
@@ -117,6 +117,11 @@ func (v VSphereProviderConfig) ExtractFailureDomain() machinev1.VSphereFailureDo
 		return machinev1.VSphereFailureDomain{}
 	}
 
+	// Older OCP installs will not have PlatformSpec set for infrastructure.
+	if v.infrastructure.Spec.PlatformSpec.VSphere == nil {
+		return machinev1.VSphereFailureDomain{}
+	}
+
 	failureDomains := v.infrastructure.Spec.PlatformSpec.VSphere.FailureDomains
 
 	for _, failureDomain := range failureDomains {

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/vsphere_test.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/vsphere_test.go
@@ -181,4 +181,16 @@ var _ = Describe("VSphere Provider Config", Label("vSphereProviderConfig"), func
 			Expect(newProviderSpec.VSphere().providerConfig.Network.Devices[0].Nameservers).To(BeNil())
 		})
 	})
+
+	Context("no vsphere platform spec in infrastructure", func() {
+		BeforeEach(func() {
+			providerConfig.infrastructure.Spec.PlatformSpec.VSphere = nil
+		})
+
+		It("should should return empty failure domain", func() {
+			expected := providerConfig.ExtractFailureDomain()
+
+			Expect(expected).To(Equal(v1.VSphereFailureDomain{}))
+		})
+	})
 })

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -456,6 +456,10 @@ func convertVSphereProviderConfigToControlPlaneMachineSetProviderSpec(providerCo
 	vspherePs := providerConfig.VSphere().Config()
 	vspherePs.Name = ""
 
+	vspherePs.Workspace = &machinev1beta1.Workspace{}
+	vspherePs.Template = ""
+	vspherePs.Network = machinev1beta1.NetworkSpec{}
+
 	rawBytes, err := json.Marshal(vspherePs)
 	if err != nil {
 		return nil, fmt.Errorf("error marshalling vsphere providerSpec: %w", err)


### PR DESCRIPTION
Cherry-Pick of https://github.com/openshift/cluster-control-plane-machine-set-operator/pull/287

### Changes
- Added logic to handler older infrastructure definitions where platform spec is not present.