### PR TITLE
OCPBUGS-20061: Add unreadyNodeGracePeriod for allowing brief node hiccups

### DIFF
--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/provider_test.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/provider_test.go
@@ -18,6 +18,7 @@ package v1beta1
 
 import (
 	"fmt"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -1551,6 +1552,156 @@ var _ = Describe("MachineProvider", func() {
 							"machineName", masterMachineName("4"),
 							"nodeName", "node-4",
 							"index", int32(4),
+							"ready", true,
+							"needsUpdate", false,
+							"diff", nilDiff,
+							"errorMessage", "",
+						},
+						Message: "Gathered Machine Info",
+					},
+				},
+			}),
+			Entry("with ready Machines but one of them has the Node unready for less than unreadyNodeGracePeriod", getMachineInfosTableInput{
+				machines: []*machinev1beta1.Machine{
+					masterMachineBuilder.WithName(masterMachineName("0")).WithProviderSpecBuilder(providerSpecBuilder.WithAvailabilityZone("us-east-1a").WithSubnet(usEast1aSubnetbeta1)).
+						WithPhase("Running").WithNodeRef(corev1.ObjectReference{Name: "node-0"}).Build(),
+					masterMachineBuilder.WithName(masterMachineName("1")).WithProviderSpecBuilder(providerSpecBuilder.WithAvailabilityZone("us-east-1b").WithSubnet(usEast1bSubnetbeta1)).
+						WithPhase("Running").WithNodeRef(corev1.ObjectReference{Name: "node-1"}).Build(),
+					masterMachineBuilder.WithName(masterMachineName("2")).WithProviderSpecBuilder(providerSpecBuilder.WithAvailabilityZone("us-east-1c").WithSubnet(usEast1cSubnetbeta1)).
+						WithPhase("Running").WithNodeRef(corev1.ObjectReference{Name: "node-2"}).Build(),
+				},
+
+				nodes: []*corev1.Node{
+					masterNodeBuilder.WithName("node-0").WithConditions(
+						[]corev1.NodeCondition{
+							{
+								Type:               corev1.NodeReady,
+								Status:             corev1.ConditionFalse,
+								LastTransitionTime: metav1.NewTime(time.Now().Add(-(unreadyNodeGracePeriod / 2))),
+							},
+						},
+					).Build(),
+					masterNodeBuilder.WithName("node-1").Build(),
+					masterNodeBuilder.WithName("node-2").Build(),
+				},
+				failureDomains: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomain),
+					1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomain),
+					2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomain),
+				},
+				expectedMachineInfos: []machineproviders.MachineInfo{
+					readyMachineInfoBuilder.WithIndex(0).WithMachineName(masterMachineName("0")).WithNodeName("node-0").Build(),
+					readyMachineInfoBuilder.WithIndex(1).WithMachineName(masterMachineName("1")).WithNodeName("node-1").Build(),
+					readyMachineInfoBuilder.WithIndex(2).WithMachineName(masterMachineName("2")).WithNodeName("node-2").Build(),
+				},
+				expectedLogs: []testutils.LogEntry{
+					{
+						Level: 4,
+						KeysAndValues: []interface{}{
+							"machineName", masterMachineName("0"),
+							"nodeName", "node-0",
+							"index", int32(0),
+							"ready", true,
+							"needsUpdate", false,
+							"diff", nilDiff,
+							"errorMessage", "",
+						},
+						Message: "Gathered Machine Info",
+					},
+					{
+						Level: 4,
+						KeysAndValues: []interface{}{
+							"machineName", masterMachineName("1"),
+							"nodeName", "node-1",
+							"index", int32(1),
+							"ready", true,
+							"needsUpdate", false,
+							"diff", nilDiff,
+							"errorMessage", "",
+						},
+						Message: "Gathered Machine Info",
+					},
+					{
+						Level: 4,
+						KeysAndValues: []interface{}{
+							"machineName", masterMachineName("2"),
+							"nodeName", "node-2",
+							"index", int32(2),
+							"ready", true,
+							"needsUpdate", false,
+							"diff", nilDiff,
+							"errorMessage", "",
+						},
+						Message: "Gathered Machine Info",
+					},
+				},
+			}),
+			Entry("with ready Machines but one of them has the Node unready for more than unreadyNodeGracePeriod", getMachineInfosTableInput{
+				machines: []*machinev1beta1.Machine{
+					masterMachineBuilder.WithName(masterMachineName("0")).WithProviderSpecBuilder(providerSpecBuilder.WithAvailabilityZone("us-east-1a").WithSubnet(usEast1aSubnetbeta1)).
+						WithPhase("Running").WithNodeRef(corev1.ObjectReference{Name: "node-0"}).Build(),
+					masterMachineBuilder.WithName(masterMachineName("1")).WithProviderSpecBuilder(providerSpecBuilder.WithAvailabilityZone("us-east-1b").WithSubnet(usEast1bSubnetbeta1)).
+						WithPhase("Running").WithNodeRef(corev1.ObjectReference{Name: "node-1"}).Build(),
+					masterMachineBuilder.WithName(masterMachineName("2")).WithProviderSpecBuilder(providerSpecBuilder.WithAvailabilityZone("us-east-1c").WithSubnet(usEast1cSubnetbeta1)).
+						WithPhase("Running").WithNodeRef(corev1.ObjectReference{Name: "node-2"}).Build(),
+				},
+
+				nodes: []*corev1.Node{
+					masterNodeBuilder.WithName("node-0").WithConditions(
+						[]corev1.NodeCondition{
+							{
+								Type:               corev1.NodeReady,
+								Status:             corev1.ConditionFalse,
+								LastTransitionTime: metav1.NewTime(time.Now().Add(-(unreadyNodeGracePeriod + time.Minute*1))),
+							},
+						},
+					).Build(),
+					masterNodeBuilder.WithName("node-1").Build(),
+					masterNodeBuilder.WithName("node-2").Build(),
+				},
+				failureDomains: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(usEast1aFailureDomain),
+					1: failuredomain.NewAWSFailureDomain(usEast1bFailureDomain),
+					2: failuredomain.NewAWSFailureDomain(usEast1cFailureDomain),
+				},
+				expectedMachineInfos: []machineproviders.MachineInfo{
+					readyMachineInfoBuilder.WithIndex(0).WithMachineName(masterMachineName("0")).WithNodeName("node-0").WithReady(false).Build(),
+					readyMachineInfoBuilder.WithIndex(1).WithMachineName(masterMachineName("1")).WithNodeName("node-1").Build(),
+					readyMachineInfoBuilder.WithIndex(2).WithMachineName(masterMachineName("2")).WithNodeName("node-2").Build(),
+				},
+				expectedLogs: []testutils.LogEntry{
+					{
+						Level: 4,
+						KeysAndValues: []interface{}{
+							"machineName", masterMachineName("0"),
+							"nodeName", "node-0",
+							"index", int32(0),
+							"ready", false,
+							"needsUpdate", false,
+							"diff", nilDiff,
+							"errorMessage", "",
+						},
+						Message: "Gathered Machine Info",
+					},
+					{
+						Level: 4,
+						KeysAndValues: []interface{}{
+							"machineName", masterMachineName("1"),
+							"nodeName", "node-1",
+							"index", int32(1),
+							"ready", true,
+							"needsUpdate", false,
+							"diff", nilDiff,
+							"errorMessage", "",
+						},
+						Message: "Gathered Machine Info",
+					},
+					{
+						Level: 4,
+						KeysAndValues: []interface{}{
+							"machineName", masterMachineName("2"),
+							"nodeName", "node-2",
+							"index", int32(2),
 							"ready", true,
 							"needsUpdate", false,
 							"diff", nilDiff,


### PR DESCRIPTION
### What this does
unreadyNodeGracePeriod is the period in which the node is presumed being unready for a reboot (e.g. during upgrades) or a brief hiccup. This leaves some leeway to avoid immediately reacting on brief node unreadiness.

### Context
This strict node readiness checking behaviour was previously introduced when we dediced "machine's node must be ready for CPMS machine to be ready" by https://github.com/openshift/cluster-control-plane-machine-set-operator/pull/171 

### Testing the fix
How was this tested?
Through the launch of several aggregated payload jobs that perform upgrades.
I did run some before the fix ([1](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/aggregator-periodic-ci-openshift-release-master-ci-4.16-e2e-aws-ovn-upgrade/1788878968938565632)), and some with the fix ([2](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/aggregator-periodic-ci-openshift-release-master-ci-4.16-e2e-aws-ovn-upgrade/1798042764714184704)). Then checking in the Spyglass Intervals in the Prow Job run.

**Before the fix**:
The control-plane-machine-set-operator goes unavailable 3 times (red segments, first row), aligning with the timeline when the control plane nodes go NotReady due to the upgrade reboots (yellow segments (highlighted in organge), last row).
<img width="1635" alt="Screenshot 2024-06-05 at 09 17 01" src="https://github.com/openshift/cluster-control-plane-machine-set-operator/assets/4902157/75a10583-5bd9-4069-9e0d-89a17c197c10">

**After the fix**:
The control-plane-machine-set-operator doesn't go unavailable, even during the segments when the control plane nodes go NotReady due to the upgrade reboots (yellow segments (highlighted in organge), last row).
<img width="1665" alt="Screenshot 2024-06-05 at 09 16 05" src="https://github.com/openshift/cluster-control-plane-machine-set-operator/assets/4902157/bf252c5a-a8ae-42d3-8b5b-6123d9307f74">

