### PR TITLE
OCPBUGS-35069: Improved debugging of API listing errors

### DIFF
--- a/test/e2e/framework/utils.go
+++ b/test/e2e/framework/utils.go
@@ -93,7 +93,7 @@ func Async(wg *sync.WaitGroup, cancel context.CancelFunc, testFunc func() bool) 
 // The check and condition functions must use the passed Gomega for any assertions so that we can handle failures
 // within the functions appropriately.
 func RunCheckUntil(ctx context.Context, check, condition func(context.Context, GomegaAssertions) bool) bool {
-	return gomega.Eventually(func() error {
+	return gomega.EventuallyWithOffset(1, func() error {
 		checkErr := runAssertion(ctx, check)
 		conditionErr := runAssertion(ctx, condition)
 

--- a/test/e2e/helpers/machine.go
+++ b/test/e2e/helpers/machine.go
@@ -529,7 +529,8 @@ func sortMachinesByCreationTimeDescending(machines []machinev1beta1.Machine) []m
 func isRetryableAPIError(err error) bool {
 	// These errors may indicate a transient error that we can retry in tests.
 	if apierrs.IsInternalError(err) || apierrs.IsTimeout(err) || apierrs.IsServerTimeout(err) ||
-		apierrs.IsTooManyRequests(err) || utilnet.IsProbableEOF(err) || utilnet.IsConnectionReset(err) {
+		apierrs.IsTooManyRequests(err) || utilnet.IsProbableEOF(err) || utilnet.IsConnectionReset(err) ||
+		utilnet.IsHTTP2ConnectionLost(err) {
 		return true
 	}
 

--- a/test/e2e/helpers/machine.go
+++ b/test/e2e/helpers/machine.go
@@ -152,7 +152,7 @@ func EventuallyIndexIsBeingReplaced(ctx context.Context, testFramework framework
 			if err := k8sClient.List(ctx, list, controlPlaneMachineSelector); err != nil {
 				// For temporary errors in listing objects we don't want to break this check,
 				// so we return happy and retry at the next check.
-				return g.Expect(err).Should(WithTransform(isRetryableAPIError, BeTrue()))
+				return g.Expect(err).Should(WithTransform(isRetryableAPIError, BeTrue()), "expected temporary error while listing machines: %v", err)
 			}
 
 			return g.Expect(list).Should(
@@ -166,7 +166,7 @@ func EventuallyIndexIsBeingReplaced(ctx context.Context, testFramework framework
 			if err := k8sClient.List(ctx, list, controlPlaneMachineSelector); err != nil {
 				// For temporary errors in listing the objects we don't want to break the until condition,
 				// so we return false, which is the standard behaviour for this condition when things haven't settled yet.
-				return !g.Expect(err).Should(WithTransform(isRetryableAPIError, BeTrue()))
+				return !g.Expect(err).Should(WithTransform(isRetryableAPIError, BeTrue()), "expected temporary error while listing machines: %v", err)
 			}
 
 			return g.Expect(list).Should(
@@ -294,7 +294,7 @@ func waitForNewMachineRunning(ctx context.Context, testFramework framework.Frame
 			if err := k8sClient.List(ctx, machineList, machineSelector); err != nil {
 				// For temporary errors in listing objects we don't want to break this check,
 				// so we return happy and retry at the next check.
-				return g.Expect(err).Should(WithTransform(isRetryableAPIError, BeTrue()))
+				return g.Expect(err).Should(WithTransform(isRetryableAPIError, BeTrue()), "expected temporary error while listing machines: %v", err)
 			}
 
 			return g.Expect(machineList).Should(HaveField("Items", SatisfyAll(
@@ -318,7 +318,7 @@ func waitForNewMachineRunning(ctx context.Context, testFramework framework.Frame
 			if err := k8sClient.Get(ctx, machineKey, machine); err != nil {
 				// For temporary errors in getting the object we don't want to break the until condition,
 				// so we return false, which is the standard behaviour for this condition when things haven't settled yet.
-				return !g.Expect(err).Should(WithTransform(isRetryableAPIError, BeTrue()))
+				return !g.Expect(err).Should(WithTransform(isRetryableAPIError, BeTrue()), "expected temporary error while listing machines: %v", err)
 			}
 
 			return g.Expect(machine).Should(HaveField("Status.Phase", HaveValue(Equal("Running"))), "expected new machine to be running")


### PR DESCRIPTION
Digging into [this CI run](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-4.15-periodics-e2e-azure/1796537353917960192) it appears that a non-retryable API error caused the test to fail, when it probably should not have done.

It would be preferable to be able to see what error caused the check to fail, so I'm adding a format string which should print out any errors received.