### PR TITLE
[release-4.14] OCPBUGS-35338: Improved debugging of API listing errors

### DIFF
--- a/test/e2e/framework/utils.go
+++ b/test/e2e/framework/utils.go
@@ -93,7 +93,7 @@ func Async(wg *sync.WaitGroup, cancel context.CancelFunc, testFunc func() bool) 
 // The check and condition functions must use the passed Gomega for any assertions so that we can handle failures
 // within the functions appropriately.
 func RunCheckUntil(ctx context.Context, check, condition func(context.Context, GomegaAssertions) bool) bool {
-	return gomega.Eventually(func() error {
+	return gomega.EventuallyWithOffset(1, func() error {
 		checkErr := runAssertion(ctx, check)
 		conditionErr := runAssertion(ctx, condition)
 

--- a/test/e2e/helpers/machine.go
+++ b/test/e2e/helpers/machine.go
@@ -529,7 +529,8 @@ func sortMachinesByCreationTimeDescending(machines []machinev1beta1.Machine) []m
 func isRetryableAPIError(err error) bool {
 	// These errors may indicate a transient error that we can retry in tests.
 	if apierrs.IsInternalError(err) || apierrs.IsTimeout(err) || apierrs.IsServerTimeout(err) ||
-		apierrs.IsTooManyRequests(err) || utilnet.IsProbableEOF(err) || utilnet.IsConnectionReset(err) {
+		apierrs.IsTooManyRequests(err) || utilnet.IsProbableEOF(err) || utilnet.IsConnectionReset(err) ||
+		isHTTP2ConnectionLost(err) {
 		return true
 	}
 
@@ -539,4 +540,9 @@ func isRetryableAPIError(err error) bool {
 	}
 
 	return false
+}
+
+// Returns if the given err is "http2: client connection lost" error.
+func isHTTP2ConnectionLost(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "http2: client connection lost")
 }

--- a/test/e2e/helpers/machine.go
+++ b/test/e2e/helpers/machine.go
@@ -152,7 +152,7 @@ func EventuallyIndexIsBeingReplaced(ctx context.Context, testFramework framework
 			if err := k8sClient.List(ctx, list, controlPlaneMachineSelector); err != nil {
 				// For temporary errors in listing objects we don't want to break this check,
 				// so we return happy and retry at the next check.
-				return g.Expect(err).Should(WithTransform(isRetryableAPIError, BeTrue()))
+				return g.Expect(err).Should(WithTransform(isRetryableAPIError, BeTrue()), "expected temporary error while listing machines: %v", err)
 			}
 
 			return g.Expect(list).Should(
@@ -166,7 +166,7 @@ func EventuallyIndexIsBeingReplaced(ctx context.Context, testFramework framework
 			if err := k8sClient.List(ctx, list, controlPlaneMachineSelector); err != nil {
 				// For temporary errors in listing the objects we don't want to break the until condition,
 				// so we return false, which is the standard behaviour for this condition when things haven't settled yet.
-				return !g.Expect(err).Should(WithTransform(isRetryableAPIError, BeTrue()))
+				return !g.Expect(err).Should(WithTransform(isRetryableAPIError, BeTrue()), "expected temporary error while listing machines: %v", err)
 			}
 
 			return g.Expect(list).Should(
@@ -294,7 +294,7 @@ func waitForNewMachineRunning(ctx context.Context, testFramework framework.Frame
 			if err := k8sClient.List(ctx, machineList, machineSelector); err != nil {
 				// For temporary errors in listing objects we don't want to break this check,
 				// so we return happy and retry at the next check.
-				return g.Expect(err).Should(WithTransform(isRetryableAPIError, BeTrue()))
+				return g.Expect(err).Should(WithTransform(isRetryableAPIError, BeTrue()), "expected temporary error while listing machines: %v", err)
 			}
 
 			return g.Expect(machineList).Should(HaveField("Items", SatisfyAll(
@@ -318,7 +318,7 @@ func waitForNewMachineRunning(ctx context.Context, testFramework framework.Frame
 			if err := k8sClient.Get(ctx, machineKey, machine); err != nil {
 				// For temporary errors in getting the object we don't want to break the until condition,
 				// so we return false, which is the standard behaviour for this condition when things haven't settled yet.
-				return !g.Expect(err).Should(WithTransform(isRetryableAPIError, BeTrue()))
+				return !g.Expect(err).Should(WithTransform(isRetryableAPIError, BeTrue()), "expected temporary error while listing machines: %v", err)
 			}
 
 			return g.Expect(machine).Should(HaveField("Status.Phase", HaveValue(Equal("Running"))), "expected new machine to be running")


### PR DESCRIPTION
One of the utils doesn't exist in 4.14, so had to copy over the `isHTTP2ConnectionLost` helper.

Taking over from #302 