### PR TITLE
OCPBUGS-35416: Wait for ControlPlaneMachineSet to be created when waiting for it to be updated

### DIFF
--- a/test/e2e/helpers/controlplanemachineset.go
+++ b/test/e2e/helpers/controlplanemachineset.go
@@ -230,11 +230,10 @@ func EnsureControlPlaneMachineSetUpdated(testFramework framework.Framework) {
 
 	Expect(testFramework).ToNot(BeNil(), "test framework should not be nil")
 
-	k8sClient := testFramework.GetClient()
 	ctx := testFramework.GetContext()
 
-	cpms := &machinev1.ControlPlaneMachineSet{}
-	Expect(k8sClient.Get(testFramework.GetContext(), testFramework.ControlPlaneMachineSetKey(), cpms)).To(Succeed(), "control plane machine set should exist")
+	cpms := testFramework.NewEmptyControlPlaneMachineSet()
+	Eventually(komega.Get(cpms)).Should(Succeed(), "control plane machine set should exist")
 
 	WaitForControlPlaneMachineSetDesiredReplicas(ctx, cpms)
 }


### PR DESCRIPTION
Seeing this in presubmits sometimes. One of the tests using this helper expects the CPMS generator to regenerate the CPMS right at the end of the test, but we then immediately call `EnsureControlPlaneMachineSetUpdated` which expects the CPMS to exist.

In the right conditions, this second helper can catch the generator mid way between delete and create as it regenerates, and that causes the test to fail with a not found error.

This should help to prevent that.