### PR TITLE
OCPBUGS-38641: Add 1 minute stabilisation for clusteroperators after rollout

### DIFF
--- a/pkg/controllers/controlplanemachineset/controller_test.go
+++ b/pkg/controllers/controlplanemachineset/controller_test.go
@@ -1129,6 +1129,7 @@ var _ = Describe("With a running controller", func() {
 
 				testOptions.RolloutTimeout = 10 * time.Second
 				testOptions.StabilisationTimeout = 1 * time.Second
+				testOptions.StabilisationMinimumAvailability = 2 * time.Second
 			})
 
 			helpers.ItShouldPerformARollingUpdate(&testOptions)

--- a/pkg/controllers/controlplanemachineset/controller_test.go
+++ b/pkg/controllers/controlplanemachineset/controller_test.go
@@ -1129,7 +1129,7 @@ var _ = Describe("With a running controller", func() {
 
 				testOptions.RolloutTimeout = 10 * time.Second
 				testOptions.StabilisationTimeout = 1 * time.Second
-				testOptions.StabilisationMinimumAvailability = 2 * time.Second
+				testOptions.StabilisationMinimumAvailability = 500 * time.Millisecond
 			})
 
 			helpers.ItShouldPerformARollingUpdate(&testOptions)

--- a/test/e2e/helpers/cases.go
+++ b/test/e2e/helpers/cases.go
@@ -258,7 +258,7 @@ func ItShouldUninstallTheControlPlaneMachineSet(testFramework framework.Framewor
 		ExpectControlPlaneMachinesAllRunning(testFramework)
 		ExpectControlPlaneMachinesNotOwned(testFramework)
 		ExpectControlPlaneMachinesWithoutDeletionTimestamp(testFramework)
-		EventuallyClusterOperatorsShouldStabilise(1 * time.Minute)
+		EventuallyClusterOperatorsShouldStabilise(1*time.Minute, 2*time.Minute, 10*time.Second)
 	})
 }
 
@@ -314,7 +314,7 @@ func ItShouldNotCauseARollout(testFramework framework.Framework) {
 		), "control plane machine set replicas should consisently be up to date")
 
 		// Check that the operators are stable.
-		EventuallyClusterOperatorsShouldStabilise(1 * time.Minute)
+		EventuallyClusterOperatorsShouldStabilise(1*time.Minute, 2*time.Minute, 10*time.Second)
 	})
 }
 
@@ -330,7 +330,7 @@ func ItShouldCheckAllControlPlaneMachinesHaveCorrectOwnerReferences(testFramewor
 		ConsistentlyControlPlaneMachinesWithoutDeletionTimestamp(testFramework)
 
 		// Check that the operators are stable.
-		EventuallyClusterOperatorsShouldStabilise(1 * time.Minute)
+		EventuallyClusterOperatorsShouldStabilise(1*time.Minute, 2*time.Minute, 10*time.Second)
 	})
 }
 

--- a/test/e2e/helpers/cases.go
+++ b/test/e2e/helpers/cases.go
@@ -43,9 +43,10 @@ func ItShouldHaveAnActiveControlPlaneMachineSet(testFramework framework.Framewor
 
 // RollingUpdatePeriodicTestOptions allow the test cases to be configured.
 type RollingUpdatePeriodicTestOptions struct {
-	TestFramework        framework.Framework
-	RolloutTimeout       time.Duration
-	StabilisationTimeout time.Duration
+	TestFramework                    framework.Framework
+	RolloutTimeout                   time.Duration
+	StabilisationTimeout             time.Duration
+	StabilisationMinimumAvailability time.Duration
 }
 
 // ControlPlaneMachineSetRegenerationTestOptions allow test cases to be configured.
@@ -112,7 +113,12 @@ func ItShouldPerformARollingUpdate(opts *RollingUpdatePeriodicTestOptions) {
 
 		stabilisationInterval := stabilisationTimeout / 50
 
-		EventuallyClusterOperatorsShouldStabilise(stabilisationTimeout, stabilisationInterval)
+		stabilisationMinimumAvailability := time.Minute
+		if opts.StabilisationMinimumAvailability != 0 {
+			stabilisationMinimumAvailability = opts.StabilisationMinimumAvailability
+		}
+
+		EventuallyClusterOperatorsShouldStabilise(stabilisationMinimumAvailability, stabilisationTimeout, stabilisationInterval)
 		By("Cluster stabilised after the rollout")
 	})
 }
@@ -167,7 +173,7 @@ func ItShouldRollingUpdateReplaceTheOutdatedMachine(testFramework framework.Fram
 		By("Control plane machine rollout completed successfully")
 
 		By("Waiting for the cluster to stabilise after the rollout")
-		EventuallyClusterOperatorsShouldStabilise(30*time.Minute, 30*time.Second)
+		EventuallyClusterOperatorsShouldStabilise(1*time.Minute, 30*time.Minute, 30*time.Second)
 		By("Cluster stabilised after the rollout")
 	})
 }
@@ -239,7 +245,7 @@ func ItShouldOnDeleteReplaceTheOutDatedMachineWhenDeleted(testFramework framewor
 		By("Control plane machine rollout completed successfully")
 
 		By("Waiting for the cluster to stabilise after the rollout")
-		EventuallyClusterOperatorsShouldStabilise(20*time.Minute, 20*time.Second)
+		EventuallyClusterOperatorsShouldStabilise(1*time.Minute, 20*time.Minute, 20*time.Second)
 		By("Cluster stabilised after the rollout")
 	})
 }
@@ -252,7 +258,7 @@ func ItShouldUninstallTheControlPlaneMachineSet(testFramework framework.Framewor
 		ExpectControlPlaneMachinesAllRunning(testFramework)
 		ExpectControlPlaneMachinesNotOwned(testFramework)
 		ExpectControlPlaneMachinesWithoutDeletionTimestamp(testFramework)
-		EventuallyClusterOperatorsShouldStabilise()
+		EventuallyClusterOperatorsShouldStabilise(1 * time.Minute)
 	})
 }
 
@@ -308,7 +314,7 @@ func ItShouldNotCauseARollout(testFramework framework.Framework) {
 		), "control plane machine set replicas should consisently be up to date")
 
 		// Check that the operators are stable.
-		EventuallyClusterOperatorsShouldStabilise()
+		EventuallyClusterOperatorsShouldStabilise(1 * time.Minute)
 	})
 }
 
@@ -324,7 +330,7 @@ func ItShouldCheckAllControlPlaneMachinesHaveCorrectOwnerReferences(testFramewor
 		ConsistentlyControlPlaneMachinesWithoutDeletionTimestamp(testFramework)
 
 		// Check that the operators are stable.
-		EventuallyClusterOperatorsShouldStabilise()
+		EventuallyClusterOperatorsShouldStabilise(1 * time.Minute)
 	})
 }
 

--- a/test/e2e/helpers/clusteroperators.go
+++ b/test/e2e/helpers/clusteroperators.go
@@ -30,7 +30,7 @@ import (
 
 // EventuallyClusterOperatorsShouldStabilise checks that the cluster operators stabilise over time.
 // Stabilise means that they are available, are not progressing, and are not degraded.
-func EventuallyClusterOperatorsShouldStabilise(minimumAvailability time.Duration, gomegaArgs ...interface{}) {
+func EventuallyClusterOperatorsShouldStabilise(minimumAvailability, timeout, interval time.Duration) {
 	key := format.RegisterCustomFormatter(formatClusterOperatorsCondtions)
 	defer format.UnregisterCustomFormatter(key)
 
@@ -39,9 +39,9 @@ func EventuallyClusterOperatorsShouldStabilise(minimumAvailability time.Duration
 	// that contain elements that are both "Type" something and "Status" something.
 	clusterOperators := &configv1.ClusterOperatorList{}
 
-	By("Waiting for the cluster operators to stabilise (minimum availability time: " + minimumAvailability.String() + ", timeout: " + gomegaArgs[0].(time.Duration).String() + ", polling interval: " + gomegaArgs[1].(time.Duration).String() + ")")
+	By("Waiting for the cluster operators to stabilise (minimum availability time: " + minimumAvailability.String() + ", timeout: " + timeout.String() + ", polling interval: " + interval.String() + ")")
 
-	Eventually(komega.ObjectList(clusterOperators), gomegaArgs...).Should(HaveField("Items", HaveEach(HaveField("Status.Conditions",
+	Eventually(komega.ObjectList(clusterOperators), timeout, interval).Should(HaveField("Items", HaveEach(HaveField("Status.Conditions",
 		SatisfyAll(
 			ContainElement(
 				And(

--- a/test/e2e/periodic_test.go
+++ b/test/e2e/periodic_test.go
@@ -27,7 +27,7 @@ import (
 
 var _ = Describe("ControlPlaneMachineSet Operator", framework.Periodic(), func() {
 	BeforeEach(func() {
-		helpers.EventuallyClusterOperatorsShouldStabilise(10*time.Minute, 10*time.Second)
+		helpers.EventuallyClusterOperatorsShouldStabilise(1*time.Minute, 10*time.Minute, 10*time.Second)
 	})
 
 	Context("With an active ControlPlaneMachineSet", func() {

--- a/test/e2e/presubmit_test.go
+++ b/test/e2e/presubmit_test.go
@@ -31,7 +31,7 @@ import (
 
 var _ = Describe("ControlPlaneMachineSet Operator", framework.PreSubmit(), func() {
 	BeforeEach(func() {
-		helpers.EventuallyClusterOperatorsShouldStabilise(10*time.Minute, 10*time.Second)
+		helpers.EventuallyClusterOperatorsShouldStabilise(1*time.Minute, 10*time.Minute, 10*time.Second)
 	}, OncePerOrdered)
 
 	Context("With an active ControlPlaneMachineSet", func() {


### PR DESCRIPTION
In recent runs, we are seeing the etcd operator rolls out a new revision immediately after the test completes. This isn't what we intend, but, it doesn't appear that there's a bug in the logic, since the etcd operator eventually stabilises and as does the cluster.

This change is an attempt to make sure that the cluster catches these rollouts, by waiting at least one minute after the last transition of any cluster operator before declaring that the cluster is stable

/hold for testing