### PR TITLE
OAPE-19: Support customized control plane machine names with prefix

### DIFF
--- a/cmd/control-plane-machine-set-operator/main.go
+++ b/cmd/control-plane-machine-set-operator/main.go
@@ -189,10 +189,11 @@ func main() { //nolint:funlen,cyclop
 	}
 
 	if err := (&cpmscontroller.ControlPlaneMachineSetReconciler{
-		UncachedClient: client.NewNamespacedClient(uncachedClient, managedNamespace),
-		Namespace:      managedNamespace,
-		OperatorName:   "control-plane-machine-set",
-		ReleaseVersion: util.GetReleaseVersion(),
+		UncachedClient:      client.NewNamespacedClient(uncachedClient, managedNamespace),
+		Namespace:           managedNamespace,
+		OperatorName:        "control-plane-machine-set",
+		ReleaseVersion:      util.GetReleaseVersion(),
+		FeatureGateAccessor: featureGateAccessor,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ControlPlaneMachineSet")
 		os.Exit(1)

--- a/pkg/controllers/controlplanemachineset/cluster_operator_test.go
+++ b/pkg/controllers/controlplanemachineset/cluster_operator_test.go
@@ -30,7 +30,6 @@ import (
 	corev1resourcebuilder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/core/v1"
 	machinev1resourcebuilder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/machine/v1"
 	metav1resourcebuilder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/meta/v1"
-	"github.com/openshift/cluster-control-plane-machine-set-operator/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -92,16 +91,11 @@ var _ = Describe("Cluster Operator Status with a running controller", func() {
 		})
 		Expect(err).ToNot(HaveOccurred(), "Manager should be able to be created")
 
-		By("Setting up a featureGateAccessor")
-		featureGateAccessor, err := util.SetupFeatureGateAccessor(mgr)
-		Expect(err).ToNot(HaveOccurred(), "Feature gate accessor should be created")
-
 		reconciler := &ControlPlaneMachineSetReconciler{
-			Client:              k8sClient,
-			UncachedClient:      k8sClient,
-			Namespace:           namespaceName,
-			OperatorName:        operatorName,
-			FeatureGateAccessor: featureGateAccessor,
+			Client:         k8sClient,
+			UncachedClient: k8sClient,
+			Namespace:      namespaceName,
+			OperatorName:   operatorName,
 		}
 		Expect(reconciler.SetupWithManager(mgr)).To(Succeed(), "Reconciler should be able to setup with manager")
 

--- a/pkg/controllers/controlplanemachineset/cluster_operator_test.go
+++ b/pkg/controllers/controlplanemachineset/cluster_operator_test.go
@@ -30,6 +30,7 @@ import (
 	corev1resourcebuilder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/core/v1"
 	machinev1resourcebuilder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/machine/v1"
 	metav1resourcebuilder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/meta/v1"
+	"github.com/openshift/cluster-control-plane-machine-set-operator/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -91,11 +92,16 @@ var _ = Describe("Cluster Operator Status with a running controller", func() {
 		})
 		Expect(err).ToNot(HaveOccurred(), "Manager should be able to be created")
 
+		By("Setting up a featureGateAccessor")
+		featureGateAccessor, err := util.SetupFeatureGateAccessor(mgr)
+		Expect(err).ToNot(HaveOccurred(), "Feature gate accessor should be created")
+
 		reconciler := &ControlPlaneMachineSetReconciler{
-			Client:         k8sClient,
-			UncachedClient: k8sClient,
-			Namespace:      namespaceName,
-			OperatorName:   operatorName,
+			Client:              k8sClient,
+			UncachedClient:      k8sClient,
+			Namespace:           namespaceName,
+			OperatorName:        operatorName,
+			FeatureGateAccessor: featureGateAccessor,
 		}
 		Expect(reconciler.SetupWithManager(mgr)).To(Succeed(), "Reconciler should be able to setup with manager")
 

--- a/pkg/controllers/controlplanemachineset/controller_test.go
+++ b/pkg/controllers/controlplanemachineset/controller_test.go
@@ -35,6 +35,7 @@ import (
 	metav1resourcebuilder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/meta/v1"
 	"github.com/openshift/cluster-control-plane-machine-set-operator/pkg/machineproviders"
 	machineprovidersresourcebuilder "github.com/openshift/cluster-control-plane-machine-set-operator/pkg/test/resourcebuilder/machineproviders"
+	"github.com/openshift/cluster-control-plane-machine-set-operator/pkg/util"
 	"github.com/openshift/cluster-control-plane-machine-set-operator/test/e2e/framework"
 	"github.com/openshift/cluster-control-plane-machine-set-operator/test/e2e/helpers"
 	"github.com/openshift/cluster-control-plane-machine-set-operator/test/integration"
@@ -182,11 +183,16 @@ var _ = Describe("With a running controller", func() {
 		})
 		Expect(err).ToNot(HaveOccurred(), "Manager should be able to be created")
 
+		By("Setting up a featureGateAccessor")
+		featureGateAccessor, err := util.SetupFeatureGateAccessor(mgr)
+		Expect(err).ToNot(HaveOccurred(), "Feature gate accessor should be created")
+
 		reconciler := &ControlPlaneMachineSetReconciler{
-			Client:         mgr.GetClient(),
-			UncachedClient: mgr.GetClient(),
-			Namespace:      namespaceName,
-			OperatorName:   operatorName,
+			Client:              mgr.GetClient(),
+			UncachedClient:      mgr.GetClient(),
+			Namespace:           namespaceName,
+			OperatorName:        operatorName,
+			FeatureGateAccessor: featureGateAccessor,
 		}
 		Expect(reconciler.SetupWithManager(mgr)).To(Succeed(), "Reconciler should be able to setup with manager")
 

--- a/pkg/controllers/controlplanemachineset/controller_test.go
+++ b/pkg/controllers/controlplanemachineset/controller_test.go
@@ -54,18 +54,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
-var _ = Describe("With a running controller", func() {
-	var mgrCancel context.CancelFunc
-	var mgrDone chan struct{}
-	var mgr ctrl.Manager
+const (
+	operatorName = "control-plane-machine-set"
+)
 
-	var namespaceName string
-
-	const operatorName = "control-plane-machine-set"
-
-	var co *configv1.ClusterOperator
-
-	usEast1aSubnet := machinev1beta1.AWSResourceReference{
+var (
+	usEast1aSubnet = machinev1beta1.AWSResourceReference{
 		Filters: []machinev1beta1.Filter{
 			{
 				Name: "tag:Name",
@@ -76,7 +70,7 @@ var _ = Describe("With a running controller", func() {
 		},
 	}
 
-	usEast1bSubnet := machinev1beta1.AWSResourceReference{
+	usEast1bSubnet = machinev1beta1.AWSResourceReference{
 		Filters: []machinev1beta1.Filter{
 			{
 				Name: "tag:Name",
@@ -87,7 +81,7 @@ var _ = Describe("With a running controller", func() {
 		},
 	}
 
-	usEast1cSubnet := machinev1beta1.AWSResourceReference{
+	usEast1cSubnet = machinev1beta1.AWSResourceReference{
 		Filters: []machinev1beta1.Filter{
 			{
 				Name: "tag:Name",
@@ -98,21 +92,21 @@ var _ = Describe("With a running controller", func() {
 		},
 	}
 
-	usEast1aProviderSpecBuilder := machinev1beta1resourcebuilder.AWSProviderSpec().
-		WithAvailabilityZone("us-east-1a").
-		WithSubnet(usEast1aSubnet)
+	usEast1aProviderSpecBuilder = machinev1beta1resourcebuilder.AWSProviderSpec().
+					WithAvailabilityZone("us-east-1a").
+					WithSubnet(usEast1aSubnet)
 
-	usEast1bProviderSpecBuilder := machinev1beta1resourcebuilder.AWSProviderSpec().
-		WithAvailabilityZone("us-east-1b").
-		WithSubnet(usEast1bSubnet)
+	usEast1bProviderSpecBuilder = machinev1beta1resourcebuilder.AWSProviderSpec().
+					WithAvailabilityZone("us-east-1b").
+					WithSubnet(usEast1bSubnet)
 
-	usEast1cProviderSpecBuilder := machinev1beta1resourcebuilder.AWSProviderSpec().
-		WithAvailabilityZone("us-east-1c").
-		WithSubnet(usEast1cSubnet)
+	usEast1cProviderSpecBuilder = machinev1beta1resourcebuilder.AWSProviderSpec().
+					WithAvailabilityZone("us-east-1c").
+					WithSubnet(usEast1cSubnet)
 
-	usEast1aFailureDomainBuilder := machinev1resourcebuilder.AWSFailureDomain().
-		WithAvailabilityZone("us-east-1a").
-		WithSubnet(machinev1.AWSResourceReference{
+	usEast1aFailureDomainBuilder = machinev1resourcebuilder.AWSFailureDomain().
+					WithAvailabilityZone("us-east-1a").
+					WithSubnet(machinev1.AWSResourceReference{
 			Type: machinev1.AWSFiltersReferenceType,
 			Filters: &[]machinev1.AWSResourceFilter{
 				{
@@ -122,9 +116,9 @@ var _ = Describe("With a running controller", func() {
 			},
 		})
 
-	usEast1bFailureDomainBuilder := machinev1resourcebuilder.AWSFailureDomain().
-		WithAvailabilityZone("us-east-1b").
-		WithSubnet(machinev1.AWSResourceReference{
+	usEast1bFailureDomainBuilder = machinev1resourcebuilder.AWSFailureDomain().
+					WithAvailabilityZone("us-east-1b").
+					WithSubnet(machinev1.AWSResourceReference{
 			Type: machinev1.AWSFiltersReferenceType,
 			Filters: &[]machinev1.AWSResourceFilter{
 				{
@@ -134,9 +128,9 @@ var _ = Describe("With a running controller", func() {
 			},
 		})
 
-	usEast1cFailureDomainBuilder := machinev1resourcebuilder.AWSFailureDomain().
-		WithAvailabilityZone("us-east-1c").
-		WithSubnet(machinev1.AWSResourceReference{
+	usEast1cFailureDomainBuilder = machinev1resourcebuilder.AWSFailureDomain().
+					WithAvailabilityZone("us-east-1c").
+					WithSubnet(machinev1.AWSResourceReference{
 			Type: machinev1.AWSFiltersReferenceType,
 			Filters: &[]machinev1.AWSResourceFilter{
 				{
@@ -146,18 +140,28 @@ var _ = Describe("With a running controller", func() {
 			},
 		})
 
-	tmplBuilder := machinev1resourcebuilder.OpenShiftMachineV1Beta1Template().
-		WithFailureDomainsBuilder(machinev1resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
+	tmplBuilder = machinev1resourcebuilder.OpenShiftMachineV1Beta1Template().
+			WithFailureDomainsBuilder(machinev1resourcebuilder.AWSFailureDomains().WithFailureDomainBuilders(
 			usEast1aFailureDomainBuilder,
 			usEast1bFailureDomainBuilder,
 			usEast1cFailureDomainBuilder,
 		)).
 		WithProviderSpecBuilder(machinev1beta1resourcebuilder.AWSProviderSpec())
 
-	masterNodeBuilder := corev1resourcebuilder.Node().AsMaster()
+	masterNodeBuilder = corev1resourcebuilder.Node().AsMaster()
 
 	// Running phase for setting machines to running.
-	running := "Running"
+	running = "Running"
+)
+
+var _ = Describe("With a running controller", func() {
+	var mgrCancel, fgCancel context.CancelFunc
+	var mgrDone, fgDone chan struct{}
+	var mgr ctrl.Manager
+
+	var namespaceName string
+
+	var co *configv1.ClusterOperator
 
 	BeforeEach(func() {
 		By("Setting up a namespace for the test")
@@ -184,7 +188,21 @@ var _ = Describe("With a running controller", func() {
 		Expect(err).ToNot(HaveOccurred(), "Manager should be able to be created")
 
 		By("Setting up a featureGateAccessor")
-		featureGateAccessor, err := util.SetupFeatureGateAccessor(mgr)
+		var fgCtx context.Context
+		fgCtx, fgCancel = context.WithCancel(context.Background())
+		fgDone = make(chan struct{})
+
+		createFeatureGate(
+			releaseVersion,
+			[]configv1.FeatureGateAttributes{ // enabled
+				{
+					Name: "CPMSMachineNamePrefix",
+				},
+			},
+			[]configv1.FeatureGateAttributes{}, // disabled
+		)
+
+		featureGateAccessor, err := util.SetupFeatureGateAccessor(fgCtx, mgr)
 		Expect(err).ToNot(HaveOccurred(), "Feature gate accessor should be created")
 
 		reconciler := &ControlPlaneMachineSetReconciler{
@@ -204,6 +222,7 @@ var _ = Describe("With a running controller", func() {
 		go func() {
 			defer GinkgoRecover()
 			defer close(mgrDone)
+			defer close(fgDone)
 
 			Expect(mgr.Start(mgrCtx)).To(Succeed())
 		}()
@@ -218,6 +237,13 @@ var _ = Describe("With a running controller", func() {
 		mgrCancel()
 		// Wait for the mgrDone to be closed, which will happen once the mgr has stopped
 		<-mgrDone
+
+		By("Stopping the featureGateAccessor")
+		fgCancel()
+		<-fgDone
+
+		// Remove Featuregate
+		testutils.CleanupResources(Default, ctx, cfg, k8sClient, "", &configv1.FeatureGate{})
 
 		testutils.CleanupResources(Default, ctx, cfg, k8sClient, namespaceName,
 			&corev1.Node{},
@@ -1420,6 +1446,490 @@ var _ = Describe("With a running controller", func() {
 				HaveEach(HaveField("ObjectMeta.OwnerReferences", HaveLen(0))),
 			)), "each machine should have no owner references")
 		})
+	})
+})
+
+var _ = Describe("With a running controller and machine name prefix", func() {
+
+	Context("When CPMSMachineNamePrefix feature gate is disabled", func() {
+
+		var mgrCancel, fgCancel context.CancelFunc
+		var mgrDone, fgDone chan struct{}
+		var mgr ctrl.Manager
+
+		var namespaceName string
+
+		var co *configv1.ClusterOperator
+
+		BeforeEach(func() {
+			By("Setting up a namespace for the test")
+			ns := corev1resourcebuilder.Namespace().WithGenerateName("control-plane-machine-set-controller-").Build()
+			Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+			namespaceName = ns.GetName()
+
+			By("Setting up a manager and controller")
+			var err error
+			mgr, err = ctrl.NewManager(cfg, ctrl.Options{
+				Scheme: testScheme,
+				Metrics: server.Options{
+					BindAddress: "0",
+				},
+				WebhookServer: webhook.NewServer(webhook.Options{
+					Port:    testEnv.WebhookInstallOptions.LocalServingPort,
+					Host:    testEnv.WebhookInstallOptions.LocalServingHost,
+					CertDir: testEnv.WebhookInstallOptions.LocalServingCertDir,
+				}),
+				Controller: config.Controller{
+					SkipNameValidation: ptr.To(true),
+				},
+			})
+			Expect(err).ToNot(HaveOccurred(), "Manager should be able to be created")
+
+			By("Setting up a featureGateAccessor")
+			var fgCtx context.Context
+			fgCtx, fgCancel = context.WithCancel(context.Background())
+			fgDone = make(chan struct{})
+
+			createFeatureGate(releaseVersion,
+				[]configv1.FeatureGateAttributes{}, // enabled
+
+				[]configv1.FeatureGateAttributes{ // disabled
+					{
+						Name: "CPMSMachineNamePrefix",
+					},
+				},
+			)
+
+			featureGateAccessor, err := util.SetupFeatureGateAccessor(fgCtx, mgr)
+			Expect(err).ToNot(HaveOccurred(), "Feature gate accessor should be created")
+
+			reconciler := &ControlPlaneMachineSetReconciler{
+				Client:              mgr.GetClient(),
+				UncachedClient:      mgr.GetClient(),
+				Namespace:           namespaceName,
+				OperatorName:        operatorName,
+				FeatureGateAccessor: featureGateAccessor,
+			}
+			Expect(reconciler.SetupWithManager(mgr)).To(Succeed(), "Reconciler should be able to setup with manager")
+
+			By("Starting the manager")
+			var mgrCtx context.Context
+			mgrCtx, mgrCancel = context.WithCancel(context.Background())
+			mgrDone = make(chan struct{})
+
+			go func() {
+				defer GinkgoRecover()
+				defer close(mgrDone)
+				defer close(fgDone)
+
+				Expect(mgr.Start(mgrCtx)).To(Succeed())
+			}()
+
+			// CVO will create a blank cluster operator for us before the operator starts.
+			co = configv1resourcebuilder.ClusterOperator().WithName(operatorName).Build()
+			Expect(k8sClient.Create(ctx, co)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			By("Stopping the manager")
+			mgrCancel()
+			// Wait for the mgrDone to be closed, which will happen once the mgr has stopped
+			<-mgrDone
+
+			By("Stopping the featureGateAccessor")
+			fgCancel()
+			<-fgDone
+
+			// Remove Featuregate
+			testutils.CleanupResources(Default, ctx, cfg, k8sClient, "", &configv1.FeatureGate{})
+
+			testutils.CleanupResources(Default, ctx, cfg, k8sClient, namespaceName,
+				&corev1.Node{},
+				&configv1.ClusterOperator{},
+				&machinev1beta1.Machine{},
+				&machinev1.ControlPlaneMachineSet{},
+			)
+		})
+
+		Context("when Control Plane Machine Set is updated to set MachineNamePrefix", func() {
+			var cpms *machinev1.ControlPlaneMachineSet
+			testOptions := helpers.RollingUpdatePeriodicTestOptions{}
+			prefix := "control-plane-prefix"
+
+			BeforeEach(func() {
+				By("Creating Machines owned by the ControlPlaneMachineSet")
+				machineBuilder := machinev1beta1resourcebuilder.Machine().AsMaster().WithNamespace(namespaceName)
+
+				machines := map[int]machinev1beta1resourcebuilder.MachineBuilder{
+					0: machineBuilder.WithProviderSpecBuilder(usEast1aProviderSpecBuilder),
+					1: machineBuilder.WithProviderSpecBuilder(usEast1bProviderSpecBuilder),
+					2: machineBuilder.WithProviderSpecBuilder(usEast1cProviderSpecBuilder),
+				}
+
+				for i := range machines {
+					nodeName := fmt.Sprintf("node-%d", i)
+					machineName := fmt.Sprintf("master-%d", i)
+
+					machine := machines[i].WithName(machineName).Build()
+
+					Expect(k8sClient.Create(ctx, machine)).To(Succeed())
+					Expect(k8sClient.Create(ctx, masterNodeBuilder.WithName(nodeName).AsReady().Build())).To(Succeed())
+
+					Eventually(komega.UpdateStatus(machine, func() {
+						machine.Status.NodeRef = &corev1.ObjectReference{Name: nodeName}
+					})).Should(Succeed())
+				}
+
+				By("Registering the integration machine manager")
+
+				// The machine manager is a dummy implementation that moves machines from zero, through the expected
+				// phases and then eventually to the Running phase.
+				// This allows the CPMS to react to the changes in the machine status and run through its own logic.
+				// We use it here so that we can simulate a full rolling replacement of the control plane which needs
+				// machines to be able to move through the phases to the Running phase.
+
+				machineManager := integration.NewIntegrationMachineManager(integration.MachineManagerOptions{
+					ActionDelay: 500 * time.Millisecond,
+				})
+				Expect(machineManager.SetupWithManager(mgr)).To(Succeed())
+
+				// Wait for the machines to all report running before creating the CPMS.
+				By("Waiting for the machines to become ready")
+				Eventually(komega.ObjectList(&machinev1beta1.MachineList{}), 2*time.Second).Should(HaveField("Items", HaveEach(
+					HaveField("Status.Phase", HaveValue(Equal("Running"))),
+				)))
+
+				// The default CPMS should be sufficient for this test.
+				By("Creating the ControlPlaneMachineSet")
+				cpms = machinev1resourcebuilder.ControlPlaneMachineSet().WithNamespace(namespaceName).WithMachineTemplateBuilder(tmplBuilder).Build()
+				Expect(k8sClient.Create(ctx, cpms)).Should(Succeed())
+
+				By("Waiting for the ControlPlaneMachineSet to report a stable status")
+				Eventually(komega.Object(cpms)).Should(HaveField("Status", SatisfyAll(
+					HaveField("ObservedGeneration", Equal(int64(1))),
+					HaveField("Replicas", Equal(int32(3))),
+					HaveField("UpdatedReplicas", Equal(int32(3))),
+					HaveField("ReadyReplicas", Equal(int32(3))),
+					HaveField("UnavailableReplicas", Equal(int32(0))),
+				)))
+			})
+
+			// Update the CPMS to set MachineNamePrefix
+			JustBeforeEach(func() {
+				// The CPMS is configured for AWS so use the AWS Platform Type.
+				testFramework := framework.NewFrameworkWith(testScheme, k8sClient, configv1.AWSPlatformType, framework.Full, namespaceName)
+
+				helpers.UpdateControlPlaneMachineSetMachineNamePrefix(testFramework, prefix, 10*time.Second, 1*time.Second)
+
+				testOptions.TestFramework = testFramework
+
+				testOptions.RolloutTimeout = 10 * time.Second
+				testOptions.StabilisationTimeout = 1 * time.Second
+				testOptions.StabilisationMinimumAvailability = 500 * time.Millisecond
+			})
+
+			It("should keep the machine names unchanged consistently", func() {
+				machineList := &machinev1beta1.MachineList{}
+				Consistently(komega.ObjectList(machineList, client.InNamespace(namespaceName))).Should(HaveField("Items",
+					SatisfyAll(
+						ContainElement(HaveField("ObjectMeta.Name", Equal("master-0"))),
+						ContainElement(HaveField("ObjectMeta.Name", Equal("master-1"))),
+						ContainElement(HaveField("ObjectMeta.Name", Equal("master-2"))),
+					),
+				))
+			})
+
+			It("should keep the status unchanged consistently", func() {
+				Consistently(komega.Object(cpms)).Should(HaveField("Status", SatisfyAll(
+					HaveField("Replicas", Equal(int32(3))),
+					HaveField("ReadyReplicas", Equal(int32(3))),
+					HaveField("UpdatedReplicas", Equal(int32(3))),
+					HaveField("UnavailableReplicas", Equal(int32(0))),
+				)))
+			})
+
+			Context("and the instance size is changed", func() {
+				JustBeforeEach(func() {
+					helpers.IncreaseControlPlaneMachineSetInstanceSize(testOptions.TestFramework, 10*time.Second, 1*time.Second)
+				})
+
+				helpers.ItShouldPerformARollingUpdate(&testOptions)
+
+				It("should not create machines with prefixed name consistently", func() {
+					nameMatcherWithPrefix := MatchRegexp(fmt.Sprintf("%s-[a-z0-9]{5}-\\d", prefix))
+
+					machineList := &machinev1beta1.MachineList{}
+
+					Consistently(komega.ObjectList(machineList, client.InNamespace(namespaceName))).Should(HaveField("Items",
+						SatisfyAll(
+							Not(ContainElement(HaveField("ObjectMeta.Name", nameMatcherWithPrefix))),
+							Not(ContainElement(HaveField("ObjectMeta.Name", nameMatcherWithPrefix))),
+							Not(ContainElement(HaveField("ObjectMeta.Name", nameMatcherWithPrefix))),
+						),
+					))
+				})
+			})
+		})
+	})
+
+	Context("When CPMSMachineNamePrefix feature gate is enabled", func() {
+
+		var mgrCancel, fgCancel context.CancelFunc
+		var mgrDone, fgDone chan struct{}
+		var mgr ctrl.Manager
+
+		var namespaceName string
+
+		var co *configv1.ClusterOperator
+
+		BeforeEach(func() {
+			By("Setting up a namespace for the test")
+			ns := corev1resourcebuilder.Namespace().WithGenerateName("control-plane-machine-set-controller-").Build()
+			Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+			namespaceName = ns.GetName()
+
+			By("Setting up a manager and controller")
+			var err error
+			mgr, err = ctrl.NewManager(cfg, ctrl.Options{
+				Scheme: testScheme,
+				Metrics: server.Options{
+					BindAddress: "0",
+				},
+				WebhookServer: webhook.NewServer(webhook.Options{
+					Port:    testEnv.WebhookInstallOptions.LocalServingPort,
+					Host:    testEnv.WebhookInstallOptions.LocalServingHost,
+					CertDir: testEnv.WebhookInstallOptions.LocalServingCertDir,
+				}),
+				Controller: config.Controller{
+					SkipNameValidation: ptr.To(true),
+				},
+			})
+			Expect(err).ToNot(HaveOccurred(), "Manager should be able to be created")
+
+			By("Setting up a featureGateAccessor")
+			var fgCtx context.Context
+			fgCtx, fgCancel = context.WithCancel(context.Background())
+			fgDone = make(chan struct{})
+
+			createFeatureGate(releaseVersion,
+				[]configv1.FeatureGateAttributes{ // enabled
+					{
+						Name: "CPMSMachineNamePrefix",
+					},
+				},
+				[]configv1.FeatureGateAttributes{}, // disabled
+			)
+
+			featureGateAccessor, err := util.SetupFeatureGateAccessor(fgCtx, mgr)
+			Expect(err).ToNot(HaveOccurred(), "Feature gate accessor should be created")
+
+			reconciler := &ControlPlaneMachineSetReconciler{
+				Client:              mgr.GetClient(),
+				UncachedClient:      mgr.GetClient(),
+				Namespace:           namespaceName,
+				OperatorName:        operatorName,
+				FeatureGateAccessor: featureGateAccessor,
+			}
+			Expect(reconciler.SetupWithManager(mgr)).To(Succeed(), "Reconciler should be able to setup with manager")
+
+			By("Starting the manager")
+			var mgrCtx context.Context
+			mgrCtx, mgrCancel = context.WithCancel(context.Background())
+			mgrDone = make(chan struct{})
+
+			go func() {
+				defer GinkgoRecover()
+				defer close(mgrDone)
+				defer close(fgDone)
+
+				Expect(mgr.Start(mgrCtx)).To(Succeed())
+			}()
+
+			// CVO will create a blank cluster operator for us before the operator starts.
+			co = configv1resourcebuilder.ClusterOperator().WithName(operatorName).Build()
+			Expect(k8sClient.Create(ctx, co)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			By("Stopping the manager")
+			mgrCancel()
+			// Wait for the mgrDone to be closed, which will happen once the mgr has stopped
+			<-mgrDone
+
+			By("Stopping the featureGateAccessor")
+			fgCancel()
+			<-fgDone
+
+			// Remove Featuregate
+			testutils.CleanupResources(Default, ctx, cfg, k8sClient, "", &configv1.FeatureGate{})
+
+			testutils.CleanupResources(Default, ctx, cfg, k8sClient, namespaceName,
+				&corev1.Node{},
+				&configv1.ClusterOperator{},
+				&machinev1beta1.Machine{},
+				&machinev1.ControlPlaneMachineSet{},
+			)
+		})
+
+		Context("when Control Plane Machine Set is updated to set MachineNamePrefix", func() {
+			var cpms *machinev1.ControlPlaneMachineSet
+			testOptions := helpers.RollingUpdatePeriodicTestOptions{}
+			prefix := "control-plane-prefix"
+
+			BeforeEach(func() {
+				By("Creating Machines owned by the ControlPlaneMachineSet")
+				machineBuilder := machinev1beta1resourcebuilder.Machine().AsMaster().WithNamespace(namespaceName)
+
+				machines := map[int]machinev1beta1resourcebuilder.MachineBuilder{
+					0: machineBuilder.WithProviderSpecBuilder(usEast1aProviderSpecBuilder),
+					1: machineBuilder.WithProviderSpecBuilder(usEast1bProviderSpecBuilder),
+					2: machineBuilder.WithProviderSpecBuilder(usEast1cProviderSpecBuilder),
+				}
+
+				for i := range machines {
+					nodeName := fmt.Sprintf("node-%d", i)
+					machineName := fmt.Sprintf("master-%d", i)
+
+					machine := machines[i].WithName(machineName).Build()
+
+					Expect(k8sClient.Create(ctx, machine)).To(Succeed())
+					Expect(k8sClient.Create(ctx, masterNodeBuilder.WithName(nodeName).AsReady().Build())).To(Succeed())
+
+					Eventually(komega.UpdateStatus(machine, func() {
+						machine.Status.NodeRef = &corev1.ObjectReference{Name: nodeName}
+					})).Should(Succeed())
+				}
+
+				By("Registering the integration machine manager")
+
+				// The machine manager is a dummy implementation that moves machines from zero, through the expected
+				// phases and then eventually to the Running phase.
+				// This allows the CPMS to react to the changes in the machine status and run through its own logic.
+				// We use it here so that we can simulate a full rolling replacement of the control plane which needs
+				// machines to be able to move through the phases to the Running phase.
+
+				machineManager := integration.NewIntegrationMachineManager(integration.MachineManagerOptions{
+					ActionDelay: 500 * time.Millisecond,
+				})
+				Expect(machineManager.SetupWithManager(mgr)).To(Succeed())
+
+				// Wait for the machines to all report running before creating the CPMS.
+				By("Waiting for the machines to become ready")
+				Eventually(komega.ObjectList(&machinev1beta1.MachineList{}), 2*time.Second).Should(HaveField("Items", HaveEach(
+					HaveField("Status.Phase", HaveValue(Equal("Running"))),
+				)))
+
+				// The default CPMS should be sufficient for this test.
+				By("Creating the ControlPlaneMachineSet")
+				cpms = machinev1resourcebuilder.ControlPlaneMachineSet().WithNamespace(namespaceName).WithMachineTemplateBuilder(tmplBuilder).Build()
+				Expect(k8sClient.Create(ctx, cpms)).Should(Succeed())
+
+				By("Waiting for the ControlPlaneMachineSet to report a stable status")
+				Eventually(komega.Object(cpms)).Should(HaveField("Status", SatisfyAll(
+					HaveField("ObservedGeneration", Equal(int64(1))),
+					HaveField("Replicas", Equal(int32(3))),
+					HaveField("UpdatedReplicas", Equal(int32(3))),
+					HaveField("ReadyReplicas", Equal(int32(3))),
+					HaveField("UnavailableReplicas", Equal(int32(0))),
+				)))
+			})
+
+			// Update the CPMS to set MachineNamePrefix
+			JustBeforeEach(func() {
+				// The CPMS is configured for AWS so use the AWS Platform Type.
+				testFramework := framework.NewFrameworkWith(testScheme, k8sClient, configv1.AWSPlatformType, framework.Full, namespaceName)
+
+				helpers.UpdateControlPlaneMachineSetMachineNamePrefix(testFramework, prefix, 10*time.Second, 1*time.Second)
+
+				testOptions.TestFramework = testFramework
+
+				testOptions.RolloutTimeout = 10 * time.Second
+				testOptions.StabilisationTimeout = 1 * time.Second
+				testOptions.StabilisationMinimumAvailability = 500 * time.Millisecond
+			})
+
+			It("machine name should remain unchanged consistently", func() {
+				machineList := &machinev1beta1.MachineList{}
+				Consistently(komega.ObjectList(machineList, client.InNamespace(namespaceName))).Should(HaveField("Items",
+					SatisfyAll(
+						ContainElement(HaveField("ObjectMeta.Name", Equal("master-0"))),
+						ContainElement(HaveField("ObjectMeta.Name", Equal("master-1"))),
+						ContainElement(HaveField("ObjectMeta.Name", Equal("master-2"))),
+					),
+				))
+			})
+
+			It("should keep the status unchanged consistently", func() {
+				Consistently(komega.Object(cpms)).Should(HaveField("Status", SatisfyAll(
+					HaveField("Replicas", Equal(int32(3))),
+					HaveField("ReadyReplicas", Equal(int32(3))),
+					HaveField("UpdatedReplicas", Equal(int32(3))),
+					HaveField("UnavailableReplicas", Equal(int32(0))),
+				)))
+			})
+
+			Context("and the instance size is changed", func() {
+				JustBeforeEach(func() {
+					helpers.IncreaseControlPlaneMachineSetInstanceSize(testOptions.TestFramework, 10*time.Second, 1*time.Second)
+				})
+
+				helpers.ItShouldPerformARollingUpdate(&testOptions)
+
+				It("creates machines only with prefixed name", func() {
+					nameMatcherWithPrefix := MatchRegexp(fmt.Sprintf("%s-[a-z0-9]{5}-\\d", prefix))
+
+					machineList := &machinev1beta1.MachineList{}
+
+					Eventually(komega.ObjectList(machineList, client.InNamespace(namespaceName))).Should(HaveField("Items", HaveLen(3))) // Should have 3 machines
+
+					Eventually(komega.ObjectList(machineList, client.InNamespace(namespaceName))).Should(HaveField("Items",
+						SatisfyAll(
+							ContainElement(HaveField("ObjectMeta.Name", nameMatcherWithPrefix)),
+							ContainElement(HaveField("ObjectMeta.Name", nameMatcherWithPrefix)),
+							ContainElement(HaveField("ObjectMeta.Name", nameMatcherWithPrefix)),
+						),
+					))
+				})
+			})
+
+			Context("and a machine is deleted", func() {
+				index := 1
+
+				JustBeforeEach(func() {
+					machine := &machinev1beta1.Machine{}
+					machineName := fmt.Sprintf("master-%d", index)
+					machineKey := client.ObjectKey{Namespace: namespaceName, Name: machineName}
+
+					By(fmt.Sprintf("Deleting machine in index %d", index))
+
+					Expect(k8sClient.Get(ctx, machineKey, machine)).To(Succeed())
+					Expect(k8sClient.Delete(ctx, machine)).Should(Succeed())
+				})
+
+				It("should create a replacement machine for the correct index", func() {
+					helpers.EventuallyIndexIsBeingReplaced(ctx, testOptions.TestFramework, index)
+				})
+
+				It("should only name the replacement machine with prefix", func() {
+					nameMatcherWithPrefix := MatchRegexp(fmt.Sprintf("%s-[a-z0-9]{5}-%d", prefix, index)) // For the prefixed machine
+
+					nameWithoutPrefix1 := "master-0" // Index 0 should follow old name
+					nameWithoutPrefix2 := "master-2" // Index 2 should follow old name
+
+					machineList := &machinev1beta1.MachineList{}
+					Eventually(komega.ObjectList(machineList, client.InNamespace(namespaceName))).Should(HaveField("Items", HaveLen(3))) // Should have 3 machines
+
+					Eventually(komega.ObjectList(machineList, client.InNamespace(namespaceName))).Should(HaveField("Items",
+						SatisfyAll(
+							ContainElement(HaveField("ObjectMeta.Name", nameMatcherWithPrefix)),
+							ContainElement(HaveField("ObjectMeta.Name", Equal(nameWithoutPrefix1))),
+							ContainElement(HaveField("ObjectMeta.Name", Equal(nameWithoutPrefix2))),
+						),
+					))
+				})
+			})
+		})
+
 	})
 })
 

--- a/pkg/controllers/controlplanemachinesetgenerator/controller_test.go
+++ b/pkg/controllers/controlplanemachinesetgenerator/controller_test.go
@@ -424,7 +424,7 @@ var _ = Describe("controlplanemachinesetgenerator controller on AWS", func() {
 		mgr, err = ctrl.NewManager(cfg, managerOptions)
 		Expect(err).ToNot(HaveOccurred(), "Manager should be able to be created")
 
-		featureGateAccessor, err := util.SetupFeatureGateAccessor(mgr)
+		featureGateAccessor, err := util.SetupFeatureGateAccessor(ctx, mgr)
 		Expect(err).ToNot(HaveOccurred(), "Feature gate accessor should be created")
 
 		reconciler = &ControlPlaneMachineSetGeneratorReconciler{
@@ -1004,7 +1004,7 @@ var _ = Describe("controlplanemachinesetgenerator controller on Azure", func() {
 		mgr, err = ctrl.NewManager(cfg, managerOptions)
 		Expect(err).ToNot(HaveOccurred(), "Manager should be able to be created")
 
-		featureGateAccessor, err := util.SetupFeatureGateAccessor(mgr)
+		featureGateAccessor, err := util.SetupFeatureGateAccessor(ctx, mgr)
 		Expect(err).ToNot(HaveOccurred(), "Feature gate accessor should be created")
 
 		reconciler = &ControlPlaneMachineSetGeneratorReconciler{
@@ -1590,7 +1590,7 @@ var _ = Describe("controlplanemachinesetgenerator controller on GCP", func() {
 		mgr, err = ctrl.NewManager(cfg, managerOptions)
 		Expect(err).ToNot(HaveOccurred(), "Manager should be able to be created")
 
-		featureGateAccessor, err := util.SetupFeatureGateAccessor(mgr)
+		featureGateAccessor, err := util.SetupFeatureGateAccessor(ctx, mgr)
 		Expect(err).ToNot(HaveOccurred(), "Feature gate accessor should be created")
 
 		reconciler = &ControlPlaneMachineSetGeneratorReconciler{
@@ -2131,7 +2131,7 @@ var _ = Describe("controlplanemachinesetgenerator controller on Nutanix", func()
 		mgr, err = ctrl.NewManager(cfg, managerOptions)
 		Expect(err).ToNot(HaveOccurred(), "Manager should be able to be created")
 
-		featureGateAccessor, err := util.SetupFeatureGateAccessor(mgr)
+		featureGateAccessor, err := util.SetupFeatureGateAccessor(ctx, mgr)
 		Expect(err).ToNot(HaveOccurred(), "Feature gate accessor should be created")
 
 		reconciler = &ControlPlaneMachineSetGeneratorReconciler{
@@ -2666,7 +2666,7 @@ var _ = Describe("controlplanemachinesetgenerator controller on OpenStack", func
 		mgr, err = ctrl.NewManager(cfg, managerOptions)
 		Expect(err).ToNot(HaveOccurred(), "Manager should be able to be created")
 
-		featureGateAccessor, err := util.SetupFeatureGateAccessor(mgr)
+		featureGateAccessor, err := util.SetupFeatureGateAccessor(ctx, mgr)
 		Expect(err).ToNot(HaveOccurred(), "Feature gate accessor should be created")
 
 		reconciler = &ControlPlaneMachineSetGeneratorReconciler{

--- a/pkg/machineproviders/providers/machineproviders.go
+++ b/pkg/machineproviders/providers/machineproviders.go
@@ -38,12 +38,21 @@ var (
 	errUnexpectedMachineType = errors.New("unexpected value for spec.template.machineType")
 )
 
+// MachineProviderOptions holds configuration options for the machine provider.
+type MachineProviderOptions struct {
+	// AllowMachineNamePrefix option is set when the CPMSMachineNamePrefix
+	// feature gate is enabled.
+	AllowMachineNamePrefix bool
+}
+
 // NewMachineProvider constructs a MachineProvider based on the machine type passed.
 // This can then be used to access and manipulate machines within the cluster.
-func NewMachineProvider(ctx context.Context, logger logr.Logger, cl client.Client, recorder record.EventRecorder, cpms *machinev1.ControlPlaneMachineSet) (machineproviders.MachineProvider, error) {
+func NewMachineProvider(ctx context.Context, logger logr.Logger, cl client.Client, recorder record.EventRecorder, cpms *machinev1.ControlPlaneMachineSet, opts MachineProviderOptions) (machineproviders.MachineProvider, error) {
 	switch cpms.Spec.Template.MachineType {
 	case machinev1.OpenShiftMachineV1Beta1MachineType:
-		provider, err := openshiftmachinev1beta1.NewMachineProvider(ctx, logger, cl, recorder, cpms)
+		provider, err := openshiftmachinev1beta1.NewMachineProvider(ctx, logger, cl, recorder, cpms, openshiftmachinev1beta1.OpenshiftMachineProviderOptions{
+			AllowMachineNamePrefix: opts.AllowMachineNamePrefix,
+		})
 		if err != nil {
 			return nil, fmt.Errorf("error constructing %s machine provider: %w", machinev1.OpenShiftMachineV1Beta1MachineType, err)
 		}

--- a/pkg/machineproviders/providers/machineproviders_test.go
+++ b/pkg/machineproviders/providers/machineproviders_test.go
@@ -205,6 +205,7 @@ var _ = Describe("MachineProviders", func() {
 
 			BeforeEach(func() {
 				cpms := cpmsBuilder.Build()
+				cpms.Spec.MachineNamePrefix = "machine-prefix"
 				opts.AllowMachineNamePrefix = true
 
 				provider, err = NewMachineProvider(ctx, logger.Logger(), k8sClient, recorder, cpms, opts)
@@ -347,8 +348,10 @@ var _ = Describe("MachineProviders", func() {
 				var err error
 
 				BeforeEach(func() {
+					cpms := cpmsBuilder.Build()
+					cpms.Spec.MachineNamePrefix = "machine-prefix"
 					opts.AllowMachineNamePrefix = true
-					provider, err = NewMachineProvider(ctx, logger.Logger(), k8sClient, recorder, cpmsBuilder.Build(), opts)
+					provider, err = NewMachineProvider(ctx, logger.Logger(), k8sClient, recorder, cpms, opts)
 				})
 
 				It("does not error", func() {

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/provider_test.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/provider_test.go
@@ -1937,8 +1937,17 @@ var _ = Describe("MachineProvider", func() {
 						nameMatcher := MatchRegexp(fmt.Sprintf("%s-[a-z0-9]{5}-%d", machinePrefix, 0))
 
 						machineList := &machinev1beta1.MachineList{}
-						Eventually(komega.ObjectList(machineList, client.InNamespace(namespaceName))).Should(HaveField("Items",
+						Consistently(komega.ObjectList(machineList, client.InNamespace(namespaceName))).Should(HaveField("Items",
 							Not(ContainElement(HaveField("ObjectMeta.Name", nameMatcher)))))
+					})
+
+					It("rather creates machine with normal format", func() {
+						nameMatcher := MatchRegexp(fmt.Sprintf("%s-master-[a-z0-9]{5}-%d", "cpms-aws-cluster-id", 0))
+
+						machineList := &machinev1beta1.MachineList{}
+						Eventually(komega.ObjectList(machineList, client.InNamespace(namespaceName))).Should(HaveField("Items", ContainElement(
+							HaveField("ObjectMeta.Name", nameMatcher),
+						)))
 					})
 				})
 			})

--- a/pkg/util/feature_gate.go
+++ b/pkg/util/feature_gate.go
@@ -52,7 +52,7 @@ func GetReleaseVersion() string {
 }
 
 // SetupFeatureGateAccessor Setup FeatureGateAccess instance.
-func SetupFeatureGateAccessor(mgr manager.Manager) (featuregates.FeatureGateAccess, error) {
+func SetupFeatureGateAccessor(ctx context.Context, mgr manager.Manager) (featuregates.FeatureGateAccess, error) {
 	desiredVersion := GetReleaseVersion()
 	missingVersion := "0.0.1-snapshot"
 
@@ -70,8 +70,8 @@ func SetupFeatureGateAccessor(mgr manager.Manager) (featuregates.FeatureGateAcce
 		configInformers.Config().V1().FeatureGates(),
 		events.NewLoggingEventRecorder("controlplanemachineset"),
 	)
-	go featureGateAccessor.Run(context.Background())
-	go configInformers.Start(context.Background().Done())
+	go featureGateAccessor.Run(ctx)
+	go configInformers.Start(ctx.Done())
 
 	select {
 	case <-featureGateAccessor.InitialFeatureGatesObserved():

--- a/test/e2e/helpers/controlplanemachineset.go
+++ b/test/e2e/helpers/controlplanemachineset.go
@@ -383,3 +383,18 @@ func UpdateControlPlaneMachineSetProviderSpec(testFramework framework.Framework,
 		cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec.ProviderSpec = updatedProviderSpec
 	}), gomegaArgs...).Should(Succeed(), "control plane machine should be able to be updated")
 }
+
+// UpdateControlPlaneMachineSetMachineNamePrefix updates the machine name prefix of the control plane machine set to match the machineNamePrefix given.
+func UpdateControlPlaneMachineSetMachineNamePrefix(testFramework framework.Framework, machineNamePrefix string, gomegaArgs ...interface{}) {
+	By("Updating the machine name prefix of the control plane machine set")
+
+	Expect(testFramework).ToNot(BeNil(), "test framework should not be nil")
+
+	cpms := testFramework.NewEmptyControlPlaneMachineSet()
+
+	Eventually(komega.Get(cpms), gomegaArgs...).Should(Succeed(), "control plane machine set should exist")
+
+	Eventually(komega.Update(cpms, func() {
+		cpms.Spec.MachineNamePrefix = machineNamePrefix
+	}), gomegaArgs...).Should(Succeed(), "control plane machine should be able to be updated")
+}

--- a/test/e2e/helpers/feature_gate.go
+++ b/test/e2e/helpers/feature_gate.go
@@ -1,0 +1,74 @@
+package helpers
+
+import (
+	"context"
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/cluster-control-plane-machine-set-operator/test/e2e/framework"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+type featureGateFilter struct {
+	enabled  sets.String
+	disabled sets.String
+}
+
+func newFeatureGateFilter(ctx context.Context, testFramework framework.Framework) (*featureGateFilter, error) {
+	k8sClient := testFramework.GetClient()
+
+	featureGate := &configv1.FeatureGate{}
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: "cluster"}, featureGate); err != nil {
+		return nil, err
+	}
+	clusterVersion := &configv1.ClusterVersion{}
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: "version"}, clusterVersion); err != nil {
+		return nil, err
+	}
+
+	desiredVersion := clusterVersion.Status.Desired.Version
+	if len(desiredVersion) == 0 && len(clusterVersion.Status.History) > 0 {
+		desiredVersion = clusterVersion.Status.History[0].Version
+	}
+
+	ret := &featureGateFilter{
+		enabled:  sets.NewString(),
+		disabled: sets.NewString(),
+	}
+	found := false
+	for _, featureGateValues := range featureGate.Status.FeatureGates {
+		if featureGateValues.Version != desiredVersion {
+			continue
+		}
+		found = true
+		for _, enabled := range featureGateValues.Enabled {
+			ret.enabled.Insert(string(enabled.Name))
+		}
+		for _, disabled := range featureGateValues.Disabled {
+			ret.disabled.Insert(string(disabled.Name))
+		}
+		break
+	}
+	if !found {
+		return nil, fmt.Errorf("no featuregates found")
+	}
+
+	return ret, nil
+}
+
+func (f *featureGateFilter) isEnabled(featureGateName string) bool {
+	if f.enabled.Has(featureGateName) {
+		return true
+	}
+
+	if f.disabled.Has(featureGateName) {
+		return false
+	}
+
+	panic(fmt.Errorf("feature %q is not registered in FeatureGates %v", featureGateName, f.knownFeatures()))
+}
+
+func (f *featureGateFilter) knownFeatures() sets.String {
+	return f.enabled.Clone().Union(f.disabled)
+}

--- a/test/e2e/helpers/feature_gate.go
+++ b/test/e2e/helpers/feature_gate.go
@@ -1,7 +1,24 @@
+/*
+Copyright 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package helpers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -10,21 +27,28 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
+var (
+	errNoFeatureGatesFound  = errors.New("no featuregates found")
+	errFeatureNotRegistered = errors.New("feature is not registered in FeatureGates")
+)
+
 type featureGateFilter struct {
-	enabled  sets.String
-	disabled sets.String
+	enabled  sets.Set[string]
+	disabled sets.Set[string]
 }
 
-func newFeatureGateFilter(ctx context.Context, testFramework framework.Framework) (*featureGateFilter, error) {
+// NewFeatureGateFilter creates a new featureGateFilter from the cluster's FeatureGate.
+func NewFeatureGateFilter(ctx context.Context, testFramework framework.Framework) (*featureGateFilter, error) {
 	k8sClient := testFramework.GetClient()
 
 	featureGate := &configv1.FeatureGate{}
 	if err := k8sClient.Get(ctx, types.NamespacedName{Name: "cluster"}, featureGate); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get featuregate: %w", err)
 	}
+
 	clusterVersion := &configv1.ClusterVersion{}
 	if err := k8sClient.Get(ctx, types.NamespacedName{Name: "version"}, clusterVersion); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get clusterversion: %w", err)
 	}
 
 	desiredVersion := clusterVersion.Status.Desired.Version
@@ -33,31 +57,38 @@ func newFeatureGateFilter(ctx context.Context, testFramework framework.Framework
 	}
 
 	ret := &featureGateFilter{
-		enabled:  sets.NewString(),
-		disabled: sets.NewString(),
+		enabled:  sets.New[string](),
+		disabled: sets.New[string](),
 	}
 	found := false
+
 	for _, featureGateValues := range featureGate.Status.FeatureGates {
 		if featureGateValues.Version != desiredVersion {
 			continue
 		}
+
 		found = true
+
 		for _, enabled := range featureGateValues.Enabled {
 			ret.enabled.Insert(string(enabled.Name))
 		}
+
 		for _, disabled := range featureGateValues.Disabled {
 			ret.disabled.Insert(string(disabled.Name))
 		}
+
 		break
 	}
+
 	if !found {
-		return nil, fmt.Errorf("no featuregates found")
+		return nil, errNoFeatureGatesFound
 	}
 
 	return ret, nil
 }
 
-func (f *featureGateFilter) isEnabled(featureGateName string) bool {
+// IsEnabled checks if the given feature gate is enabled on the current cluster.
+func (f *featureGateFilter) IsEnabled(featureGateName string) bool {
 	if f.enabled.Has(featureGateName) {
 		return true
 	}
@@ -66,9 +97,9 @@ func (f *featureGateFilter) isEnabled(featureGateName string) bool {
 		return false
 	}
 
-	panic(fmt.Errorf("feature %q is not registered in FeatureGates %v", featureGateName, f.knownFeatures()))
+	panic(fmt.Errorf("feature %q: %w %v", featureGateName, errFeatureNotRegistered, f.knownFeatures()))
 }
 
-func (f *featureGateFilter) knownFeatures() sets.String {
+func (f *featureGateFilter) knownFeatures() sets.Set[string] {
 	return f.enabled.Clone().Union(f.disabled)
 }

--- a/test/e2e/helpers/machine.go
+++ b/test/e2e/helpers/machine.go
@@ -71,7 +71,7 @@ func CheckControlPlaneMachineRollingReplacement(testFramework framework.Framewor
 	cpms := &machinev1.ControlPlaneMachineSet{}
 	Expect(k8sClient.Get(ctx, testFramework.ControlPlaneMachineSetKey(), cpms)).To(Succeed(), "control plane machine set should exist")
 
-	currentFeatureGates, err := newFeatureGateFilter(ctx, testFramework)
+	currentFeatureGates, err := NewFeatureGateFilter(ctx, testFramework)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(currentFeatureGates).NotTo(BeNil())
 
@@ -120,7 +120,7 @@ func CheckControlPlaneMachineOnDeleteReplacement(testFramework framework.Framewo
 	cpms := &machinev1.ControlPlaneMachineSet{}
 	Expect(k8sClient.Get(ctx, testFramework.ControlPlaneMachineSetKey(), cpms)).To(Succeed(), "control plane machine set should exist")
 
-	currentFeatureGates, err := newFeatureGateFilter(ctx, testFramework)
+	currentFeatureGates, err := NewFeatureGateFilter(ctx, testFramework)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(currentFeatureGates).NotTo(BeNil())
 
@@ -292,7 +292,7 @@ func checkReplacementMachineName(machine *machinev1beta1.Machine, cpms *machinev
 
 	// If CPMSMachineNamePrefix featuregate is enabled and MachineNamePrefix is set,
 	// the replacement machine should follow prefixed naming convention.
-	allowMachineNamePrefix := fg.isEnabled(string(features.FeatureGateCPMSMachineNamePrefix))
+	allowMachineNamePrefix := fg.IsEnabled(string(features.FeatureGateCPMSMachineNamePrefix))
 	machineNamePrefix := cpms.Spec.MachineNamePrefix
 
 	if allowMachineNamePrefix && len(machineNamePrefix) > 0 {


### PR DESCRIPTION
This PR introduces the ability to customize the naming format of Control Plane Machines. This is achieved through a new `machineNamePrefix` field in the ControlPlaneMachineSet spec, gated behind the `CPMSMachineNamePrefix` feature gate.

When feature gate is enabled and `machineNamePrefix` field is specified, it allows users to specify a prefix that will be used in `getMachineName`. The resulting machine name will consist of the provided prefix, followed by a randomly generated string of 5 characters and the machine index.

Otherwise, it will fall back to the default naming convention.

- Implementes : https://github.com/openshift/enhancements/pull/1714
- API PR: https://github.com/openshift/api/pull/2086
- Part of: [OAPE-19](https://issues.redhat.com//browse/OAPE-19)

