### PR TITLE
NO-JIRA: Update support matrix

### DIFF
--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -88,14 +88,15 @@ Please ensure that you have 3 (or 5) control plane machines before creating the 
 The control plane machine set is currently supported for a number of platforms and OpenShift versions.
 The matrix shows in detail the support for each specific combination.
 
-| Platform \ OpenShift version |      <=4.11    |      4.12           |      4.13           |      4.14           |      4.15           |
-|------------------------------|:---------------|:--------------------|:--------------------|:--------------------|:--------------------|
-| AWS                          |  Not Supported | Full                | Full                | Full                | Full                |
-| Azure                        |  Not Supported | Manual              | Full                | Full                | Full                |
-| GCP                          |  Not Supported | Not Supported       | Full                | Full                | Full                |
-| OpenStack                    |  Not Supported | Not Supported       | Not Supported       | Full                | Full                |
-| VSphere                      |  Not Supported | Manual (Single Zone)| Manual (Single Zone)| Manual (Single Zone)| Manual, Full (Tech preview) |
-| Other Platforms              |  Not Supported | Not Supported       | Not Supported       | Not Supported       | Not Supported       |
+| Platform \ OpenShift version |      <=4.11    |      4.12           |      4.13           |      4.14           |      4.15                   | 4.16+               |
+|------------------------------|:---------------|:--------------------|:--------------------|:--------------------|:----------------------------|:--------------------|
+| AWS                          |  Not Supported | Full                | Full                | Full                | Full                        | Full                |
+| Azure                        |  Not Supported | Manual              | Full                | Full                | Full                        | Full                |
+| GCP                          |  Not Supported | Not Supported       | Full                | Full                | Full                        | Full                |
+| OpenStack                    |  Not Supported | Not Supported       | Not Supported       | Full                | Full                        | Full                |
+| VSphere                      |  Not Supported | Manual (Single Zone)| Manual (Single Zone)| Manual (Single Zone)| Manual, Full (Tech preview) | Full                |
+| Nutanix                      |  Not Supported | Not Supported       | Not Supported       | Manual (Single Zone)| Full                        | Full                |
+| Other Platforms              |  Not Supported | Not Supported       | Not Supported       | Not Supported       | Not Supported               | Not Supported       |
 
 #### Keys
 

--- a/pkg/controllers/controlplanemachinesetgenerator/controller.go
+++ b/pkg/controllers/controlplanemachinesetgenerator/controller.go
@@ -59,7 +59,6 @@ const (
 const (
 	unsupportedNumberOfControlPlaneMachines     = "Unable to generate control plane machine set, unsupported number of control plane machines"
 	unsupportedPlatform                         = "Unable to generate control plane machine set, unsupported platform"
-	notEnabledPlatformVSphere                   = "Unable to generate control plane machine set, vSphere is tech preview. may be enabled with VSphereControlPlaneMachineSet feature gate"
 	controlPlaneMachineSetNotFound              = "Control plane machine set not found"
 	controlPlaneMachineSetUpToDate              = "Control plane machine set is up to date"
 	controlPlaneMachineSetOutdated              = "Control plane machine set is outdated"


### PR DESCRIPTION
Update support matrix to include up to date information about providers support.

Nutanix:
- added https://github.com/openshift/cluster-control-plane-machine-set-operator/pull/200/files
- FDs support added: https://github.com/openshift/cluster-control-plane-machine-set-operator/pull/258

VSphere:
- FDs support GAed: https://github.com/openshift/api/pull/1733/