### PR TITLE
[release-4.13] OCPBUGS-48259: Add unreadyNodeGracePeriod for allowing brief node hiccups

### DIFF
--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/provider.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/provider.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/go-logr/logr"
 	machinev1 "github.com/openshift/api/machine/v1"
@@ -52,6 +53,11 @@ const (
 	// openshiftMachineRoleLabel is the OpenShift Machine API machine role label.
 	// This must be present on all OpenShift Machine API Machine templates.
 	openshiftMachineRoleLabel = "machine.openshift.io/cluster-api-machine-role"
+
+	// unreadyNodeGracePeriod is the period in which
+	// the node is presumed being unready for a reboot (e.g. during upgrades) or a brief hiccup.
+	// This leaves some leeway to avoid immediately reacting on brief node unreadiness.
+	unreadyNodeGracePeriod = time.Minute * 20
 )
 
 var (
@@ -389,6 +395,13 @@ func (m *openshiftMachineProvider) isMachineReady(ctx context.Context, machine m
 		return true, nil
 	}
 
+	if pointer.StringDeref(machine.Status.Phase, "") == runningPhase && isNodeNotReadyWithinNodeGracePeriod(node) {
+		// The machine is running and its node has been notReady only for less than the unreadyNodeGracePeriod, so we consider the CPMS Machine to be ready for now.
+		// We do so to allow some leeway for intermittent blips, hiccups and node reboots (e.g. for node upgrades).
+		// This is due to https://issues.redhat.com/browse/OCPBUGS-20061
+		return true, nil
+	}
+
 	if pointer.StringDeref(machine.Status.Phase, "") == deletingPhase && isNodeReady(node) {
 		// The machine was previously running but is now being deleted.
 		// The machine is still ready until the node is drained and removed from the cluster.
@@ -442,6 +455,31 @@ func isNodeReady(node *corev1.Node) bool {
 	for _, c := range node.Status.Conditions {
 		if c.Type == corev1.NodeReady {
 			return c.Status == corev1.ConditionTrue
+		}
+	}
+
+	return false
+}
+
+// isNodeNotReadyWithinNodeGracePeriod returns true if a node is NotReady but it has been so only for less than the unreadyNodeGracePeriod; false otherwise.
+func isNodeNotReadyWithinNodeGracePeriod(node *corev1.Node) bool {
+	if node == nil {
+		return false
+	}
+
+	for _, c := range node.Status.Conditions {
+		if c.Type == corev1.NodeReady {
+			if c.Status == corev1.ConditionTrue {
+				return true
+			}
+
+			isWithinUnreadyNodeGracePeriod := c.LastTransitionTime.Add(unreadyNodeGracePeriod).After(time.Now())
+
+			if (c.Status == corev1.ConditionFalse || c.Status == corev1.ConditionUnknown) && isWithinUnreadyNodeGracePeriod {
+				// The node is not ready but the last transition time from ready -> not ready was less than the unreadyNodeGracePeriod,
+				// hence we consider the node to be presumably in rebooting stage (e.g. due to an upgrade).
+				return true
+			}
 		}
 	}
 

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/provider_test.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/provider_test.go
@@ -18,6 +18,7 @@ package v1beta1
 
 import (
 	"fmt"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -1443,6 +1444,156 @@ var _ = Describe("MachineProvider", func() {
 							"machineName", masterMachineName("4"),
 							"nodeName", "node-4",
 							"index", int32(4),
+							"ready", true,
+							"needsUpdate", false,
+							"diff", nilDiff,
+							"errorMessage", "",
+						},
+						Message: "Gathered Machine Info",
+					},
+				},
+			}),
+			Entry("with ready Machines but one of them has the Node unready for less than unreadyNodeGracePeriod", getMachineInfosTableInput{
+				machines: []*machinev1beta1.Machine{
+					masterMachineBuilder.WithName(masterMachineName("0")).WithProviderSpecBuilder(providerSpecBuilder.WithAvailabilityZone("us-east-1a").WithSubnet(usEast1aSubnetbeta1)).
+						WithPhase("Running").WithNodeRef(corev1.ObjectReference{Name: "node-0"}).Build(),
+					masterMachineBuilder.WithName(masterMachineName("1")).WithProviderSpecBuilder(providerSpecBuilder.WithAvailabilityZone("us-east-1b").WithSubnet(usEast1bSubnetbeta1)).
+						WithPhase("Running").WithNodeRef(corev1.ObjectReference{Name: "node-1"}).Build(),
+					masterMachineBuilder.WithName(masterMachineName("2")).WithProviderSpecBuilder(providerSpecBuilder.WithAvailabilityZone("us-east-1c").WithSubnet(usEast1cSubnetbeta1)).
+						WithPhase("Running").WithNodeRef(corev1.ObjectReference{Name: "node-2"}).Build(),
+				},
+
+				nodes: []*corev1.Node{
+					masterNodeBuilder.WithName("node-0").WithConditions(
+						[]corev1.NodeCondition{
+							{
+								Type:               corev1.NodeReady,
+								Status:             corev1.ConditionFalse,
+								LastTransitionTime: metav1.NewTime(time.Now().Add(-(unreadyNodeGracePeriod / 2))),
+							},
+						},
+					).Build(),
+					masterNodeBuilder.WithName("node-1").Build(),
+					masterNodeBuilder.WithName("node-2").Build(),
+				},
+				failureDomains: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(machinev1resourcebuilder.AWSFailureDomain().WithAvailabilityZone("us-east-1a").WithSubnet(usEast1aSubnet).Build()),
+					1: failuredomain.NewAWSFailureDomain(machinev1resourcebuilder.AWSFailureDomain().WithAvailabilityZone("us-east-1b").WithSubnet(usEast1bSubnet).Build()),
+					2: failuredomain.NewAWSFailureDomain(machinev1resourcebuilder.AWSFailureDomain().WithAvailabilityZone("us-east-1c").WithSubnet(usEast1cSubnet).Build()),
+				},
+				expectedMachineInfos: []machineproviders.MachineInfo{
+					readyMachineInfoBuilder.WithIndex(0).WithMachineName(masterMachineName("0")).WithNodeName("node-0").Build(),
+					readyMachineInfoBuilder.WithIndex(1).WithMachineName(masterMachineName("1")).WithNodeName("node-1").Build(),
+					readyMachineInfoBuilder.WithIndex(2).WithMachineName(masterMachineName("2")).WithNodeName("node-2").Build(),
+				},
+				expectedLogs: []testutils.LogEntry{
+					{
+						Level: 4,
+						KeysAndValues: []interface{}{
+							"machineName", masterMachineName("0"),
+							"nodeName", "node-0",
+							"index", int32(0),
+							"ready", true,
+							"needsUpdate", false,
+							"diff", nilDiff,
+							"errorMessage", "",
+						},
+						Message: "Gathered Machine Info",
+					},
+					{
+						Level: 4,
+						KeysAndValues: []interface{}{
+							"machineName", masterMachineName("1"),
+							"nodeName", "node-1",
+							"index", int32(1),
+							"ready", true,
+							"needsUpdate", false,
+							"diff", nilDiff,
+							"errorMessage", "",
+						},
+						Message: "Gathered Machine Info",
+					},
+					{
+						Level: 4,
+						KeysAndValues: []interface{}{
+							"machineName", masterMachineName("2"),
+							"nodeName", "node-2",
+							"index", int32(2),
+							"ready", true,
+							"needsUpdate", false,
+							"diff", nilDiff,
+							"errorMessage", "",
+						},
+						Message: "Gathered Machine Info",
+					},
+				},
+			}),
+			Entry("with ready Machines but one of them has the Node unready for more than unreadyNodeGracePeriod", getMachineInfosTableInput{
+				machines: []*machinev1beta1.Machine{
+					masterMachineBuilder.WithName(masterMachineName("0")).WithProviderSpecBuilder(providerSpecBuilder.WithAvailabilityZone("us-east-1a").WithSubnet(usEast1aSubnetbeta1)).
+						WithPhase("Running").WithNodeRef(corev1.ObjectReference{Name: "node-0"}).Build(),
+					masterMachineBuilder.WithName(masterMachineName("1")).WithProviderSpecBuilder(providerSpecBuilder.WithAvailabilityZone("us-east-1b").WithSubnet(usEast1bSubnetbeta1)).
+						WithPhase("Running").WithNodeRef(corev1.ObjectReference{Name: "node-1"}).Build(),
+					masterMachineBuilder.WithName(masterMachineName("2")).WithProviderSpecBuilder(providerSpecBuilder.WithAvailabilityZone("us-east-1c").WithSubnet(usEast1cSubnetbeta1)).
+						WithPhase("Running").WithNodeRef(corev1.ObjectReference{Name: "node-2"}).Build(),
+				},
+
+				nodes: []*corev1.Node{
+					masterNodeBuilder.WithName("node-0").WithConditions(
+						[]corev1.NodeCondition{
+							{
+								Type:               corev1.NodeReady,
+								Status:             corev1.ConditionFalse,
+								LastTransitionTime: metav1.NewTime(time.Now().Add(-(unreadyNodeGracePeriod + time.Minute*1))),
+							},
+						},
+					).Build(),
+					masterNodeBuilder.WithName("node-1").Build(),
+					masterNodeBuilder.WithName("node-2").Build(),
+				},
+				failureDomains: map[int32]failuredomain.FailureDomain{
+					0: failuredomain.NewAWSFailureDomain(machinev1resourcebuilder.AWSFailureDomain().WithAvailabilityZone("us-east-1a").WithSubnet(usEast1aSubnet).Build()),
+					1: failuredomain.NewAWSFailureDomain(machinev1resourcebuilder.AWSFailureDomain().WithAvailabilityZone("us-east-1b").WithSubnet(usEast1bSubnet).Build()),
+					2: failuredomain.NewAWSFailureDomain(machinev1resourcebuilder.AWSFailureDomain().WithAvailabilityZone("us-east-1c").WithSubnet(usEast1cSubnet).Build()),
+				},
+				expectedMachineInfos: []machineproviders.MachineInfo{
+					readyMachineInfoBuilder.WithIndex(0).WithMachineName(masterMachineName("0")).WithNodeName("node-0").WithReady(false).Build(),
+					readyMachineInfoBuilder.WithIndex(1).WithMachineName(masterMachineName("1")).WithNodeName("node-1").Build(),
+					readyMachineInfoBuilder.WithIndex(2).WithMachineName(masterMachineName("2")).WithNodeName("node-2").Build(),
+				},
+				expectedLogs: []testutils.LogEntry{
+					{
+						Level: 4,
+						KeysAndValues: []interface{}{
+							"machineName", masterMachineName("0"),
+							"nodeName", "node-0",
+							"index", int32(0),
+							"ready", false,
+							"needsUpdate", false,
+							"diff", nilDiff,
+							"errorMessage", "",
+						},
+						Message: "Gathered Machine Info",
+					},
+					{
+						Level: 4,
+						KeysAndValues: []interface{}{
+							"machineName", masterMachineName("1"),
+							"nodeName", "node-1",
+							"index", int32(1),
+							"ready", true,
+							"needsUpdate", false,
+							"diff", nilDiff,
+							"errorMessage", "",
+						},
+						Message: "Gathered Machine Info",
+					},
+					{
+						Level: 4,
+						KeysAndValues: []interface{}{
+							"machineName", masterMachineName("2"),
+							"nodeName", "node-2",
+							"index", int32(2),
 							"ready", true,
 							"needsUpdate", false,
 							"diff", nilDiff,


### PR DESCRIPTION
Manual cherry-pick of https://github.com/openshift/cluster-control-plane-machine-set-operator/pull/340

/assign damdo

/cherrypick release 4.12