### PR TITLE
OCPBUGS-50580: Fix MachineNamePrefix periodic on OpenStack

### DIFF
--- a/pkg/controllers/controlplanemachineset/controller_test.go
+++ b/pkg/controllers/controlplanemachineset/controller_test.go
@@ -1153,14 +1153,14 @@ var _ = Describe("With a running controller", func() {
 			)))
 		})
 
-		Context("and the instance size is changed", func() {
+		Context("and the provider spec is modified", func() {
 			var testOptions helpers.RollingUpdatePeriodicTestOptions
 
 			BeforeEach(func() {
 				// The CPMS is configured for AWS so use the AWS Platform Type.
 				testFramework := framework.NewFrameworkWith(testScheme, k8sClient, configv1.AWSPlatformType, framework.Full, namespaceName)
 
-				helpers.IncreaseControlPlaneMachineSetInstanceSize(testFramework, 10*time.Second, 1*time.Second)
+				helpers.ModifyControlPlaneMachineSetToTriggerRollout(testFramework, 10*time.Second, 1*time.Second)
 
 				testOptions.TestFramework = testFramework
 
@@ -1648,9 +1648,9 @@ var _ = Describe("With a running controller and machine name prefix", func() {
 				)))
 			})
 
-			Context("and the instance size is changed", func() {
+			Context("and the provider spec is modified", func() {
 				JustBeforeEach(func() {
-					helpers.IncreaseControlPlaneMachineSetInstanceSize(testOptions.TestFramework, 10*time.Second, 1*time.Second)
+					helpers.ModifyControlPlaneMachineSetToTriggerRollout(testOptions.TestFramework, 10*time.Second, 1*time.Second)
 				})
 
 				helpers.ItShouldPerformARollingUpdate(&testOptions)
@@ -1868,9 +1868,9 @@ var _ = Describe("With a running controller and machine name prefix", func() {
 				)))
 			})
 
-			Context("and the instance size is changed", func() {
+			Context("and the provider spec is modified", func() {
 				JustBeforeEach(func() {
-					helpers.IncreaseControlPlaneMachineSetInstanceSize(testOptions.TestFramework, 10*time.Second, 1*time.Second)
+					helpers.ModifyControlPlaneMachineSetToTriggerRollout(testOptions.TestFramework, 10*time.Second, 1*time.Second)
 				})
 
 				helpers.ItShouldPerformARollingUpdate(&testOptions)

--- a/test/e2e/periodic_test.go
+++ b/test/e2e/periodic_test.go
@@ -38,9 +38,9 @@ var _ = Describe("ControlPlaneMachineSet Operator", framework.Periodic(), func()
 			helpers.EnsureActiveControlPlaneMachineSet(testFramework)
 		})
 
-		Context("and the instance type is changed", func() {
+		Context("and the provider spec is changed", func() {
 			BeforeEach(func() {
-				helpers.IncreaseControlPlaneMachineSetInstanceSize(testFramework)
+				helpers.ModifyControlPlaneMachineSetToTriggerRollout(testFramework)
 			})
 
 			helpers.ItShouldPerformARollingUpdate(&helpers.RollingUpdatePeriodicTestOptions{
@@ -70,9 +70,9 @@ var _ = Describe("ControlPlaneMachineSet Operator", framework.Periodic(), func()
 				helpers.UpdateControlPlaneMachineSetMachineNamePrefix(testFramework, resetPrefix)
 			})
 
-			Context("and the instance type of index 1 is not as expected", func() {
+			Context("and the provider spec of index 1 is not as expected", func() {
 				BeforeEach(func() {
-					helpers.IncreaseControlPlaneMachineInstanceSize(testFramework, 1)
+					helpers.ModifyMachineProviderSpecToTriggerRollout(testFramework, 1)
 				})
 
 				helpers.ItShouldRollingUpdateReplaceTheOutdatedMachine(testFramework, 1)

--- a/test/e2e/presubmit_test.go
+++ b/test/e2e/presubmit_test.go
@@ -42,9 +42,9 @@ var _ = Describe("ControlPlaneMachineSet Operator", framework.PreSubmit(), func(
 			helpers.EnsureActiveControlPlaneMachineSet(testFramework)
 		}, OncePerOrdered)
 
-		Context("and the instance type of index 1 is not as expected", func() {
+		Context("and the provider spec of index 1 is not as expected", func() {
 			BeforeEach(func() {
-				helpers.IncreaseControlPlaneMachineInstanceSize(testFramework, 1)
+				helpers.ModifyMachineProviderSpecToTriggerRollout(testFramework, 1)
 			})
 
 			helpers.ItShouldRollingUpdateReplaceTheOutdatedMachine(testFramework, 1)
@@ -72,9 +72,9 @@ var _ = Describe("ControlPlaneMachineSet Operator", framework.PreSubmit(), func(
 				helpers.UpdateControlPlaneMachineSetMachineNamePrefix(testFramework, resetPrefix)
 			})
 
-			Context("and the instance type of index 1 is not as expected", func() {
+			Context("and the provider spec of index 1 is not as expected", func() {
 				BeforeEach(func() {
-					helpers.IncreaseControlPlaneMachineInstanceSize(testFramework, 1)
+					helpers.ModifyMachineProviderSpecToTriggerRollout(testFramework, 1)
 				})
 
 				helpers.ItShouldRollingUpdateReplaceTheOutdatedMachine(testFramework, 1)
@@ -92,11 +92,11 @@ var _ = Describe("ControlPlaneMachineSet Operator", framework.PreSubmit(), func(
 				helpers.EnsureControlPlaneMachineSetUpdateStrategy(testFramework, originalStrategy)
 			}, OncePerOrdered)
 
-			Context("and the instance type of index 2 is not as expected", Ordered, func() {
+			Context("and the provider spec of index 2 is not as expected", Ordered, func() {
 				var originalProviderSpec machinev1beta1.ProviderSpec
 
 				BeforeAll(func() {
-					originalProviderSpec, _ = helpers.IncreaseControlPlaneMachineInstanceSize(testFramework, 2)
+					originalProviderSpec, _ = helpers.ModifyMachineProviderSpecToTriggerRollout(testFramework, 2)
 				})
 
 				AfterAll(func() {
@@ -180,7 +180,7 @@ var _ = Describe("ControlPlaneMachineSet Operator", framework.PreSubmit(), func(
 				BeforeEach(func() {
 					opts.TestFramework = testFramework
 					opts.UID = helpers.GetControlPlaneMachineSetUID(testFramework)
-					opts.Index, opts.OriginalProviderSpec, opts.UpdatedProviderSpec = helpers.IncreaseNewestControlPlaneMachineInstanceSize(testFramework)
+					opts.Index, opts.OriginalProviderSpec, opts.UpdatedProviderSpec = helpers.ModifyNewestMachineProviderSpecToTriggerRollout(testFramework)
 				})
 
 				AfterEach(func() {


### PR DESCRIPTION
This test assumed that multiple calls to
IncreaseControlPlaneMachineInstanceSize would trigger a rollout every
time. However, this was not true on OpenStack, as flavor names are not
predictable. The OpenStack function assumed it would only ever be called
once, and set a single alternate flavor name passed as an environment
variable. This meant that when called a second time, it did not trigger
a rollout.

In this change we rename the 3 'Increase...InstanceSize' functions to
better reflect their intended function, which is to trigger a rollout.
With this context, we update the OpenStack implementations to add a
random tag instead. This was already the fallback behaviour if no
alternate flavor was passed, and has the additional advantage that it
can be called as many times as required.

Merge first:
- [x] https://github.com/openshift/release/pull/62034
