### PR TITLE
Workaround static pod controller bug by doubling timeout

### DIFF
--- a/test/e2e/helpers/cases.go
+++ b/test/e2e/helpers/cases.go
@@ -173,7 +173,10 @@ func ItShouldRollingUpdateReplaceTheOutdatedMachine(testFramework framework.Fram
 		By("Control plane machine rollout completed successfully")
 
 		By("Waiting for the cluster to stabilise after the rollout")
-		EventuallyClusterOperatorsShouldStabilise(1*time.Minute, 30*time.Minute, 30*time.Second)
+		// Double the timeout to 60 minutes as a temporary workaround for
+		// https://issues.redhat.com/browse/OCPBUGS-50587. Put this back to a
+		// more reasonable 30 minutes when this bug is fixed.
+		EventuallyClusterOperatorsShouldStabilise(1*time.Minute, 60*time.Minute, 30*time.Second)
 		By("Cluster stabilised after the rollout")
 	})
 }


### PR DESCRIPTION
The periodics are consistently hitting
https://issues.redhat.com/browse/OCPBUGS-50587, manifesting as a timeout
waiting for the cluster to stabilise in the MachineNamePrefix test. This
change simply doubles the timeout, as the sitution should resolve itself
eventually. We should remove this workaround when the bug is fixed.
