### PR TITLE
OAPE-126: Include CPMSMachineNamePrefix feature-gate name in e2e tests

### DIFF
--- a/test/e2e/periodic_test.go
+++ b/test/e2e/periodic_test.go
@@ -48,7 +48,7 @@ var _ = Describe("ControlPlaneMachineSet Operator", framework.Periodic(), func()
 			})
 		})
 
-		Context("and ControlPlaneMachineSet is updated to set MachineNamePrefix", func() {
+		Context("and ControlPlaneMachineSet is updated to set MachineNamePrefix [OCPFeatureGate:CPMSMachineNamePrefix]", func() {
 			prefix := "master-prefix"
 			resetPrefix := ""
 

--- a/test/e2e/presubmit_test.go
+++ b/test/e2e/presubmit_test.go
@@ -50,7 +50,7 @@ var _ = Describe("ControlPlaneMachineSet Operator", framework.PreSubmit(), func(
 			helpers.ItShouldRollingUpdateReplaceTheOutdatedMachine(testFramework, 1)
 		})
 
-		Context("and ControlPlaneMachineSet is updated to set MachineNamePrefix", func() {
+		Context("and ControlPlaneMachineSet is updated to set MachineNamePrefix [OCPFeatureGate:CPMSMachineNamePrefix]", func() {
 			prefix := "master-prefix"
 			resetPrefix := ""
 


### PR DESCRIPTION
Include `CPMSMachineNamePrefix` feature gate name in e2e tests.

This is required for sippy tool to filter the e2e tests specific to this featuregate.
xRef: https://github.com/openshift/api?tab=readme-ov-file#defining-featuregate-e2e-tests

https://issues.redhat.com/browse/OAPE-126

