### PR TITLE
OCPBUGS-52448: Remove gathering of failure domains from machine sets

### DIFF
--- a/pkg/controllers/controlplanemachineset/suite_test.go
+++ b/pkg/controllers/controlplanemachineset/suite_test.go
@@ -112,6 +112,10 @@ var _ = BeforeSuite(func() {
 
 	komega.SetClient(k8sClient)
 	komega.SetContext(ctx)
+
+	// Increase default values for Consistently to ensure there is enough time for reconciliation of objects
+	SetDefaultConsistentlyDuration(500 * time.Millisecond)
+	SetDefaultConsistentlyPollingInterval(50 * time.Millisecond)
 })
 
 var _ = AfterSuite(func() {

--- a/pkg/controllers/controlplanemachinesetgenerator/aws.go
+++ b/pkg/controllers/controlplanemachinesetgenerator/aws.go
@@ -41,8 +41,8 @@ const (
 )
 
 // generateControlPlaneMachineSetAWSSpec generates an AWS flavored ControlPlaneMachineSet Spec.
-func generateControlPlaneMachineSetAWSSpec(logger logr.Logger, machines []machinev1beta1.Machine, machineSets []machinev1beta1.MachineSet) (machinev1builder.ControlPlaneMachineSetSpecApplyConfiguration, error) {
-	controlPlaneMachineSetMachineFailureDomainsApplyConfig, err := buildFailureDomains(logger, machineSets, machines, nil)
+func generateControlPlaneMachineSetAWSSpec(logger logr.Logger, machines []machinev1beta1.Machine) (machinev1builder.ControlPlaneMachineSetSpecApplyConfiguration, error) {
+	controlPlaneMachineSetMachineFailureDomainsApplyConfig, err := buildFailureDomains(logger, machines, nil)
 	if errors.Is(err, errNoFailureDomains) {
 		// This is a special case where we don't have any failure domains.
 	} else if err != nil {

--- a/pkg/controllers/controlplanemachinesetgenerator/azure.go
+++ b/pkg/controllers/controlplanemachinesetgenerator/azure.go
@@ -33,8 +33,8 @@ import (
 )
 
 // generateControlPlaneMachineSetAzureSpec generates an Azure flavored ControlPlaneMachineSet Spec.
-func generateControlPlaneMachineSetAzureSpec(logger logr.Logger, machines []machinev1beta1.Machine, machineSets []machinev1beta1.MachineSet) (machinev1builder.ControlPlaneMachineSetSpecApplyConfiguration, error) {
-	controlPlaneMachineSetMachineFailureDomainsApplyConfig, err := buildFailureDomains(logger, machineSets, machines, nil)
+func generateControlPlaneMachineSetAzureSpec(logger logr.Logger, machines []machinev1beta1.Machine) (machinev1builder.ControlPlaneMachineSetSpecApplyConfiguration, error) {
+	controlPlaneMachineSetMachineFailureDomainsApplyConfig, err := buildFailureDomains(logger, machines, nil)
 	if errors.Is(err, errNoFailureDomains) {
 		// This is a special case where we don't have any failure domains.
 	} else if err != nil {

--- a/pkg/controllers/controlplanemachinesetgenerator/gcp.go
+++ b/pkg/controllers/controlplanemachinesetgenerator/gcp.go
@@ -33,8 +33,8 @@ import (
 )
 
 // generateControlPlaneMachineSetGCPSpec generates an GCP flavored ControlPlaneMachineSet Spec.
-func generateControlPlaneMachineSetGCPSpec(logger logr.Logger, machines []machinev1beta1.Machine, machineSets []machinev1beta1.MachineSet) (machinev1builder.ControlPlaneMachineSetSpecApplyConfiguration, error) {
-	controlPlaneMachineSetMachineFailureDomainsApplyConfig, err := buildFailureDomains(logger, machineSets, machines, nil)
+func generateControlPlaneMachineSetGCPSpec(logger logr.Logger, machines []machinev1beta1.Machine) (machinev1builder.ControlPlaneMachineSetSpecApplyConfiguration, error) {
+	controlPlaneMachineSetMachineFailureDomainsApplyConfig, err := buildFailureDomains(logger, machines, nil)
 	if errors.Is(err, errNoFailureDomains) {
 		// This is a special case where we don't have any failure domains.
 	} else if err != nil {

--- a/pkg/controllers/controlplanemachinesetgenerator/nutanix.go
+++ b/pkg/controllers/controlplanemachinesetgenerator/nutanix.go
@@ -35,8 +35,8 @@ import (
 var errInvalidFailureDomainName = errors.New("invalid failure domain name")
 
 // generateControlPlaneMachineSetNutanixSpec generates a Nutanix flavored ControlPlaneMachineSet Spec.
-func generateControlPlaneMachineSetNutanixSpec(logger logr.Logger, machines []machinev1beta1.Machine, machineSets []machinev1beta1.MachineSet, infrastructure *configv1.Infrastructure) (machinev1builder.ControlPlaneMachineSetSpecApplyConfiguration, error) {
-	controlPlaneMachineSetMachineFailureDomainsApplyConfig, err := buildFailureDomains(logger, machineSets, machines, infrastructure)
+func generateControlPlaneMachineSetNutanixSpec(logger logr.Logger, machines []machinev1beta1.Machine, infrastructure *configv1.Infrastructure) (machinev1builder.ControlPlaneMachineSetSpecApplyConfiguration, error) {
+	controlPlaneMachineSetMachineFailureDomainsApplyConfig, err := buildFailureDomains(logger, machines, infrastructure)
 	if err != nil {
 		if !errors.Is(err, errNoFailureDomains) {
 			return machinev1builder.ControlPlaneMachineSetSpecApplyConfiguration{}, fmt.Errorf("failed to build ControlPlaneMachineSet's Nutanix failure domains: %w", err)

--- a/pkg/controllers/controlplanemachinesetgenerator/openstack.go
+++ b/pkg/controllers/controlplanemachinesetgenerator/openstack.go
@@ -60,13 +60,13 @@ func checkOpenStackMachinesServerGroups(logger logr.Logger, machines []machinev1
 }
 
 // generateControlPlaneMachineSetOpenStackSpec generates an OpenStack flavored ControlPlaneMachineSet Spec.
-func generateControlPlaneMachineSetOpenStackSpec(logger logr.Logger, machines []machinev1beta1.Machine, machineSets []machinev1beta1.MachineSet) (machinev1builder.ControlPlaneMachineSetSpecApplyConfiguration, error) {
+func generateControlPlaneMachineSetOpenStackSpec(logger logr.Logger, machines []machinev1beta1.Machine) (machinev1builder.ControlPlaneMachineSetSpecApplyConfiguration, error) {
 	// We want to make sure that the machines are ready to be used for generating a ControlPlaneMachineSet.
 	if err := checkOpenStackMachinesServerGroups(logger, machines); err != nil {
 		return machinev1builder.ControlPlaneMachineSetSpecApplyConfiguration{}, fmt.Errorf("failed to check OpenStack machines ServerGroup: %w", err)
 	}
 
-	controlPlaneMachineSetMachineFailureDomainsApplyConfig, err := buildFailureDomains(logger, machineSets, machines, nil)
+	controlPlaneMachineSetMachineFailureDomainsApplyConfig, err := buildFailureDomains(logger, machines, nil)
 	if errors.Is(err, errNoFailureDomains) {
 		// This is a special case where we don't have any failure domains.
 	} else if err != nil {

--- a/pkg/controllers/controlplanemachinesetgenerator/suite_test.go
+++ b/pkg/controllers/controlplanemachinesetgenerator/suite_test.go
@@ -123,6 +123,10 @@ var _ = BeforeSuite(func() {
 
 	komega.SetClient(k8sClient)
 	komega.SetContext(ctx)
+
+	// Increase default values for Consistently to ensure there is enough time for reconciliation of objects
+	SetDefaultConsistentlyDuration(500 * time.Millisecond)
+	SetDefaultConsistentlyPollingInterval(50 * time.Millisecond)
 })
 
 var _ = AfterSuite(func() {

--- a/pkg/controllers/controlplanemachinesetgenerator/utils_test.go
+++ b/pkg/controllers/controlplanemachinesetgenerator/utils_test.go
@@ -227,61 +227,6 @@ var _ = Describe("compareControlPlaneMachineSets tests", func() {
 	)
 })
 
-var _ = Describe("sortMachineSetsByCreationTimeDescending tests", func() {
-	type sortMachineSetsByCreationTimeAscendingTableInput struct {
-		input    []machinev1beta1.MachineSet
-		expected []machinev1beta1.MachineSet
-	}
-
-	timeFirst := metav1.NewTime(time.Now().Add(time.Hour * 1))
-	timeSecond := metav1.NewTime(time.Now().Add(time.Hour * 2))
-	timeThird := metav1.NewTime(time.Now().Add(time.Hour * 3))
-
-	DescribeTable("should sort (ascending) a slice of MachineSets by CreationTime,Name",
-		func(in sortMachineSetsByCreationTimeAscendingTableInput) {
-			output := sortMachineSetsByCreationTimeAscending(in.input)
-			Expect(output).To(Equal(in.expected))
-		},
-		Entry("when the input is not sorted by time", sortMachineSetsByCreationTimeAscendingTableInput{
-			input: []machinev1beta1.MachineSet{
-				*machinev1beta1resourcebuilder.MachineSet().WithName("machine-6").
-					WithCreationTimestamp(timeThird).Build(),
-				*machinev1beta1resourcebuilder.MachineSet().WithName("machine-3").
-					WithCreationTimestamp(timeSecond).Build(),
-				*machinev1beta1resourcebuilder.MachineSet().WithName("machine-1").
-					WithCreationTimestamp(timeFirst).Build(),
-			},
-			expected: []machinev1beta1.MachineSet{
-				*machinev1beta1resourcebuilder.MachineSet().WithName("machine-1").
-					WithCreationTimestamp(timeFirst).Build(),
-				*machinev1beta1resourcebuilder.MachineSet().WithName("machine-3").
-					WithCreationTimestamp(timeSecond).Build(),
-				*machinev1beta1resourcebuilder.MachineSet().WithName("machine-6").
-					WithCreationTimestamp(timeThird).Build(),
-			},
-		}),
-		Entry("when the time is the same, input is not sorted by name", sortMachineSetsByCreationTimeAscendingTableInput{
-			input: []machinev1beta1.MachineSet{
-				*machinev1beta1resourcebuilder.MachineSet().WithName("machine-6").
-					WithCreationTimestamp(timeFirst).Build(),
-				*machinev1beta1resourcebuilder.MachineSet().WithName("machine-1").
-					WithCreationTimestamp(timeFirst).Build(),
-				*machinev1beta1resourcebuilder.MachineSet().WithName("machine-3").
-					WithCreationTimestamp(timeFirst).Build(),
-			},
-			expected: []machinev1beta1.MachineSet{
-				*machinev1beta1resourcebuilder.MachineSet().WithName("machine-1").
-					WithCreationTimestamp(timeFirst).Build(),
-				*machinev1beta1resourcebuilder.MachineSet().WithName("machine-3").
-					WithCreationTimestamp(timeFirst).Build(),
-				*machinev1beta1resourcebuilder.MachineSet().WithName("machine-6").
-					WithCreationTimestamp(timeFirst).Build(),
-			},
-		}),
-	)
-
-})
-
 var _ = Describe("sortMachineByCreationTimeDescending tests", func() {
 	type sortMachinesByCreationTimeDescendingTableInput struct {
 		input    []machinev1beta1.Machine

--- a/pkg/controllers/controlplanemachinesetgenerator/vsphere.go
+++ b/pkg/controllers/controlplanemachinesetgenerator/vsphere.go
@@ -31,8 +31,8 @@ import (
 )
 
 // generateControlPlaneMachineSetVSphereSpec generates an VSphere flavored ControlPlaneMachineSet Spec.
-func generateControlPlaneMachineSetVSphereSpec(logger logr.Logger, machines []machinev1beta1.Machine, machineSets []machinev1beta1.MachineSet, infrastructure *configv1.Infrastructure) (machinev1builder.ControlPlaneMachineSetSpecApplyConfiguration, error) {
-	controlPlaneMachineSetMachineFailureDomainsApplyConfig, err := buildFailureDomains(logger, machineSets, machines, infrastructure)
+func generateControlPlaneMachineSetVSphereSpec(logger logr.Logger, machines []machinev1beta1.Machine, infrastructure *configv1.Infrastructure) (machinev1builder.ControlPlaneMachineSetSpecApplyConfiguration, error) {
+	controlPlaneMachineSetMachineFailureDomainsApplyConfig, err := buildFailureDomains(logger, machines, infrastructure)
 	if err != nil {
 		return machinev1builder.ControlPlaneMachineSetSpecApplyConfiguration{}, fmt.Errorf("failed to build ControlPlaneMachineSet's VSphere failure domains: %w", err)
 	}

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/providerconfig.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/providerconfig.go
@@ -441,22 +441,6 @@ func ExtractFailureDomainFromMachine(logger logr.Logger, machine machinev1beta1.
 	return providerConfig.ExtractFailureDomain(), nil
 }
 
-// ExtractFailureDomainsFromMachineSets creates list of FailureDomains extracted from the provided list of machineSets.
-func ExtractFailureDomainsFromMachineSets(logger logr.Logger, machineSets []machinev1beta1.MachineSet, infrastructure *configv1.Infrastructure) ([]failuredomain.FailureDomain, error) {
-	machineSetFailureDomains := failuredomain.NewSet()
-
-	for _, machineSet := range machineSets {
-		providerconfig, err := NewProviderConfigFromMachineSpec(logger, machineSet.Spec.Template.Spec, infrastructure)
-		if err != nil {
-			return nil, fmt.Errorf("error getting failure domain from machineSet %s: %w", machineSet.Name, err)
-		}
-
-		machineSetFailureDomains.Insert(providerconfig.ExtractFailureDomain())
-	}
-
-	return machineSetFailureDomains.List(), nil
-}
-
 // checkForUnknownFieldsInProviderSpecAndUnmarshal tries to unmarshal content into a platform specific provider spec
 // and detect invalid fields.
 //

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/suite_test.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/suite_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -89,6 +90,10 @@ var _ = BeforeSuite(func() {
 
 	komega.SetClient(k8sClient)
 	komega.SetContext(ctx)
+
+	// Increase default values for Consistently to ensure there is enough time for reconciliation of objects
+	SetDefaultConsistentlyDuration(500 * time.Millisecond)
+	SetDefaultConsistentlyPollingInterval(50 * time.Millisecond)
 })
 
 var _ = AfterSuite(func() {


### PR DESCRIPTION
This fixes a bug when a cluster is running with 3 control plane nodes in a single AZ, and machine pools in > 1 AZ, CPMS does not generate a config. 

We decided to remove the feature that gathers additional failure domains from MachineSets. While useful, this feature prevents the generation of the CPMS in the case mentioned above. Our priority is to generate a valid CPMS based on the current state of the control plane, allowing the cluster administrator to add failure domains later if needed, rather than requiring manual intervention upfront.