### PR TITLE
OCPBUGS-65497: Add all managed resources to ClusterOperator relatedObjects

### DIFF
--- a/manifests/0000_30_control-plane-machine-set-operator_04_clusteroperator.yaml
+++ b/manifests/0000_30_control-plane-machine-set-operator_04_clusteroperator.yaml
@@ -21,3 +21,6 @@ status:
   - group: machine.openshift.io
     name: ""
     resource: machines
+  - group: rbac.authorization.k8s.io
+    name: control-plane-machine-set-operator
+    resource: clusterroles

--- a/pkg/controllers/controlplanemachineset/cluster_operator.go
+++ b/pkg/controllers/controlplanemachineset/cluster_operator.go
@@ -51,6 +51,11 @@ func relatedObjects() []configv1.ObjectReference {
 			Resource: "machines",
 			Name:     "",
 		},
+		{
+			Group:    "rbac.authorization.k8s.io",
+			Resource: "clusterroles",
+			Name:     "control-plane-machine-set-operator",
+		},
 	}
 }
 


### PR DESCRIPTION
Adds all resources managed by the control-plane-machine-set operator to the ClusterOperator's relatedObjects list, ensuring `oc adm inspect` and must-gather collect the complete set of resources needed for debugging.

## Resources added
- ServiceAccounts
- Services, Deployments
- Roles and RoleBindings
- ClusterRoles and ClusterRoleBindings
- ValidatingWebhookConfigurations

Both the static manifest YAML and the Go source are kept in sync.