### PR TITLE
delete 3 masters simultaneously

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -9,7 +9,7 @@ REPO_ROOT=$(dirname "${BASH_SOURCE}")/..
 OPENSHIFT_CI=${OPENSHIFT_CI:-""}
 ARTIFACT_DIR=${ARTIFACT_DIR:-""}
 GINKGO=${GINKGO:-"go run -mod=vendor ${REPO_ROOT}/vendor/github.com/onsi/ginkgo/v2/ginkgo"}
-GINKGO_ARGS=${GINKGO_ARGS:-"-r -v --fail-fast --trace --timeout=4h"}
+GINKGO_ARGS=${GINKGO_ARGS:-"-r -v --fail-fast --trace --timeout=6h"}
 GINKGO_EXTRA_ARGS=${GINKGO_EXTRA_ARGS:-""}
 
 if [ "$OPENSHIFT_CI" == "true" ] && [ -n "$ARTIFACT_DIR" ] && [ -d "$ARTIFACT_DIR" ]; then # detect ci environment there

--- a/test/e2e/helpers/cases.go
+++ b/test/e2e/helpers/cases.go
@@ -256,6 +256,72 @@ func ItShouldOnDeleteReplaceTheOutDatedMachineWhenDeleted(testFramework framewor
 	})
 }
 
+// ItShouldOnDeleteReplaceAllThreeMastersWhenDeletedSimultaneously checks that the control plane machine set replaces
+// all three master machines when the update strategy is OnDelete and all three machines are deleted simultaneously.
+func ItShouldOnDeleteReplaceAllThreeMastersWhenDeletedSimultaneously(testFramework framework.Framework) {
+	// TODO: https://issues.redhat.com/browse/OCPBUGS-74151
+	It("should replace all three masters when deleted simultaneously", func() {
+		k8sClient := testFramework.GetClient()
+		ctx := testFramework.GetContext()
+
+		// Make sure the CPMS exists before we delete the Machines.
+		cpms := &machinev1.ControlPlaneMachineSet{}
+		Expect(k8sClient.Get(ctx, testFramework.ControlPlaneMachineSetKey(), cpms)).To(Succeed(), "control plane machine set should exist")
+
+		// Get all three machines
+		machine0, err := machineForIndex(testFramework, 0)
+		Expect(err).ToNot(HaveOccurred(), "control plane machine 0 should exist")
+
+		machine1, err := machineForIndex(testFramework, 1)
+		Expect(err).ToNot(HaveOccurred(), "control plane machine 1 should exist")
+
+		machine2, err := machineForIndex(testFramework, 2)
+		Expect(err).ToNot(HaveOccurred(), "control plane machine 2 should exist")
+
+		// Delete all three Machines simultaneously.
+		By("Deleting all three master machines")
+		Expect(k8sClient.Delete(ctx, machine0)).To(Succeed(), "control plane machine 0 should be able to be deleted")
+		Expect(k8sClient.Delete(ctx, machine1)).To(Succeed(), "control plane machine 1 should be able to be deleted")
+		Expect(k8sClient.Delete(ctx, machine2)).To(Succeed(), "control plane machine 2 should be able to be deleted")
+
+		// Deleting all three Machines triggers a rollout, give the rollout 90 minutes to complete.
+		rolloutCtx, cancel := context.WithTimeout(testFramework.GetContext(), 90*time.Minute)
+		defer cancel()
+
+		wg := &sync.WaitGroup{}
+
+		framework.Async(wg, cancel, func() bool {
+			return WaitForControlPlaneMachineSetDesiredReplicas(rolloutCtx, cpms.DeepCopy())
+		})
+
+		// Check rollout for all three indexes
+		framework.Async(wg, cancel, func() bool {
+			return CheckRolloutForIndex(testFramework, rolloutCtx, 0, machinev1.OnDelete)
+		})
+
+		framework.Async(wg, cancel, func() bool {
+			return CheckRolloutForIndex(testFramework, rolloutCtx, 1, machinev1.OnDelete)
+		})
+
+		framework.Async(wg, cancel, func() bool {
+			return CheckRolloutForIndex(testFramework, rolloutCtx, 2, machinev1.OnDelete)
+		})
+
+		wg.Wait()
+
+		// If there's an error in the context, either it timed out or one of the async checks failed.
+		Expect(rolloutCtx.Err()).ToNot(HaveOccurred(), "rollout should have completed successfully")
+		By("Control plane machine rollout completed successfully for all three masters")
+
+		By("Waiting for the cluster to stabilise after the rollout")
+		// 30 minutes for the rollout to complete, 2 minutes for the cluster to stabilise.
+		// Check every 20 seconds.
+		// The timeout includes the 2 minutes to stabilise, hence 32 minutes.
+		EventuallyClusterOperatorsShouldStabilise(2*time.Minute, 32*time.Minute, 20*time.Second)
+		By("Cluster stabilised after the rollout")
+	})
+}
+
 // ItShouldUninstallTheControlPlaneMachineSet checks that the control plane machine set is correctly uninstalled
 // when a deletion is triggered, without triggering control plane machines changes.
 func ItShouldUninstallTheControlPlaneMachineSet(testFramework framework.Framework) {

--- a/test/e2e/periodic.go
+++ b/test/e2e/periodic.go
@@ -99,6 +99,10 @@ var _ = Describe("ControlPlaneMachineSet Operator", framework.Periodic(), Label(
 				helpers.EnsureControlPlaneMachineSetUpdateStrategy(framework.GlobalFramework, originalStrategy)
 			}, OncePerOrdered)
 
+			Context("and all three master machines are deleted simultaneously", Ordered, func() {
+				helpers.ItShouldOnDeleteReplaceAllThreeMastersWhenDeletedSimultaneously(framework.GlobalFramework)
+			})
+
 			Context("and ControlPlaneMachineSet is updated to set MachineNamePrefix [OCPFeatureGate:CPMSMachineNamePrefix]", Ordered, func() {
 				prefix := "master-prefix-on-delete"
 				resetPrefix := ""


### PR DESCRIPTION
This is added according to [the discussion](https://redhat-internal.slack.com/archives/GE2HQ9QP4/p1768480261036919?thread_ts=1768475961.086899&cid=GE2HQ9QP4) @JoelSpeed @damdo @sunzhaohua2 PTAL, thanks!
I tested on 4.17 and it works! I've currently marked this test case as `PIt`. Once the related bug is fixed, we can change `PIt` back to `It` to enable the test.
```
liuhuali@Lius-MacBook-Pro cluster-control-plane-machine-set-operator % make e2e-periodic
GINKGO_EXTRA_ARGS=--label-filter=Periodic ./hack/e2e.sh
go run -mod=vendor ./hack/../vendor/github.com/onsi/ginkgo/v2/ginkgo -r -v --fail-fast --trace --timeout=4h --label-filter=Periodic ./test/e2e
Running Suite: E2E Suite - /Users/liuhuali/project/cluster-control-plane-machine-set-operator/test/e2e
======================================================================================================
Random Seed: 1768891084

Will run 1 of 3 specs
------------------------------
[BeforeSuite] 
/Users/liuhuali/project/cluster-control-plane-machine-set-operator/test/e2e/suite_test.go:42
[BeforeSuite] PASSED [0.000 seconds]
------------------------------
SS
------------------------------
ControlPlaneMachineSet Operator With an active ControlPlaneMachineSet with the OnDelete update strategy and all three master machines are deleted simultaneously should replace all three masters when deleted simultaneously [Periodic, Disruptive, Serial]
/Users/liuhuali/project/cluster-control-plane-machine-set-operator/test/e2e/helpers/cases.go:262
  STEP: Waiting for the cluster operators to stabilise (minimum availability time: 1m0s, timeout: 10m0s, polling interval: 10s) @ 01/20/26 14:38:26.172
  STEP: Checking the control plane machine set exists @ 01/20/26 14:38:26.733
  STEP: Checking the control plane machine set is active @ 01/20/26 14:38:27.019
  STEP: Updating the control plane machine set strategy to OnDelete @ 01/20/26 14:38:27.565
  STEP: Updating the provider spec of the control plane machine at index 0 @ 01/20/26 14:38:29.114
I0120 14:38:30.239188   18412 warning_handler.go:64] "providerSpec.value: Unsupported value: \"capacityReservationId\": Unknown field (capacityReservationId) will be ignored"
  STEP: Updating the provider spec of the control plane machine at index 1 @ 01/20/26 14:38:30.518
I0120 14:38:31.468130   18412 warning_handler.go:64] "providerSpec.value: Unsupported value: \"capacityReservationId\": Unknown field (capacityReservationId) will be ignored"
  STEP: Updating the provider spec of the control plane machine at index 2 @ 01/20/26 14:38:31.749
I0120 14:38:32.473105   18412 warning_handler.go:64] "providerSpec.value: Unsupported value: \"capacityReservationId\": Unknown field (capacityReservationId) will be ignored"
  STEP: Deleting all three master machines @ 01/20/26 14:38:33.579
  STEP: Waiting for the index 2 to be replaced @ 01/20/26 14:38:34.541
  STEP: Waiting for the index 0 to be replaced @ 01/20/26 14:38:34.541
  STEP: Waiting for the index 1 to be replaced @ 01/20/26 14:38:34.541
  STEP: Checking that other indexes (not 0) do not have 2 replicas @ 01/20/26 14:38:34.541
  STEP: Checking that other indexes (not 2) do not have 2 replicas @ 01/20/26 14:38:34.541
  STEP: Checking that other indexes (not 1) do not have 2 replicas @ 01/20/26 14:38:34.541
  STEP: Waiting for the updated replicas to equal desired replicas @ 01/20/26 14:38:34.541
  STEP: Checking that index 2 has 2 replicas @ 01/20/26 14:38:34.851
  STEP: Checking that index 1 has 2 replicas @ 01/20/26 14:38:35.121
  STEP: Checking that index 0 has 2 replicas @ 01/20/26 14:38:35.123
  STEP: Correct index is being replaced @ 01/20/26 14:38:35.464
  STEP: Index 2 replacement created @ 01/20/26 14:38:35.464
  STEP: Checking the replacement machine for index 2 @ 01/20/26 14:38:35.465
  STEP: Correct index is being replaced @ 01/20/26 14:38:35.466
  STEP: Index 1 replacement created @ 01/20/26 14:38:35.466
  STEP: Checking the replacement machine for index 1 @ 01/20/26 14:38:35.466
  STEP: Correct index is being replaced @ 01/20/26 14:38:35.467
  STEP: Index 0 replacement created @ 01/20/26 14:38:35.467
  STEP: Checking the replacement machine for index 0 @ 01/20/26 14:38:35.467
  STEP: Checking the replacement machine name @ 01/20/26 14:38:35.745
  STEP: Checking the replacement machine name @ 01/20/26 14:38:35.749
  STEP: Checking the replacement machine name @ 01/20/26 14:38:35.751
  STEP: Replacement machine name is "huliu-aws0120a-rqvvv-master-lgrfc-2" @ 01/20/26 14:38:36.693
  STEP: Replacement machine name is "huliu-aws0120a-rqvvv-master-5kccj-1" @ 01/20/26 14:38:36.693
  STEP: Replacement machine name is correct @ 01/20/26 14:38:36.694
  STEP: Waiting for the new machine become Running @ 01/20/26 14:38:36.694
  STEP: Replacement machine name is correct @ 01/20/26 14:38:36.694
  STEP: Waiting for the new machine become Running @ 01/20/26 14:38:36.694
  STEP: Replacement machine name is "huliu-aws0120a-rqvvv-master-8sckw-0" @ 01/20/26 14:38:36.694
  STEP: Replacement machine name is correct @ 01/20/26 14:38:36.694
  STEP: Waiting for the new machine become Running @ 01/20/26 14:38:36.694
  STEP: Replacement machine is Running @ 01/20/26 14:41:05.379
  STEP: Checking that the old machine is removed @ 01/20/26 14:41:05.379
  STEP: Replacement machine is Running @ 01/20/26 14:41:10.653
  STEP: Checking that the old machine is removed @ 01/20/26 14:41:10.653
  STEP: Updated replicas is now equal to desired replicas @ 01/20/26 14:41:23.816
  STEP: Waiting for the replicas to equal desired replicas @ 01/20/26 14:41:23.816
  STEP: Replacement machine is Running @ 01/20/26 14:41:26.104
  STEP: Checking that the old machine is removed @ 01/20/26 14:41:26.104
  STEP: Rollout of index 2 complete @ 01/20/26 15:09:04.512
  STEP: Replacement for index 2 is complete @ 01/20/26 15:09:04.512
  STEP: Rollout of index 0 complete @ 01/20/26 15:17:10.927
  STEP: Replacement for index 0 is complete @ 01/20/26 15:17:10.927
  STEP: Replicas is now equal to desired replicas @ 01/20/26 15:21:05.647
  STEP: Rollout of index 1 complete @ 01/20/26 15:21:08.708
  STEP: Replacement for index 1 is complete @ 01/20/26 15:21:08.708
  STEP: Control plane machine rollout completed successfully for all three masters @ 01/20/26 15:21:08.708
  STEP: Waiting for the cluster to stabilise after the rollout @ 01/20/26 15:21:08.708
  STEP: Waiting for the cluster operators to stabilise (minimum availability time: 2m0s, timeout: 32m0s, polling interval: 20s) @ 01/20/26 15:21:08.708
  STEP: Cluster stabilised after the rollout @ 01/20/26 15:36:43.892
  STEP: Updating the provider spec of the control plane machine at index 0 @ 01/20/26 15:36:43.892
  STEP: Updating the provider spec of the control plane machine at index 1 @ 01/20/26 15:36:44.808
  STEP: Updating the provider spec of the control plane machine at index 2 @ 01/20/26 15:36:45.877
  STEP: Updating the control plane machine set strategy to RollingUpdate @ 01/20/26 15:36:47.07
• [3501.532 seconds]
------------------------------

Ran 1 of 3 Specs in 3501.533 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 2 Skipped
PASS
Running Suite: Framework Suite - /Users/liuhuali/project/cluster-control-plane-machine-set-operator/test/e2e/framework
======================================================================================================================
Random Seed: 1768891084

Will run 0 of 48 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 0 of 48 Specs in 0.001 seconds
SUCCESS! -- 0 Passed | 0 Failed | 0 Pending | 48 Skipped
PASS
Running Suite: Commmon Suite - /Users/liuhuali/project/cluster-control-plane-machine-set-operator/test/e2e/helpers
==================================================================================================================
Random Seed: 1768891084

Will run 0 of 5 specs
SSSSS

Ran 0 of 5 Specs in 0.000 seconds
SUCCESS! -- 0 Passed | 0 Failed | 0 Pending | 5 Skipped
PASS

Ginkgo ran 3 suites in 58m45.359617182s
Test Suite Passed

```