### PR TITLE
OCPBUGS-65497: Add debug-useful ClusterOperator relatedObjects

### DIFF
--- a/manifests/0000_30_control-plane-machine-set-operator_04_clusteroperator.yaml
+++ b/manifests/0000_30_control-plane-machine-set-operator_04_clusteroperator.yaml
@@ -21,3 +21,9 @@ status:
   - group: machine.openshift.io
     name: ""
     resource: machines
+  - group: rbac.authorization.k8s.io
+    name: control-plane-machine-set-operator
+    resource: clusterroles
+  - group: rbac.authorization.k8s.io
+    name: control-plane-machine-set-operator
+    resource: clusterrolebindings

--- a/pkg/controllers/controlplanemachineset/cluster_operator.go
+++ b/pkg/controllers/controlplanemachineset/cluster_operator.go
@@ -51,6 +51,16 @@ func relatedObjects() []configv1.ObjectReference {
 			Resource: "machines",
 			Name:     "",
 		},
+		{
+			Group:    "rbac.authorization.k8s.io",
+			Resource: "clusterroles",
+			Name:     "control-plane-machine-set-operator",
+		},
+		{
+			Group:    "rbac.authorization.k8s.io",
+			Resource: "clusterrolebindings",
+			Name:     "control-plane-machine-set-operator",
+		},
 	}
 }
 

--- a/pkg/controllers/controlplanemachineset/related_objects_test.go
+++ b/pkg/controllers/controlplanemachineset/related_objects_test.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controlplanemachineset
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	configv1 "github.com/openshift/api/config/v1"
+	"sigs.k8s.io/yaml"
+)
+
+var _ = Describe("relatedObjects", func() {
+	It("should stay in sync with the ClusterOperator manifest", func() {
+		manifestPath := filepath.Join("..", "..", "..", "manifests", "0000_30_control-plane-machine-set-operator_04_clusteroperator.yaml")
+		data, err := os.ReadFile(manifestPath)
+		Expect(err).ToNot(HaveOccurred(), "should be able to read ClusterOperator manifest")
+
+		co := &configv1.ClusterOperator{}
+		Expect(yaml.Unmarshal(data, co)).To(Succeed(), "should be able to unmarshal ClusterOperator manifest")
+
+		Expect(co.Status.RelatedObjects).To(Equal(relatedObjects()), "Go relatedObjects() must match the static ClusterOperator manifest")
+	})
+})


### PR DESCRIPTION
Expand `control-plane-machine-set` ClusterOperator `relatedObjects` with the operator ClusterRole / ClusterRoleBinding so must-gather collects them.

Keeps the existing namespace, ControlPlaneMachineSet, and Machine relatedObjects.

## Added relatedObjects
- ClusterRole: `control-plane-machine-set-operator`
- ClusterRoleBinding: `control-plane-machine-set-operator`

## Tests
Parity test keeping the Go list in sync with the ClusterOperator manifest.