### PR TITLE
OCPBUGS-86988: Guard against empty workspace field on vsphere

### DIFF
--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/vsphere.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/vsphere.go
@@ -168,6 +168,11 @@ func (v VSphereProviderConfig) InjectFailureDomain(fd machinev1.VSphereFailureDo
 func (v VSphereProviderConfig) ExtractFailureDomain() machinev1.VSphereFailureDomain { //nolint:cyclop
 	workspace := v.providerConfig.Workspace
 
+	// If workspace is not set on the CPMS's config, the Machines will have one injected from the Infra object.
+	if workspace == nil {
+		return machinev1.VSphereFailureDomain{}
+	}
+
 	if v.infrastructure.Spec.PlatformSpec.Type != configv1.VSpherePlatformType {
 		return machinev1.VSphereFailureDomain{}
 	}

--- a/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/vsphere_test.go
+++ b/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/vsphere_test.go
@@ -262,4 +262,15 @@ var _ = Describe("VSphere Provider Config", Label("vSphereProviderConfig"), func
 			Expect(expected).To(Equal(v1.VSphereFailureDomain{}))
 		})
 	})
+
+	Context("no workspace configured in provider spec", func() {
+		BeforeEach(func() {
+			providerConfig.providerConfig.Workspace = nil
+		})
+
+		It("should return empty failure domain without panicking", func() {
+			Expect(providerConfig.ExtractFailureDomain()).To(Equal(v1.VSphereFailureDomain{}),
+				"expected empty failure domain when workspace is nil, but ExtractFailureDomain panicked")
+		})
+	})
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a potential crash in VSphere infrastructure provider when workspace configuration is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->