### PR TITLE
ARO-28722: Make internalLoadBalancer field optional for ARO in Azure ProviderConfig

### DIFF
--- a/pkg/webhooks/controlplanemachineset/webhooks.go
+++ b/pkg/webhooks/controlplanemachineset/webhooks.go
@@ -70,6 +70,12 @@ const (
 
 	// warnVSphereResourcePoolMayBeIgnored is a warning when cpms has resource pool configured when failure domains are in use.
 	warnVSphereResourcePoolMayBeIgnored = "resourcePool field is configured and may be ignored if configured in the failure domain."
+
+	// aroImagePublisher is used in validateOpenShiftAzureProviderConfig to bypass the internalLoadBalancer field validation for ARO images
+	aroImagePublisher = "azureopenshift"
+
+	// aroImageOffer is used in validateOpenShiftAzureProviderConfig to bypass the internalLoadBalancer field validation for ARO images
+	aroImageOffer = "aro4"
 )
 
 var (
@@ -422,13 +428,14 @@ func validateOpenShiftNutanixProviderConfig(parentPath *field.Path, providerConf
 }
 
 // validateOpenShiftAzureProviderConfig runs Azure specific checks on the provider config on the ControlPlaneMachineSet.
-// This ensure that the ControlPlaneMachineSet can safely replace Azure control plane machines.
+// This ensures that the ControlPlaneMachineSet can safely replace Azure control plane machines.
+// The internalLoadBalancer field validation can be skipped for machines running ARO images.
 func validateOpenShiftAzureProviderConfig(parentPath *field.Path, providerConfig providerconfig.AzureProviderConfig) []error {
 	errs := []error{}
 
 	config := providerConfig.Config()
 
-	if config.InternalLoadBalancer == "" {
+	if config.InternalLoadBalancer == "" && (config.Image.Publisher != aroImagePublisher || config.Image.Offer != aroImageOffer) {
 		errs = append(errs, field.Required(parentPath.Child("internalLoadBalancer"), "internalLoadBalancer is required for control plane machines"))
 	}
 

--- a/pkg/webhooks/controlplanemachineset/webhooks.go
+++ b/pkg/webhooks/controlplanemachineset/webhooks.go
@@ -71,10 +71,10 @@ const (
 	// warnVSphereResourcePoolMayBeIgnored is a warning when cpms has resource pool configured when failure domains are in use.
 	warnVSphereResourcePoolMayBeIgnored = "resourcePool field is configured and may be ignored if configured in the failure domain."
 
-	// aroImagePublisher is used in validateOpenShiftAzureProviderConfig to bypass the internalLoadBalancer field validation for ARO images
+	// aroImagePublisher is used in validateOpenShiftAzureProviderConfig to bypass the internalLoadBalancer field validation for ARO images.
 	aroImagePublisher = "azureopenshift"
 
-	// aroImageOffer is used in validateOpenShiftAzureProviderConfig to bypass the internalLoadBalancer field validation for ARO images
+	// aroImageOffer is used in validateOpenShiftAzureProviderConfig to bypass the internalLoadBalancer field validation for ARO images.
 	aroImageOffer = "aro4"
 )
 

--- a/pkg/webhooks/controlplanemachineset/webhooks_test.go
+++ b/pkg/webhooks/controlplanemachineset/webhooks_test.go
@@ -1247,6 +1247,97 @@ var _ = Describe("Webhooks", Ordered, func() {
 					ContainSubstring("spec.template.machines_v1beta1_machine_openshift_io.spec.providerSpec.value.internalLoadBalancer: Required value: internalLoadBalancer is required for control plane machines"),
 				))
 			})
+
+			It("without an internal load balancer and with ARO image", func() {
+				cpms := builder.WithMachineTemplateBuilder(machineTemplate.WithFailureDomainsBuilder(
+					machinev1resourcebuilder.AzureFailureDomains().WithFailureDomainBuilders(
+						zone1Builder,
+						zone2Builder,
+						zone3Builder,
+					),
+				).WithProviderSpecBuilder(
+					machinev1beta1resourcebuilder.AzureProviderSpec().WithInternalLoadBalancer(""),
+				)).Build()
+
+				azureProviderSpec := &machinev1beta1.AzureMachineProviderSpec{}
+				Expect(json.Unmarshal(cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec.ProviderSpec.Value.Raw, azureProviderSpec)).
+					To(Succeed(), "expect to unmarshal current provider spec")
+				azureProviderSpec.Image = machinev1beta1.Image{
+					Publisher: "azureopenshift",
+					Offer:     "aro4",
+					SKU:       "aro_43",
+					Version:   "43.81.20200311",
+				}
+				specData, err := json.Marshal(azureProviderSpec)
+				Expect(err).To(BeNil(), "expect to be able to marshal changes")
+				cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec.ProviderSpec.Value = &runtime.RawExtension{
+					Raw: specData,
+				}
+
+				Expect(k8sClient.Create(ctx, cpms)).To(Succeed())
+			})
+
+			It("without an internal load balancer and with ARO image publisher but non-ARO offer", func() {
+				cpms := builder.WithMachineTemplateBuilder(machineTemplate.WithFailureDomainsBuilder(
+					machinev1resourcebuilder.AzureFailureDomains().WithFailureDomainBuilders(
+						zone1Builder,
+						zone2Builder,
+						zone3Builder,
+					),
+				).WithProviderSpecBuilder(
+					machinev1beta1resourcebuilder.AzureProviderSpec().WithInternalLoadBalancer(""),
+				)).Build()
+
+				azureProviderSpec := &machinev1beta1.AzureMachineProviderSpec{}
+				Expect(json.Unmarshal(cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec.ProviderSpec.Value.Raw, azureProviderSpec)).
+					To(Succeed(), "expect to unmarshal current provider spec")
+				azureProviderSpec.Image = machinev1beta1.Image{
+					Publisher: "azureopenshift",
+					Offer:     "not-aro",
+					SKU:       "aro_43",
+					Version:   "43.81.20200311",
+				}
+				specData, err := json.Marshal(azureProviderSpec)
+				Expect(err).To(BeNil(), "expect to be able to marshal changes")
+				cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec.ProviderSpec.Value = &runtime.RawExtension{
+					Raw: specData,
+				}
+
+				Expect(k8sClient.Create(ctx, cpms)).To(MatchError(
+					ContainSubstring("spec.template.machines_v1beta1_machine_openshift_io.spec.providerSpec.value.internalLoadBalancer: Required value: internalLoadBalancer is required for control plane machines"),
+				))
+			})
+
+			It("without an internal load balancer and with non-ARO image publisher but ARO offer", func() {
+				cpms := builder.WithMachineTemplateBuilder(machineTemplate.WithFailureDomainsBuilder(
+					machinev1resourcebuilder.AzureFailureDomains().WithFailureDomainBuilders(
+						zone1Builder,
+						zone2Builder,
+						zone3Builder,
+					),
+				).WithProviderSpecBuilder(
+					machinev1beta1resourcebuilder.AzureProviderSpec().WithInternalLoadBalancer(""),
+				)).Build()
+
+				azureProviderSpec := &machinev1beta1.AzureMachineProviderSpec{}
+				Expect(json.Unmarshal(cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec.ProviderSpec.Value.Raw, azureProviderSpec)).
+					To(Succeed(), "expect to unmarshal current provider spec")
+				azureProviderSpec.Image = machinev1beta1.Image{
+					Publisher: "not-azureopenshift",
+					Offer:     "aro4",
+					SKU:       "aro_43",
+					Version:   "43.81.20200311",
+				}
+				specData, err := json.Marshal(azureProviderSpec)
+				Expect(err).To(BeNil(), "expect to be able to marshal changes")
+				cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec.ProviderSpec.Value = &runtime.RawExtension{
+					Raw: specData,
+				}
+
+				Expect(k8sClient.Create(ctx, cpms)).To(MatchError(
+					ContainSubstring("spec.template.machines_v1beta1_machine_openshift_io.spec.providerSpec.value.internalLoadBalancer: Required value: internalLoadBalancer is required for control plane machines"),
+				))
+			})
 		})
 
 		Context("on GCP", Ordered, func() {

--- a/pkg/webhooks/controlplanemachineset/webhooks_test.go
+++ b/pkg/webhooks/controlplanemachineset/webhooks_test.go
@@ -1274,7 +1274,7 @@ var _ = Describe("Webhooks", Ordered, func() {
 					Raw: specData,
 				}
 
-				Expect(k8sClient.Create(ctx, cpms)).To(Succeed())
+				Expect(k8sClient.Create(ctx, cpms)).To(Succeed(), "ARO image without an internal load balancer must be admitted")
 			})
 
 			It("without an internal load balancer and with ARO image publisher but non-ARO offer", func() {
@@ -1305,7 +1305,7 @@ var _ = Describe("Webhooks", Ordered, func() {
 
 				Expect(k8sClient.Create(ctx, cpms)).To(MatchError(
 					ContainSubstring("spec.template.machines_v1beta1_machine_openshift_io.spec.providerSpec.value.internalLoadBalancer: Required value: internalLoadBalancer is required for control plane machines"),
-				))
+				), "non-ARO offer must still be rejected when internal load balancer is missing")
 			})
 
 			It("without an internal load balancer and with non-ARO image publisher but ARO offer", func() {
@@ -1336,7 +1336,7 @@ var _ = Describe("Webhooks", Ordered, func() {
 
 				Expect(k8sClient.Create(ctx, cpms)).To(MatchError(
 					ContainSubstring("spec.template.machines_v1beta1_machine_openshift_io.spec.providerSpec.value.internalLoadBalancer: Required value: internalLoadBalancer is required for control plane machines"),
-				))
+				), "non-ARO publisher must still be rejected when internal load balancer is missing")
 			})
 		})
 


### PR DESCRIPTION
[ARO-28722](https://redhat.atlassian.net/browse/ARO-28722) - Make internalLoadBalancer field optional for ARO in Azure ProviderConfig

https://redhat.atlassian.net/browse/ARO-28722

This change makes the internalLoadBalancer field in the Azure ProviderConfig optional for machines running the Azure Red Hat OpenShift (ARO) images by checking the config.Image.Publisher and config.Image.Offer properties for values used for the ARO images.

This change is required to enable the CPMS operator to do machine replacements for ARO managed clusters that are configured as private ingress and have multiple private IPs associated with the internal load balancer.

See linked Jira for details.

- Adds checks for config.Image.Publisher and config.Image.Offer to validate machine is running an ARO image and skips the field validation for the internalLoadBalancer field before executing the Azure API call.

- Adds tests for updated functionality in validateOpenShiftAzureProviderConfig. Tests are passing locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Azure OpenShift validation to allow control plane machine sets without an internal load balancer when using supported ARO images.
  * Continued requiring an internal load balancer for non-ARO images or mismatched image details.
  * Added coverage for supported and unsupported image configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->